### PR TITLE
Fix ERV stale Tuya session causing silent command failures

### DIFF
--- a/src/erv_client.py
+++ b/src/erv_client.py
@@ -59,6 +59,9 @@ class ERVClient:
     DP_SUPPLY_SPEED = "101"
     DP_EXHAUST_SPEED = "102"
 
+    # Delay before read-back verification to allow the device to process commands
+    VERIFY_DELAY_SECONDS = 1
+
     # Fan speed presets: (supply, exhaust)
     SPEED_PRESETS = {
         FanSpeed.OFF: (1, 1),
@@ -250,7 +253,7 @@ class ERVClient:
                 return False
 
         # Read-back verification: confirm the device actually changed state
-        time.sleep(1)
+        time.sleep(self.VERIFY_DELAY_SECONDS)
         try:
             actual = self._get_status_local()
             if speed == FanSpeed.OFF:


### PR DESCRIPTION
## Summary

- Check all 3 `set_value` results in `_set_speed_local()` individually (power on, supply speed, exhaust speed) — previously only the last result was checked, so a stale session could fail on power-on and go undetected
- Add read-back verification after sending commands — reads device status back to confirm it actually changed state
- Add reconnect-and-retry logic in `set_speed()` — on first local failure, reconnects the Tuya session and retries before falling back to cloud

## Context

After a long PRESENT period (2+ hours with ERV off), the Tuya local session goes stale. When AWAY triggers TURBO, the command is sent but silently lost. CO2 data from 2026-02-19 showed the ERV didn't actually turn on for ~35 minutes after the TURBO command was sent (CO2 kept rising from 1919→1997 instead of dropping).

## Test plan

- [ ] Verify ERV TURBO activates correctly on AWAY transition after extended PRESENT period
- [ ] Verify read-back verification catches simulated failure (disconnect device briefly)
- [ ] Verify reconnect retry recovers from stale session without cloud fallback
- [ ] Verify cloud fallback still works if both local attempts fail

Fixes #14