### PR TITLE
Add Android in-app update banner

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".OfficeClimateApp"
@@ -26,6 +27,15 @@
                 <data android:scheme="officeclimate" android:host="auth" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
@@ -1,0 +1,13 @@
+package com.rajesh.officeclimate.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppArtifactMetadata(
+    @SerialName("uploaded_at") val uploadedAt: String? = null,
+    @SerialName("size_bytes") val sizeBytes: Long? = null,
+    @SerialName("uploaded_by") val uploadedBy: String? = null,
+    @SerialName("version_code") val versionCode: Long? = null,
+    @SerialName("version_name") val versionName: String? = null,
+)

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -1,6 +1,7 @@
 package com.rajesh.officeclimate.data.remote
 
 import com.rajesh.officeclimate.data.model.ApiStatus
+import com.rajesh.officeclimate.data.model.AppArtifactMetadata
 import com.rajesh.officeclimate.data.model.DailyStatsResponse
 import com.rajesh.officeclimate.data.model.LeverageResponse
 import com.rajesh.officeclimate.data.model.OHLCResponse
@@ -19,6 +20,9 @@ import retrofit2.http.Query
 interface ApiService {
     @GET("status")
     suspend fun getStatus(): ApiStatus
+
+    @GET("apps/office-climate/meta.json")
+    suspend fun getAppArtifactMetadata(): AppArtifactMetadata
 
     @POST("erv")
     suspend fun setErvSpeed(@Body body: Map<String, String>): JsonObject

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
@@ -1,0 +1,118 @@
+package com.rajesh.officeclimate.data.repository
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import com.rajesh.officeclimate.BuildConfig
+import com.rajesh.officeclimate.data.model.AppArtifactMetadata
+import com.rajesh.officeclimate.data.remote.ApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+data class AvailableAppUpdate(
+    val versionCode: Long,
+    val versionName: String,
+    val uploadedAt: String?,
+)
+
+class AppUpdateRepository(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository,
+) {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+    suspend fun getAvailableUpdate(): AvailableAppUpdate? {
+        val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
+        val metadata = fetchMetadata(serverUrl) ?: return null
+        val serverVersionCode = metadata.versionCode ?: return null
+        if (serverVersionCode <= BuildConfig.VERSION_CODE.toLong()) {
+            return null
+        }
+
+        if (settingsRepository.dismissedUpdateVersionCode.first() == serverVersionCode) {
+            return null
+        }
+
+        return AvailableAppUpdate(
+            versionCode = serverVersionCode,
+            versionName = metadata.versionName ?: serverVersionCode.toString(),
+            uploadedAt = metadata.uploadedAt,
+        )
+    }
+
+    suspend fun dismissUpdate(versionCode: Long) {
+        settingsRepository.saveDismissedUpdateVersionCode(versionCode)
+    }
+
+    suspend fun downloadUpdate(update: AvailableAppUpdate): File = withContext(Dispatchers.IO) {
+        val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
+        val request = Request.Builder()
+            .url("$serverUrl/apps/office-climate/latest.apk")
+            .build()
+
+        val updatesDir = File(context.cacheDir, "updates").apply { mkdirs() }
+        val apkFile = File(updatesDir, "office-climate-${update.versionCode}.apk")
+
+        okHttpClient().newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Update download failed: HTTP ${response.code}")
+            }
+
+            val responseBody = response.body ?: throw IOException("Update download returned no body")
+            responseBody.byteStream().use { input ->
+                apkFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+
+        apkFile
+    }
+
+    fun launchInstaller(apkFile: File) {
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            apkFile,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(intent)
+    }
+
+    private suspend fun fetchMetadata(serverUrl: String): AppArtifactMetadata? = withContext(Dispatchers.IO) {
+        try {
+            apiService(serverUrl).getAppArtifactMetadata()
+        } catch (e: HttpException) {
+            if (e.code() == 404) null else throw e
+        }
+    }
+
+    private fun apiService(serverUrl: String): ApiService {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("$serverUrl/")
+            .client(okHttpClient())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+        return retrofit.create(ApiService::class.java)
+    }
+
+    private fun okHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+}

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
@@ -18,6 +19,7 @@ class SettingsRepository(private val context: Context) {
         val SERVER_URL = stringPreferencesKey("server_url")
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_EMAIL = stringPreferencesKey("user_email")
+        val DISMISSED_UPDATE_VERSION_CODE = longPreferencesKey("dismissed_update_version_code")
     }
 
     val serverUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -34,6 +36,10 @@ class SettingsRepository(private val context: Context) {
 
     val isLoggedIn: Flow<Boolean> = context.dataStore.data.map { prefs ->
         !prefs[Keys.JWT_TOKEN].isNullOrBlank()
+    }
+
+    val dismissedUpdateVersionCode: Flow<Long?> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DISMISSED_UPDATE_VERSION_CODE]
     }
 
     suspend fun saveServerUrl(serverUrl: String) {
@@ -53,6 +59,12 @@ class SettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.JWT_TOKEN)
             prefs.remove(Keys.USER_EMAIL)
