### PR TITLE
Add Qingping-based HVAC heat hysteresis (75/71)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,8 @@ mitsubishi:
 thresholds:
   co2_critical_ppm: 2000      # ERV on even when present
   co2_refresh_target_ppm: 500  # Target for away-mode ventilation
+  hvac_heat_off_temp_f: 75     # Turn heat off at/above this Qingping temp
+  hvac_heat_on_temp_f: 71      # Turn heat back on at/below this temp (hysteresis)
   motion_timeout_seconds: 60   # Time before motion absence triggers away
   mac_poll_interval_seconds: 5 # How often to check Mac occupancy
 

--- a/src/config.py
+++ b/src/config.py
@@ -66,6 +66,8 @@ class ThresholdsConfig:
     tvoc_hysteresis_ppb: int = 30  # Turn off MEDIUM when tVOC < (threshold - hysteresis)
     hvac_min_temp_f: int = 68  # Don't heat above this when away + ERV running
     hvac_critical_temp_f: int = 55  # Always heat below this (pipe freeze protection)
+    hvac_heat_off_temp_f: int = 75  # Turn heat off when temp reaches this
+    hvac_heat_on_temp_f: int = 71  # Turn heat back on when temp drops to this
     expected_occupancy_start: str = "07:00"  # When to allow pre-conditioning
     expected_occupancy_end: str = "22:00"  # After this, no heating unless critical
     motion_timeout_seconds: int = 60

--- a/src/hvac_hysteresis.py
+++ b/src/hvac_hysteresis.py
@@ -1,0 +1,37 @@
+"""HVAC heat-band hysteresis decision helper."""
+
+from typing import Optional, Literal
+
+from .state_machine import OccupancyState
+
+
+def get_heat_band_action(
+    *,
+    temp_f: Optional[float],
+    hvac_mode: str,
+    temp_band_paused: bool,
+    state: OccupancyState,
+    erv_running: bool,
+    min_temp_f: float,
+    within_occupancy_hours: bool,
+    heat_off_temp_f: float,
+    heat_on_temp_f: float,
+) -> Literal["pause", "resume"] | None:
+    """Decide if heat should be paused/resumed for temperature comfort band."""
+    if temp_f is None:
+        return None
+
+    if hvac_mode == "heat" and temp_f >= heat_off_temp_f:
+        return "pause"
+
+    if not (temp_band_paused and hvac_mode == "off" and temp_f <= heat_on_temp_f):
+        return None
+
+    if state == OccupancyState.AWAY:
+        # Preserve existing AWAY coordination rules.
+        if erv_running and temp_f > min_temp_f:
+            return None
+        if not within_occupancy_hours:
+            return None
+
+    return "resume"

--- a/tests/test_hvac_hysteresis.py
+++ b/tests/test_hvac_hysteresis.py
@@ -1,0 +1,64 @@
+"""Unit tests for HVAC heat-band hysteresis decisions."""
+
+from src.hvac_hysteresis import get_heat_band_action
+from src.state_machine import OccupancyState
+
+
+def test_pause_when_heat_reaches_upper_temp_band():
+    action = get_heat_band_action(
+        temp_f=75.2,
+        hvac_mode="heat",
+        temp_band_paused=False,
+        state=OccupancyState.PRESENT,
+        erv_running=False,
+        min_temp_f=68,
+        within_occupancy_hours=True,
+        heat_off_temp_f=75,
+        heat_on_temp_f=71,
+    )
+    assert action == "pause"
+
+
+def test_resume_when_temp_drops_to_lower_temp_band():
+    action = get_heat_band_action(
+        temp_f=70.9,
+        hvac_mode="off",
+        temp_band_paused=True,
+        state=OccupancyState.PRESENT,
+        erv_running=False,
+        min_temp_f=68,
+        within_occupancy_hours=True,
+        heat_off_temp_f=75,
+        heat_on_temp_f=71,
+    )
+    assert action == "resume"
+
+
+def test_no_resume_in_away_when_erv_running_and_temp_above_min():
+    action = get_heat_band_action(
+        temp_f=70.0,
+        hvac_mode="off",
+        temp_band_paused=True,
+        state=OccupancyState.AWAY,
+        erv_running=True,
+        min_temp_f=68,
+        within_occupancy_hours=True,
+        heat_off_temp_f=75,
+        heat_on_temp_f=71,
+    )
+    assert action is None
+
+
+def test_no_resume_in_away_outside_occupancy_hours():
+    action = get_heat_band_action(
+        temp_f=70.0,
+        hvac_mode="off",
+        temp_band_paused=True,
+        state=OccupancyState.AWAY,
+        erv_running=False,
+        min_temp_f=68,
+        within_occupancy_hours=False,
+        heat_off_temp_f=75,
+        heat_on_temp_f=71,
+    )
+    assert action is None


### PR DESCRIPTION
## Summary
- add configurable HVAC comfort-band thresholds: heat off at 75°F and heat on at 71°F
- add a dedicated HVAC temp-band pause flag so this hysteresis is independent from existing ERV suspension logic
- integrate hysteresis decisions into HVAC evaluation while preserving AWAY/ERV occupancy-hour constraints and critical-temp protection
- clear temp-band pause on manual/external HVAC changes
- add focused unit tests for hysteresis decision logic

## Testing
- python -m pytest -q tests/test_hvac_hysteresis.py
- python -m py_compile src/orchestrator.py src/config.py src/hvac_hysteresis.py tests/test_hvac_hysteresis.py