### PR TITLE
Fix AWAY turbo window and recover local ERV control

### DIFF
--- a/src/erv_client.py
+++ b/src/erv_client.py
@@ -189,6 +189,16 @@ class ERVClient:
         logger.info(f"Setting ERV speed to {speed.value}")
 
         if self._use_cloud:
+            # Try local first in case the device recovered; cloud can't set speeds.
+            if self._device:
+                try:
+                    result = self._set_speed_local(speed)
+                    if result:
+                        logger.info("Local ERV control recovered; disabling cloud fallback")
+                        self._use_cloud = False
+                        return True
+                except Exception as e:
+                    logger.warning(f"Local ERV control still unavailable: {e}")
             return self._set_speed_cloud(speed)
         else:
             result = self._set_speed_local(speed)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -879,7 +879,7 @@ class Orchestrator:
         if new_state == OccupancyState.AWAY:
             logger.info("Clearing CO2/tVOC history for fresh adaptive calculation")
             self._co2_history.clear()
-            self._tvoc_history.clear()
+            self._tvoc_away_history.clear()
             self._away_start_time = datetime.now()
             logger.info(f"TURBO mode for {self.config.thresholds.co2_turbo_duration_minutes} min, then adaptive")
 


### PR DESCRIPTION
## Summary\n- fix AWAY transition crash by clearing the correct tVOC history buffer\n- allow local ERV control to recover even after cloud fallback\n\n## Testing\n- Not run (requires hardware)\n\nCloses #9.