+        }
+    }
+
+    suspend fun saveDismissedUpdateVersionCode(versionCode: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DISMISSED_UPDATE_VERSION_CODE] = versionCode
         }
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
@@ -21,15 +21,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -39,10 +39,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.rajesh.officeclimate.ui.theme.*
+import com.rajesh.officeclimate.data.model.ApiStatus
+import com.rajesh.officeclimate.ui.theme.Background
+import com.rajesh.officeclimate.ui.theme.Blue
+import com.rajesh.officeclimate.ui.theme.Border
+import com.rajesh.officeclimate.ui.theme.Cyan
+import com.rajesh.officeclimate.ui.theme.Emerald
+import com.rajesh.officeclimate.ui.theme.Orange
+import com.rajesh.officeclimate.ui.theme.Red
+import com.rajesh.officeclimate.ui.theme.Surface as SurfaceColor
+import com.rajesh.officeclimate.ui.theme.TextPrimary
+import com.rajesh.officeclimate.ui.theme.TextSecondary
+import com.rajesh.officeclimate.ui.theme.Yellow
 import com.rajesh.officeclimate.util.celsiusToFahrenheit
 import kotlin.math.roundToInt
 
@@ -59,6 +69,7 @@ fun DashboardScreen(
     val controlLoading by viewModel.controlLoading.collectAsState()
     val controlError by viewModel.controlError.collectAsState()
     val authExpired by viewModel.authExpired.collectAsState()
+    val updateBannerState by viewModel.updateBannerState.collectAsState()
 
     LaunchedEffect(authExpired) {
         if (authExpired) onNavigateToSettings()
@@ -71,193 +82,284 @@ fun DashboardScreen(
             viewModel.clearControlError()
         }
     }
+    LaunchedEffect(updateBannerState.error) {
+        updateBannerState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearUpdateError()
+        }
+    }
 
