### PR TITLE
Spec: Productivity Phase 2 — leverage, artifact server, domain rename

### DIFF
--- a/docs/working/productivity_phase2.md
+++ b/docs/working/productivity_phase2.md
@@ -368,7 +368,7 @@ Each card follows a consistent structure:
 ```
 
 - **Background**: `Surface` color (0xFF1A1A1E), same as existing `StatTile`
-- **Project color dot**: Uses `KnownProjectColors` map from `ProductivityScreen.kt`
+- **Project color dot**: Uses `KnownProjectColors` map (move from `ProductivityScreen.kt:65` to shared `ui/theme/ProjectColors.kt`)
 - **Hero numbers**: Large (20sp), bold, accent-colored
 - **Labels**: Small (10sp), `TextSecondary`
 - **Footer**: Small (11sp), `TextSecondary`, optional
@@ -628,7 +628,7 @@ The collection script parses `## C{NNN}:` headers from the markdown to count ACT
 
 ## Part H: Project Leverage Pipeline + UI (office-automate repo)
 
-This ticket collects Tier 3 signals from across repos and surfaces them in the Productivity tab. Depends on F (Telegram telemetry only) and G (engram stats). Most sm data is already in `tool_usage.db`.
+This ticket collects Tier 3 signals from across repos and surfaces them in the **Projects tab** (`ProjectsScreen.kt` — see Part D for UI spec). No hard dependencies — reads rsynced DBs directly. F (Telegram) is optional; G (engram `--json`) is convenience only. Most sm data is already in `tool_usage.db`.
 
 ### Data sources (4 arms)
 


### PR DESCRIPTION
## Summary

Phase 2 productivity spec covering:

- **Session-meta pipeline** — imports Claude's per-session output metrics (lines added/removed, commits, files modified) from `~/.claude/usage-data/session-meta/`
- **GitHub PR pipeline** — collects PRs across all repos under `rajeshgoli` account via `gh repo list`
- **Leverage endpoints** — `GET /history/leverage?days=7` joining orchestration input with session output and PR data to compute lines/prompt, commits/day, PRs merged/day, session productivity
- **Android UI** — leverage cards (today + this week) in the Productivity tab
- **Generic artifact server** — `POST /deploy/{app}` + `GET /apps/{app}/latest.apk` replacing the single-file `/apk` endpoint
- **Domain rename** — `climate.rajeshgo.li` → `office.rajeshgo.li`
- **Tier 3 design** — per-project leverage metrics (session-manager sm usage, engram fold recency, etc.) documented but not implemented

5 sub-tickets: A (session-meta), B (GitHub PRs), C (leverage endpoints), D (Android UI), E (artifact server + domain). A and B are independent; C depends on both; D depends on C; E is independent.

## Test plan

24 deterministic tests specified in the doc covering parser, endpoints, Android rendering, and artifact server.