-    Box(modifier = Modifier.fillMaxSize().background(Background)) {
-
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
+            .background(Background),
     ) {
-        // Header
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
         ) {
-            Text(
-                text = "Office Climate",
-                style = MaterialTheme.typography.headlineMedium,
-                color = TextPrimary,
-            )
-            IconButton(onClick = onNavigateToSettings) {
-                Text("⚙", style = MaterialTheme.typography.headlineMedium)
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
-
-        val currentStatus = status
-        if (currentStatus == null) {
-            // Loading / error state
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(top = 64.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (error != null) {
-                    Text(
-                        text = "Connection Error",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = Red,
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = error ?: "",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = TextSecondary,
-                    )
-                } else {
-                    CircularProgressIndicator(color = Emerald)
-                    Spacer(Modifier.height(16.dp))
-                    Text(
-                        text = "Connecting...",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = TextSecondary,
-                    )
+                Text(
+                    text = "Office Climate",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = TextPrimary,
+                )
+                IconButton(onClick = onNavigateToSettings) {
+                    Text("⚙", style = MaterialTheme.typography.headlineMedium)
                 }
             }
-            return
+
+            Spacer(Modifier.height(16.dp))
+
+            updateBannerState.update?.let { update ->
+                UpdateAvailableBanner(
+                    versionName = update.versionName,
+                    uploadedAt = update.uploadedAt,
+                    installing = updateBannerState.installing,
+                    onDismiss = viewModel::dismissUpdateBanner,
+                    onInstall = viewModel::installUpdate,
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            val currentStatus = status
+            if (currentStatus == null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 64.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    if (error != null) {
+                        Text(
+                            text = "Connection Error",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Red,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = error ?: "",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                        )
+                    } else {
+                        CircularProgressIndicator(color = Emerald)
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            text = "Connecting...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextSecondary,
+                        )
+                    }
+                }
+                return
+            }
+
+            StatusHero(status = currentStatus)
+
+            Spacer(Modifier.height(16.dp))
+
+            val aq = currentStatus.airQuality
+            val tempF = aq.tempC?.celsiusToFahrenheit()
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                maxItemsInEachRow = 2,
+            ) {
+                val tileModifier = Modifier.weight(1f)
+
+                VitalTile(
+                    label = "TEMPERATURE",
+                    value = tempF?.toString() ?: "--",
+                    unit = "°F",
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "HUMIDITY",
+                    value = aq.humidity?.roundToInt()?.toString() ?: "--",
+                    unit = "%",
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "tVOC",
+                    value = aq.tvoc?.toString() ?: "--",
+                    unit = "index",
+                    accentColor = if ((aq.tvoc ?: 0) > 250) Orange else TextPrimary,
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "NOISE",
+                    value = aq.noiseDb?.let { "%.0f".format(it) } ?: "--",
+                    unit = "dB",
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "DOOR",
+                    value = if (currentStatus.sensors.doorOpen) "OPEN" else "CLOSED",
+                    accentColor = if (currentStatus.sensors.doorOpen) Cyan else Emerald,
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "WINDOW",
+                    value = if (currentStatus.sensors.windowOpen) "OPEN" else "CLOSED",
+                    accentColor = if (currentStatus.sensors.windowOpen) Cyan else Emerald,
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "HVAC",
+                    value = currentStatus.hvac.mode.uppercase(),
+                    unit = if (currentStatus.hvac.mode != "off") {
+                        "${currentStatus.hvac.setpointC.celsiusToFahrenheit()}°F"
+                    } else {
+                        ""
+                    },
+                    accentColor = when (currentStatus.hvac.mode) {
+                        "heat" -> Orange
+                        "cool" -> Blue
+                        else -> TextSecondary
+                    },
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "VENT",
+                    value = when (currentStatus.erv.speed) {
+                        "quiet" -> "QUIET"
+                        "medium" -> "MEDIUM"
+                        "turbo" -> "TURBO"
+                        else -> "OFF"
+                    },
+                    accentColor = if (currentStatus.erv.running) Emerald else TextSecondary,
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "PM2.5",
+                    value = aq.pm25?.let { "%.0f".format(it) } ?: "--",
+                    unit = "µg/m³",
+                    modifier = tileModifier,
+                )
+                VitalTile(
+                    label = "MOTION",
+                    value = if (currentStatus.sensors.motionDetected) "ACTIVE" else "CLEAR",
+                    accentColor = if (currentStatus.sensors.motionDetected) Yellow else TextSecondary,
+                    modifier = tileModifier,
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            QuickControls(
+                status = currentStatus,
+                controlLoading = controlLoading,
+                onErvSpeed = viewModel::setErvSpeed,
+                onHvacMode = viewModel::setHvacMode,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            ConnectionBar(apiConnected = apiConnected, wsConnected = wsConnected, status = currentStatus)
+
+            Spacer(Modifier.height(16.dp))
         }
 
-        // Status Hero
-        StatusHero(status = currentStatus)
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
+        ) { data ->
+            Snackbar(
+                snackbarData = data,
+                containerColor = Color(0xFF7F1D1D),
+                contentColor = Color.White,
+            )
+        }
+    }
+}
 
-        Spacer(Modifier.height(16.dp))
+@Composable
+private fun UpdateAvailableBanner(
+    versionName: String,
+    uploadedAt: String?,
+    installing: Boolean,
+    onDismiss: () -> Unit,
+    onInstall: () -> Unit,
+) {
+    val shape = RoundedCornerShape(20.dp)
 
-        // Vitals Grid
-        val aq = currentStatus.airQuality
-        val tempF = aq.tempC?.celsiusToFahrenheit()
-
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            maxItemsInEachRow = 2,
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        color = Emerald.copy(alpha = 0.12f),
+        contentColor = TextPrimary,
+        tonalElevation = 0.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(1.dp, Emerald.copy(alpha = 0.35f), shape)
+                .padding(16.dp),
         ) {
-            val tileModifier = Modifier.weight(1f)
-
-            VitalTile(
-                label = "TEMPERATURE",
-                value = tempF?.toString() ?: "--",
-                unit = "°F",
-                modifier = tileModifier,
+            Text(
+                text = "Update available",
+                style = MaterialTheme.typography.titleMedium,
+                color = TextPrimary,
             )
-            VitalTile(
-                label = "HUMIDITY",
-                value = aq.humidity?.roundToInt()?.toString() ?: "--",
-                unit = "%",
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "tVOC",
-                value = aq.tvoc?.toString() ?: "--",
-                unit = "index",
-                accentColor = if ((aq.tvoc ?: 0) > 250) Orange else TextPrimary,
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "NOISE",
-                value = aq.noiseDb?.let { "%.0f".format(it) } ?: "--",
-                unit = "dB",
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "DOOR",
-                value = if (currentStatus.sensors.doorOpen) "OPEN" else "CLOSED",
-                accentColor = if (currentStatus.sensors.doorOpen) Cyan else Emerald,
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "WINDOW",
-                value = if (currentStatus.sensors.windowOpen) "OPEN" else "CLOSED",
-                accentColor = if (currentStatus.sensors.windowOpen) Cyan else Emerald,
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "HVAC",
-                value = currentStatus.hvac.mode.uppercase(),
-                unit = if (currentStatus.hvac.mode != "off")
-                    "${currentStatus.hvac.setpointC.celsiusToFahrenheit()}°F" else "",
-                accentColor = when (currentStatus.hvac.mode) {
-                    "heat" -> Orange
-                    "cool" -> Blue
-                    else -> TextSecondary
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = buildString {
+                    append("Version ")
+                    append(versionName)
+                    append(" is ready to install.")
+                    if (!uploadedAt.isNullOrBlank()) {
+                        append(" Uploaded ")
+                        append(uploadedAt)
+                        append(".")
+                    }
                 },
-                modifier = tileModifier,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
             )
-            VitalTile(
-                label = "VENT",
-                value = when (currentStatus.erv.speed) {
-                    "quiet" -> "QUIET"
-                    "medium" -> "MEDIUM"
-                    "turbo" -> "TURBO"
-                    else -> "OFF"
-                },
-                accentColor = if (currentStatus.erv.running) Emerald else TextSecondary,
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "PM2.5",
-                value = aq.pm25?.let { "%.0f".format(it) } ?: "--",
-                unit = "µg/m³",
-                modifier = tileModifier,
-            )
-            VitalTile(
-                label = "MOTION",
-                value = if (currentStatus.sensors.motionDetected) "ACTIVE" else "CLEAR",
-                accentColor = if (currentStatus.sensors.motionDetected) Yellow else TextSecondary,
-                modifier = tileModifier,
-            )
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss, enabled = !installing) {
+                    Text("Dismiss")
+                }
+                Spacer(Modifier.width(8.dp))
+                OutlinedButton(onClick = onInstall, enabled = !installing) {
+                    if (installing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = Emerald,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text("Downloading...")
+                    } else {
+                        Text("Install Update")
+                    }
+                }
+            }
         }
-
-        Spacer(Modifier.height(16.dp))
-
-        // Quick Controls
-        QuickControls(
-            status = currentStatus,
-            controlLoading = controlLoading,
-            onErvSpeed = viewModel::setErvSpeed,
-            onHvacMode = viewModel::setHvacMode,
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        // Connection Status Bar
-        ConnectionBar(apiConnected = apiConnected, wsConnected = wsConnected, status = currentStatus)
-
-        Spacer(Modifier.height(16.dp))
     }
-
-    SnackbarHost(
-        hostState = snackbarHostState,
-        modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
-    ) { data ->
-        Snackbar(
-            snackbarData = data,
-            containerColor = Color(0xFF7F1D1D),
-            contentColor = Color.White,
-        )
-    }
-
-    } // Box
 }
 
 @Composable
 fun ConnectionBar(
     apiConnected: Boolean,
     wsConnected: Boolean,
-    status: com.rajesh.officeclimate.data.model.ApiStatus,
+    status: ApiStatus,
 ) {
     val shape = RoundedCornerShape(12.dp)
 
@@ -265,7 +367,7 @@ fun ConnectionBar(
         modifier = Modifier
             .fillMaxWidth()
             .clip(shape)
-            .background(Surface.copy(alpha = 0.5f))
+            .background(SurfaceColor.copy(alpha = 0.5f))
             .border(1.dp, Border, shape)
             .padding(12.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
@@ -273,7 +375,7 @@ fun ConnectionBar(
         ConnectionDot("API", apiConnected)
         ConnectionDot("WS", wsConnected)
         ConnectionDot("Qingping", status.airQuality.co2Ppm != null)
-        ConnectionDot("YoLink", true) // YoLink is cloud-based, assume connected if API works
+        ConnectionDot("YoLink", true)
     }
 }
 
@@ -284,7 +386,7 @@ private fun ConnectionDot(label: String, connected: Boolean) {
             modifier = Modifier
                 .size(8.dp)
                 .clip(CircleShape)
-                .background(if (connected) Emerald else Red)
+                .background(if (connected) Emerald else Red),
         )
         Spacer(Modifier.width(4.dp))
         Text(

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -5,16 +5,24 @@ import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.rajesh.officeclimate.data.model.ApiStatus
+import com.rajesh.officeclimate.data.repository.AppUpdateRepository
+import com.rajesh.officeclimate.data.repository.AvailableAppUpdate
 import com.rajesh.officeclimate.data.repository.ClimateRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+data class UpdateBannerUiState(
+    val update: AvailableAppUpdate? = null,
+    val installing: Boolean = false,
+    val error: String? = null,
+)
 
 class DashboardViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepo = SettingsRepository(application)
+    private val updateRepo = AppUpdateRepository(application, settingsRepo)
+
     val climateRepo = ClimateRepository(settingsRepo, viewModelScope)
 
     val status: StateFlow<ApiStatus?> = climateRepo.status
@@ -26,14 +34,20 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     private val _controlLoading = MutableStateFlow<String?>(null)
     val controlLoading: StateFlow<String?> = _controlLoading
 
-    init {
-        climateRepo.start()
-    }
-
     private val _controlError = MutableStateFlow<String?>(null)
     val controlError: StateFlow<String?> = _controlError
 
-    fun clearControlError() { _controlError.value = null }
+    private val _updateBannerState = MutableStateFlow(UpdateBannerUiState())
+    val updateBannerState: StateFlow<UpdateBannerUiState> = _updateBannerState
+
+    init {
+        climateRepo.start()
+        refreshUpdateBanner()
+    }
+
+    fun clearControlError() {
+        _controlError.value = null
+    }
 
     fun setErvSpeed(speed: String) {
         _controlLoading.value = "erv_$speed"
@@ -56,6 +70,53 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
                     _controlError.value = "HVAC command failed: ${e.message}"
                 }
             _controlLoading.value = null
+        }
+    }
+
+    fun dismissUpdateBanner() {
+        val update = _updateBannerState.value.update ?: return
+        viewModelScope.launch {
+            updateRepo.dismissUpdate(update.versionCode)
+            _updateBannerState.value = _updateBannerState.value.copy(update = null)
+        }
+    }
+
+    fun installUpdate() {
+        val update = _updateBannerState.value.update ?: return
+        if (_updateBannerState.value.installing) return
+
+        _updateBannerState.value = _updateBannerState.value.copy(installing = true, error = null)
+        viewModelScope.launch {
+            runCatching {
+                val apkFile = updateRepo.downloadUpdate(update)
+                updateRepo.launchInstaller(apkFile)
+            }.onFailure { e ->
+                Log.e("DashboardVM", "Update install failed", e)
+                _updateBannerState.value = _updateBannerState.value.copy(
+                    installing = false,
+                    error = "Update failed: ${e.message}",
+                )
+                return@launch
+            }
+
+            _updateBannerState.value = _updateBannerState.value.copy(installing = false)
+        }
+    }
+
+    fun clearUpdateError() {
+        _updateBannerState.value = _updateBannerState.value.copy(error = null)
+    }
+
+    private fun refreshUpdateBanner() {
+        viewModelScope.launch {
+            runCatching { updateRepo.getAvailableUpdate() }
+                .onSuccess { update ->
+                    _updateBannerState.value = UpdateBannerUiState(update = update)
+                }
+                .onFailure { e ->
+                    Log.w("DashboardVM", "Update check failed", e)
+                    _updateBannerState.value = UpdateBannerUiState()
+                }
         }
     }
 

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="apk_updates"
+        path="updates/" />
+</paths>

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1543,44 +1543,63 @@ class Orchestrator:
         except Exception:
             return web.json_response({"ok": False, "error": "Expected multipart form upload"}, status=400)
 
-        file_part = None
-        while True:
-            part = await reader.next()
-            if part is None:
-                break
-            if part.name == "file":
-                file_part = part
-                break
-
-        if file_part is None:
-            return web.json_response({"ok": False, "error": "Missing multipart field 'file'"}, status=400)
-
         app_dir = self._get_app_artifact_dir(app)
         artifact_path = self._get_app_artifact_path(app)
         app_dir.mkdir(parents=True, exist_ok=True)
 
         fd, temp_path = tempfile.mkstemp(dir=str(app_dir), prefix=".tmp-artifact-", suffix=".apk")
         size_bytes = 0
+        file_uploaded = False
+        version_code: Optional[int] = None
+        version_name: Optional[str] = None
 
         try:
             with os.fdopen(fd, "wb") as handle:
                 while True:
-                    chunk = await file_part.read_chunk(size=64 * 1024)
-                    if not chunk:
+                    part = await reader.next()
+                    if part is None:
                         break
+                    if part.name == "file":
+                        file_uploaded = True
+                        while True:
+                            chunk = await part.read_chunk(size=64 * 1024)
+                            if not chunk:
+                                break
 
-                    size_bytes += len(chunk)
-                    if size_bytes > ARTIFACT_MAX_SIZE_BYTES:
-                        try:
-                            os.unlink(temp_path)
-                        except FileNotFoundError:
-                            pass
-                        return web.json_response(
-                            {"ok": False, "error": "Artifact exceeds 100 MB limit"},
-                            status=413,
-                        )
+                            size_bytes += len(chunk)
+                            if size_bytes > ARTIFACT_MAX_SIZE_BYTES:
+                                try:
+                                    os.unlink(temp_path)
+                                except FileNotFoundError:
+                                    pass
+                                return web.json_response(
+                                    {"ok": False, "error": "Artifact exceeds 100 MB limit"},
+                                    status=413,
+                                )
 
-                    handle.write(chunk)
+                            handle.write(chunk)
+                        continue
+                    if part.name == "version_code":
+                        raw_version_code = (await part.text()).strip()
+                        if raw_version_code:
+                            try:
+                                version_code = int(raw_version_code)
+                            except ValueError:
+                                return web.json_response(
+                                    {"ok": False, "error": "version_code must be an integer"},
+                                    status=400,
+                                )
+                        continue
+                    if part.name == "version_name":
+                        raw_version_name = (await part.text()).strip()
+                        version_name = raw_version_name or None
+
+            if not file_uploaded:
+                try:
+                    os.unlink(temp_path)
+                except FileNotFoundError:
+                    pass
+                return web.json_response({"ok": False, "error": "Missing multipart field 'file'"}, status=400)
 
             os.replace(temp_path, artifact_path)
 
@@ -1589,7 +1608,11 @@ class Orchestrator:
                 "size_bytes": size_bytes,
                 "uploaded_by": request.get("user_email", "unknown"),
             }
-            self._write_json_atomically(app_dir / "meta.json", metadata)
+            if version_code is not None:
+                metadata["version_code"] = version_code
+            if version_name is not None:
+                metadata["version_name"] = version_name
+            self._write_json_atomically(self._get_app_artifact_meta_path(app), metadata)
 
             return web.json_response({
                 "ok": True,
@@ -1619,6 +1642,24 @@ class Orchestrator:
             artifact_path,
             headers={"Content-Disposition": f"attachment; filename={app}.apk"},
         )
+
+    async def _handle_app_artifact_meta_get(self, request: web.Request) -> web.Response:
+        """Handle GET /apps/{app}/meta.json to read the latest artifact metadata."""
+        app = request.match_info.get("app", "")
+        if not self._is_valid_artifact_app_name(app):
+            raise web.HTTPNotFound(text="Artifact metadata not found")
+
+        metadata_path = self._get_app_artifact_meta_path(app)
+        if not metadata_path.exists():
+            raise web.HTTPNotFound(text="Artifact metadata not found")
+
+        try:
+            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to read artifact metadata for {app}: {e}")
+            raise web.HTTPInternalServerError(text="Artifact metadata unreadable") from e
+
+        return web.json_response(payload)
 
     async def _handle_apk_get(self, request: web.Request) -> web.Response:
         """Handle GET /apk for backward-compatible legacy APK downloads."""
@@ -2168,6 +2209,10 @@ class Orchestrator:
         """Return the latest artifact path for the given app."""
         return self._get_app_artifact_dir(app) / "latest.apk"
 
+    def _get_app_artifact_meta_path(self, app: str) -> Path:
+        """Return the metadata path for the given app."""
+        return self._get_app_artifact_dir(app) / "meta.json"
+
     @staticmethod
     def _write_json_atomically(path: Path, payload: dict) -> None:
         """Write JSON metadata via a temp file and os.replace."""
@@ -2432,6 +2477,7 @@ class Orchestrator:
         self._app.router.add_get("/history", self._handle_history_get)
         self._app.router.add_get("/apk", self._handle_apk_get)
         self._app.router.add_get("/apps/{app}/latest.apk", self._handle_app_artifact_get)
+        self._app.router.add_get("/apps/{app}/meta.json", self._handle_app_artifact_meta_get)
         self._app.router.add_post("/deploy/{app}", self._handle_deploy_post)
         self._app.router.add_get("/history/sessions", self._handle_history_sessions_get)
         self._app.router.add_get("/history/co2-ohlc", self._handle_history_co2_ohlc_get)

--- a/tests/test_artifact_server.py
+++ b/tests/test_artifact_server.py
@@ -129,6 +129,7 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         )
         app.router.add_post("/deploy/{app}", orchestrator._handle_deploy_post)
         app.router.add_get("/apps/{app}/latest.apk", orchestrator._handle_app_artifact_get)
+        app.router.add_get("/apps/{app}/meta.json", orchestrator._handle_app_artifact_meta_get)
         app.router.add_get("/apk", orchestrator._handle_apk_get)
 
         server = TestServer(app)
@@ -153,7 +154,15 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         self.addAsyncCleanup(server.close)
         return orchestrator, client
 
-    async def _upload(self, client: TestClient, *, body: bytes, token: str | None = "good-token"):
+    async def _upload(
+        self,
+        client: TestClient,
+        *,
+        body: bytes,
+        token: str | None = "good-token",
+        version_code: int | None = None,
+        version_name: str | None = None,
+    ):
         form = FormData()
         form.add_field(
             "file",
@@ -161,6 +170,10 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
             filename="artifact.apk",
             content_type="application/vnd.android.package-archive",
         )
+        if version_code is not None:
+            form.add_field("version_code", str(version_code))
+        if version_name is not None:
+            form.add_field("version_name", version_name)
         headers = {}
         if token is not None:
             headers["Authorization"] = f"Bearer {token}"
@@ -169,7 +182,12 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
     async def test_upload_success_writes_artifact_and_metadata(self):
         _, client = await self._make_client()
 
-        response = await self._upload(client, body=b"apk-bytes")
+        response = await self._upload(
+            client,
+            body=b"apk-bytes",
+            version_code=7,
+            version_name="1.2.0",
+        )
         payload = await response.json()
 
         self.assertEqual(response.status, 200)
@@ -184,7 +202,22 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         metadata = json.loads(metadata_path.read_text())
         self.assertEqual(metadata["size_bytes"], len(b"apk-bytes"))
         self.assertEqual(metadata["uploaded_by"], "engineer@rajeshgo.li")
+        self.assertEqual(metadata["version_code"], 7)
+        self.assertEqual(metadata["version_name"], "1.2.0")
         self.assertIn("uploaded_at", metadata)
+
+    async def test_meta_endpoint_returns_uploaded_metadata(self):
+        _, client = await self._make_client()
+        await self._upload(client, body=b"meta-bytes", version_code=9, version_name="2.0")
+
+        response = await client.get("/apps/office-climate/meta.json")
+        payload = await response.json()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(payload["size_bytes"], len(b"meta-bytes"))
+        self.assertEqual(payload["version_code"], 9)
+        self.assertEqual(payload["version_name"], "2.0")
+        self.assertEqual(payload["uploaded_by"], "engineer@rajeshgo.li")
 
     async def test_download_returns_uploaded_artifact(self):
         _, client = await self._make_client()
@@ -224,6 +257,35 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         response = await client.get("/apps/nonexistent/latest.apk")
 
         self.assertEqual(response.status, 404)
+
+    async def test_missing_metadata_returns_404(self):
+        _, client = await self._make_client()
+
+        response = await client.get("/apps/nonexistent/meta.json")
+
+        self.assertEqual(response.status, 404)
+
+    async def test_upload_rejects_invalid_version_code(self):
+        _, client = await self._make_client()
+
+        form = FormData()
+        form.add_field(
+            "file",
+            b"apk-bytes",
+            filename="artifact.apk",
+            content_type="application/vnd.android.package-archive",
+        )
+        form.add_field("version_code", "abc")
+
+        response = await client.post(
+            "/deploy/office-climate",
+            data=form,
+            headers={"Authorization": "Bearer good-token"},
+        )
+        payload = await response.json()
+
+        self.assertEqual(response.status, 400)
+        self.assertEqual(payload["error"], "version_code must be an integer")
 
     async def test_upload_size_limit_returns_413(self):
         with patch.object(orchestrator_module, "ARTIFACT_MAX_SIZE_BYTES", 16):


### PR DESCRIPTION
## Summary
- expose versioned app artifact metadata at `/apps/{app}/meta.json` and allow deploy uploads to persist `version_code`/`version_name`
- add Android update detection, dismissible banner state, APK download-to-cache, and installer launch via `FileProvider`
- cover the backend metadata contract with artifact-server tests

## Testing
- `PYTHONPATH=/Users/rajesh/Desktop/automation/office-automate python3 -m pytest tests/test_artifact_server.py`
- Android Gradle build could not be run in this environment because no Java runtime is installed on PATH