### PR TITLE
Session telemetry collector

### DIFF
--- a/collect_session_telemetry.py
+++ b/collect_session_telemetry.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Collect session telemetry from tool_usage.db and git into telemetry.db."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from src.config import load_config
+from src.project_names import normalize_project_name
+from src.telemetry_db import (
+    DEFAULT_LEGACY_DB_PATH,
+    DEFAULT_TELEMETRY_DB_PATH,
+    migrate_legacy_session_output,
+    upsert_collector_session_output_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_TOOL_DB_PATH = Path.home() / ".local" / "share" / "claude-sessions" / "tool_usage.db"
+DATABASE_TIMEZONE = ZoneInfo("America/Los_Angeles")
+SHORTSTAT_RE = re.compile(
+    r"\s*(\d+) files? changed"
+    r"(?:,\s*(\d+) insertions?\(\+\))?"
+    r"(?:,\s*(\d+) deletions?\(-\))?"
+)
+HUMAN_SESSION_RE = re.compile(r"^claude-[0-9a-f]+$")
+
+
+@dataclass
+class GitCommand:
+    timestamp: datetime
+    repo: str
+    bash_command: str
+
+
+@dataclass
+class SessionInfo:
+    session_id: str
+    session_name: str
+    project_name: str
+    start_time: datetime
+    end_time: datetime
+    tool_counts: dict[str, int] = field(default_factory=dict)
+    git_commits: list[GitCommand] = field(default_factory=list)
+    git_pushes: list[GitCommand] = field(default_factory=list)
+
+
+@dataclass
+class CommitStats:
+    repo: str
+    commit_hash: str
+    author_date: datetime
+    subject: str
+    files_changed: int
+    insertions: int
+    deletions: int
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _timestamp_to_sqlite(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _parse_datetime(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+
+    parsed: Optional[datetime] = None
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        for fmt in (
+            "%Y-%m-%d %H:%M:%S.%f",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S",
+        ):
+            try:
+                parsed = datetime.strptime(normalized, fmt)
+                break
+            except ValueError:
+                continue
+    if parsed is None:
+        raise ValueError(f"Unsupported timestamp: {value}")
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(DATABASE_TIMEZONE).replace(tzinfo=None)
+    return parsed
+
+
+def _normalize_repo_name(path_or_name: str) -> str:
+    return normalize_project_name(path_or_name or "unknown")
+
+
+def _is_human_session(session_name: str, session_id: str) -> int:
+    if HUMAN_SESSION_RE.fullmatch(session_name or ""):
+        return 1
+    if not session_name or session_name == session_id:
+        return 1
+    return 0
+
+
+def build_session_index(tool_db: Path, cutoff: datetime) -> dict[str, SessionInfo]:
+    """Build per-session activity from tool_usage.db."""
+    if not tool_db.exists():
+        logger.warning("tool_usage DB not found at %s", tool_db)
+        return {}
+
+    sessions: dict[str, SessionInfo] = {}
+    with _connect(tool_db) as conn:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'tool_usage'"
+        ).fetchone()
+        if table is None:
+            logger.warning("tool_usage table missing in %s", tool_db)
+            return sessions
+
+        rows = conn.execute(
+            """
+            SELECT
+                session_id,
+                session_name,
+                project_name,
+                tool_name,
+                target_file,
+                bash_command,
+                timestamp,
+                cwd
+            FROM tool_usage
+            WHERE hook_type = 'PreToolUse'
+              AND timestamp >= ?
+            ORDER BY session_id, timestamp
+            """,
+            (_timestamp_to_sqlite(cutoff),),
+        ).fetchall()
+
+    for row in rows:
+        timestamp = _parse_datetime(row["timestamp"])
+        session_id = row["session_id"]
+        session_name = row["session_name"] or session_id
+        project_name = _normalize_repo_name(row["project_name"] or row["cwd"] or "unknown")
+        info = sessions.get(session_id)
+        if info is None:
+            info = SessionInfo(
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                start_time=timestamp,
+                end_time=timestamp,
+            )
+            sessions[session_id] = info
+        else:
+            info.start_time = min(info.start_time, timestamp)
+            info.end_time = max(info.end_time, timestamp)
+
+        tool_name = row["tool_name"] or "unknown"
+        info.tool_counts[tool_name] = info.tool_counts.get(tool_name, 0) + 1
+
+        bash_command = (row["bash_command"] or "").strip()
+        repo_name = _normalize_repo_name(row["cwd"] or project_name)
+        if tool_name == "Bash" and bash_command.startswith("git commit"):
+            info.git_commits.append(GitCommand(timestamp, repo_name, bash_command))
+        elif tool_name == "Bash" and bash_command.startswith("git push"):
+            info.git_pushes.append(GitCommand(timestamp, repo_name, bash_command))
+
+    return sessions
+
+
+def collect_git_stats(repos: list[Path], cutoff: datetime) -> dict[str, list[CommitStats]]:
+    """Collect git shortstat output for watched repos."""
+    commits_by_repo: dict[str, list[CommitStats]] = {}
+    cutoff_arg = cutoff.isoformat(sep=" ", timespec="seconds")
+
+    for repo in repos:
+        expanded = repo.expanduser()
+        if not expanded.exists():
+            logger.warning("Skipping missing repo: %s", expanded)
+            continue
+
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(expanded),
+                "log",
+                "--all",
+                "--no-merges",
+                "--format=COMMIT:%H|%aI|%s",
+                "--shortstat",
+                f"--after={cutoff_arg}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        repo_name = _normalize_repo_name(expanded.name)
+        commits: list[CommitStats] = []
+        current: Optional[CommitStats] = None
+
+        for raw_line in result.stdout.splitlines():
+            line = raw_line.rstrip()
+            if line.startswith("COMMIT:"):
+                if current is not None:
+                    commits.append(current)
+                commit_hash, author_date, subject = line[len("COMMIT:"):].split("|", 2)
+                current = CommitStats(
+                    repo=repo_name,
+                    commit_hash=commit_hash,
+                    author_date=_parse_datetime(author_date),
+                    subject=subject,
+                    files_changed=0,
+                    insertions=0,
+                    deletions=0,
+                )
+                continue
+
+            if current is None:
+                continue
+
+            match = SHORTSTAT_RE.match(line)
+            if match:
+                current.files_changed = int(match.group(1) or 0)
+                current.insertions = int(match.group(2) or 0)
+                current.deletions = int(match.group(3) or 0)
+
+        if current is not None:
+            commits.append(current)
+
+        commits_by_repo[repo_name] = commits
+
+    return commits_by_repo
+
+
+def _match_commit(
+    command: GitCommand,
+    commits_by_repo: dict[str, list[CommitStats]],
+    matched_hashes: set[str],
+) -> Optional[CommitStats]:
+    best_match: Optional[CommitStats] = None
+    best_delta: Optional[float] = None
+
+    for commit in commits_by_repo.get(command.repo, []):
+        if commit.commit_hash in matched_hashes:
+            continue
+        delta = abs((commit.author_date - command.timestamp).total_seconds())
+        if delta >= 60:
+            continue
+        if best_delta is None or delta < best_delta:
+            best_match = commit
+            best_delta = delta
+
+    return best_match
+
+
+def _session_row(session: SessionInfo, matched_commits: list[CommitStats]) -> tuple:
+    duration_minutes = max(
+        0,
+        int((session.end_time - session.start_time).total_seconds() // 60),
+    )
+    lines_added = sum(commit.insertions for commit in matched_commits)
+    lines_removed = sum(commit.deletions for commit in matched_commits)
+    files_modified = sum(commit.files_changed for commit in matched_commits)
+    git_pushes = sum(1 for push in session.git_pushes if "--delete" not in push.bash_command)
+
+    return (
+        session.session_id,
+        session.project_name,
+        _timestamp_to_sqlite(session.start_time),
+        duration_minutes,
+        lines_added,
+        lines_removed,
+        files_modified,
+        len(session.git_commits),
+        git_pushes,
+        0,
+        0,
+        0,
+        0,
+        json.dumps(session.tool_counts, sort_keys=True),
+        None,
+        _is_human_session(session.session_name, session.session_id),
+    )
+
+
+def _synthetic_rows(
+    commits_by_repo: dict[str, list[CommitStats]],
+    matched_hashes: set[str],
+) -> list[tuple]:
+    grouped: dict[tuple[str, str], list[CommitStats]] = {}
+    for repo, commits in commits_by_repo.items():
+        for commit in commits:
+            if commit.commit_hash in matched_hashes:
+                continue
+            date_key = commit.author_date.strftime("%Y-%m-%d")
+            grouped.setdefault((repo, date_key), []).append(commit)
+
+    rows = []
+    for (repo, date_key), commits in sorted(grouped.items()):
+        earliest = min(commit.author_date for commit in commits)
+        rows.append((
+            f"unattributed-{repo}-{date_key}",
+            repo,
+            _timestamp_to_sqlite(earliest),
+            0,
+            sum(commit.insertions for commit in commits),
+            sum(commit.deletions for commit in commits),
+            sum(commit.files_changed for commit in commits),
+            len(commits),
+            0,
+            0,
+            0,
+            0,
+            0,
+            None,
+            None,
+            0,
+        ))
+    return rows
+
+
+def _load_repo_paths() -> list[Path]:
+    config = load_config(REPO_ROOT / "config.yaml")
+    if config.telemetry is None or not config.telemetry.repos:
+        raise ValueError("config.yaml is missing telemetry.repos")
+    return [Path(path).expanduser() for path in config.telemetry.repos]
+
+
+def collect_session_telemetry(
+    *,
+    tool_db_path: Path = DEFAULT_TOOL_DB_PATH,
+    output_db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
+    repos: Optional[list[Path]] = None,
+    days: int = 2,
+    dry_run: bool = False,
+    now: Optional[datetime] = None,
+) -> dict[str, int]:
+    """Collect telemetry rows and optionally write them to telemetry.db."""
+    current_time = now or datetime.now()
+    cutoff = current_time - timedelta(days=max(days, 1))
+    repo_paths = repos or _load_repo_paths()
+
+    migrate_legacy_session_output(DEFAULT_LEGACY_DB_PATH, output_db_path)
+    sessions = build_session_index(tool_db_path, cutoff)
+    commits_by_repo = collect_git_stats(repo_paths, cutoff)
+
+    matched_hashes: set[str] = set()
+    rows = []
+    for session in sessions.values():
+        matched_commits: list[CommitStats] = []
+        for command in session.git_commits:
+            match = _match_commit(command, commits_by_repo, matched_hashes)
+            if match is None:
+                continue
+            matched_hashes.add(match.commit_hash)
+            matched_commits.append(match)
+        rows.append(_session_row(session, matched_commits))
+
+    rows.extend(_synthetic_rows(commits_by_repo, matched_hashes))
+
+    if not dry_run:
+        upsert_collector_session_output_rows(rows, output_db_path)
+
+    synthetic_count = sum(1 for row in rows if str(row[0]).startswith("unattributed-"))
+    return {
+        "sessions": len(sessions),
+        "rows_written": len(rows),
+        "synthetic_rows": synthetic_count,
+        "matched_commits": len(matched_hashes),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect session telemetry into telemetry.db")
+    parser.add_argument("--tool-db", type=Path, default=DEFAULT_TOOL_DB_PATH)
+    parser.add_argument("--output", type=Path, default=DEFAULT_TELEMETRY_DB_PATH)
+    parser.add_argument("--days", type=int, default=2)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    stats = collect_session_telemetry(
+        tool_db_path=args.tool_db,
+        output_db_path=args.output,
+        days=args.days,
+        dry_run=args.dry_run,
+    )
+    logger.info("Session telemetry collection complete: %s", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,3 +56,12 @@ orchestrator:
   # Optional: Enable HTTP Basic Auth for remote access (recommended with Cloudflare Tunnel)
   # auth_username: "admin"
   # auth_password: "your_secure_password"
+
+telemetry:
+  repos:
+    - ~/Desktop/automation/office-automate
+    - ~/Desktop/automation/session-manager
+    - ~/Desktop/automation/taskbar
+    - ~/Desktop/fractal-market-simulator
+    - ~/Desktop/automation/social_media
+    - ~/Desktop/automation/backup-manager

--- a/scripts/launchd/com.office-automate.telemetry.plist
+++ b/scripts/launchd/com.office-automate.telemetry.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.telemetry</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/rajesh/Desktop/automation/office-automate/venv/bin/python</string>
+    <string>/Users/rajesh/Desktop/automation/office-automate/collect_session_telemetry.py</string>
+    <string>--output</string>
+    <string>/Users/rajesh/Desktop/automation/office-automate/data/telemetry.db</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/rajesh/Desktop/automation/office-automate</string>
+  <key>StartInterval</key>
+  <integer>1800</integer>
+  <key>StandardErrorPath</key>
+  <string>/tmp/session-telemetry.log</string>
+</dict>
+</plist>

--- a/scripts/sync_session_history.sh
+++ b/scripts/sync_session_history.sh
@@ -14,5 +14,6 @@ mkdir -p "${DATA_DIR}"
 rsync -az "${WORK_MAC_USER}@${WORK_MAC_HOST}:${CLAUDE_REMOTE}" "${DATA_DIR}/claude_history.jsonl"
 rsync -az "${WORK_MAC_USER}@${WORK_MAC_HOST}:${CODEX_REMOTE}" "${DATA_DIR}/codex_history.jsonl"
 rsync -az "${WORK_MAC_USER}@${WORK_MAC_HOST}:${CODEX_STATE_REMOTE}" "${DATA_DIR}/codex_state.sqlite"
+rsync -az "${WORK_MAC_USER}@${WORK_MAC_HOST}:~/Desktop/automation/office-automate/data/telemetry.db" "${DATA_DIR}/telemetry.db"
 
 python3 "${REPO_ROOT}/session_stats_parser.py"

--- a/session_stats_parser.py
+++ b/session_stats_parser.py
@@ -16,6 +16,11 @@ from zoneinfo import ZoneInfo
 
 from src.database import DEFAULT_DB_PATH, Database
 from src.project_names import normalize_project_name
+from src.telemetry_db import (
+    DEFAULT_TELEMETRY_DB_PATH,
+    migrate_legacy_session_output,
+    replace_session_output_rows,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -301,10 +306,11 @@ def collect_github_prs(
 def import_session_meta(
     *,
     db_path: Path = DEFAULT_DB_PATH,
+    telemetry_db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
     session_meta_dir: Path = DEFAULT_SESSION_META_DIR,
 ) -> int:
-    """Import all session-meta JSON files into SQLite using replace semantics."""
-    db = Database(db_path)
+    """Import all session-meta JSON files into telemetry.db using replace semantics."""
+    migrate_legacy_session_output(db_path, telemetry_db_path)
     rows = []
 
     for path in sorted(session_meta_dir.glob("*.json")):
@@ -349,8 +355,7 @@ def import_session_meta(
             0 if is_machine_generated(first_prompt) else 1,
         ))
 
-    db.replace_session_output(rows)
-    return len(rows)
+    return replace_session_output_rows(rows, telemetry_db_path)
 
 
 def main() -> None:
@@ -366,6 +371,7 @@ def main() -> None:
     parser.add_argument("--codex-state", type=Path, default=DEFAULT_CODEX_STATE)
     parser.add_argument("--owner", default=DEFAULT_GITHUB_OWNER)
     parser.add_argument("--session-meta-dir", type=Path, default=DEFAULT_SESSION_META_DIR)
+    parser.add_argument("--telemetry-db-path", type=Path, default=DEFAULT_TELEMETRY_DB_PATH)
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
@@ -388,6 +394,7 @@ def main() -> None:
     else:
         imported = import_session_meta(
             db_path=args.db_path,
+            telemetry_db_path=args.telemetry_db_path,
             session_meta_dir=args.session_meta_dir,
         )
         logger.info("Imported session-meta rows: %s", imported)

--- a/src/config.py
+++ b/src/config.py
@@ -143,6 +143,11 @@ class OrchestratorConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    repos: list[str]
+
+
+@dataclass
 class Config:
     yolink: YoLinkConfig
     qingping: QingpingConfig
@@ -151,6 +156,7 @@ class Config:
     thresholds: ThresholdsConfig
     orchestrator: OrchestratorConfig
     tuya_cloud: Optional[TuyaCloudConfig] = None
+    telemetry: Optional[TelemetryConfig] = None
 
 
 def load_config(path: str = "config.yaml") -> Config:
@@ -180,6 +186,10 @@ def load_config(path: str = "config.yaml") -> Config:
     if "tuya_cloud" in data:
         tuya_cloud = TuyaCloudConfig(**data["tuya_cloud"])
 
+    telemetry = None
+    if "telemetry" in data:
+        telemetry = TelemetryConfig(**data["telemetry"])
+
     return Config(
         yolink=YoLinkConfig(**data["yolink"]),
         qingping=QingpingConfig(**data["qingping"]),
@@ -188,4 +198,5 @@ def load_config(path: str = "config.yaml") -> Config:
         thresholds=ThresholdsConfig(**data.get("thresholds", {})),
         orchestrator=orchestrator_config,
         tuya_cloud=tuya_cloud,
+        telemetry=telemetry,
     )

--- a/src/database.py
+++ b/src/database.py
@@ -22,6 +22,7 @@ from typing import Optional, Dict, Any, List
 from contextlib import contextmanager
 
 from src.project_names import normalize_project_name
+from src.telemetry_db import DEFAULT_TELEMETRY_DB_PATH, ensure_telemetry_db
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +32,13 @@ DEFAULT_DB_PATH = Path(__file__).parent.parent / "data" / "office_climate.db"
 class Database:
     """SQLite database for office climate data."""
 
-    def __init__(self, db_path: Optional[Path] = None):
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        telemetry_db_path: Optional[Path] = None,
+    ):
         self.db_path = db_path or DEFAULT_DB_PATH
+        self.telemetry_db_path = telemetry_db_path or DEFAULT_TELEMETRY_DB_PATH
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_schema()
 
@@ -147,27 +153,6 @@ class Database:
                 CREATE INDEX IF NOT EXISTS idx_prs_created ON github_prs(created_at);
                 CREATE INDEX IF NOT EXISTS idx_prs_merged ON github_prs(merged_at);
 
-                -- Claude session output imported from session-meta JSON
-                CREATE TABLE IF NOT EXISTS session_output (
-                    session_id TEXT PRIMARY KEY,
-                    project TEXT NOT NULL DEFAULT 'unknown',
-                    start_time DATETIME NOT NULL,
-                    duration_minutes INTEGER NOT NULL DEFAULT 0,
-                    lines_added INTEGER NOT NULL DEFAULT 0,
-                    lines_removed INTEGER NOT NULL DEFAULT 0,
-                    files_modified INTEGER NOT NULL DEFAULT 0,
-                    git_commits INTEGER NOT NULL DEFAULT 0,
-                    git_pushes INTEGER NOT NULL DEFAULT 0,
-                    user_message_count INTEGER NOT NULL DEFAULT 0,
-                    assistant_message_count INTEGER NOT NULL DEFAULT 0,
-                    input_tokens INTEGER NOT NULL DEFAULT 0,
-                    output_tokens INTEGER NOT NULL DEFAULT 0,
-                    tool_counts TEXT,
-                    languages TEXT,
-                    is_human_session INTEGER NOT NULL DEFAULT 1
-                );
-                CREATE INDEX IF NOT EXISTS idx_session_output_start ON session_output(start_time);
-                CREATE INDEX IF NOT EXISTS idx_session_output_project ON session_output(project);
             """)
             logger.info(f"Database initialized at {self.db_path}")
 
@@ -470,54 +455,6 @@ class Database:
                     changed_files = excluded.changed_files,
                     created_at = excluded.created_at,
                     merged_at = excluded.merged_at
-            """, rows)
-
-    def replace_session_output(
-        self,
-        rows: List[tuple[
-            str,
-            str,
-            str,
-            int,
-            int,
-            int,
-            int,
-            int,
-            int,
-            int,
-            int,
-            int,
-            int,
-            Optional[str],
-            Optional[str],
-            int,
-        ]],
-    ) -> None:
-        """Replace session-meta rows keyed by session ID."""
-        if not rows:
-            return
-
-        with self._connection() as conn:
-            conn.executemany("""
-                INSERT OR REPLACE INTO session_output (
-                    session_id,
-                    project,
-                    start_time,
-                    duration_minutes,
-                    lines_added,
-                    lines_removed,
-                    files_modified,
-                    git_commits,
-                    git_pushes,
-                    user_message_count,
-                    assistant_message_count,
-                    input_tokens,
-                    output_tokens,
-                    tool_counts,
-                    languages,
-                    is_human_session
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, rows)
 
     def upsert_project_leverage(
@@ -897,47 +834,52 @@ class Database:
         }
 
         with self._connection() as conn:
-            orchestration_rows = conn.execute("""
-                SELECT
-                    date(timestamp) AS date,
-                    COUNT(*) AS prompts,
-                    COUNT(DISTINCT session_id) AS sessions
-                FROM orchestration_activity
-                WHERE timestamp >= ?
-                GROUP BY date(timestamp)
-            """, (cutoff,)).fetchall()
+            ensure_telemetry_db(self.telemetry_db_path)
+            conn.execute("ATTACH DATABASE ? AS telemetry", (str(self.telemetry_db_path),))
+            try:
+                orchestration_rows = conn.execute("""
+                    SELECT
+                        date(timestamp) AS date,
+                        COUNT(*) AS prompts,
+                        COUNT(DISTINCT session_id) AS sessions
+                    FROM orchestration_activity
+                    WHERE timestamp >= ?
+                    GROUP BY date(timestamp)
+                """, (cutoff,)).fetchall()
 
-            session_rows = conn.execute("""
-                SELECT
-                    date(start_time) AS date,
-                    SUM(lines_added) AS lines_added,
-                    SUM(lines_removed) AS lines_removed,
-                    SUM(files_modified) AS files_modified,
-                    SUM(git_commits) AS commits,
-                    SUM(duration_minutes) AS duration_minutes
-                FROM session_output
-                WHERE start_time >= ?
-                GROUP BY date(start_time)
-            """, (cutoff,)).fetchall()
+                session_rows = conn.execute("""
+                    SELECT
+                        date(start_time) AS date,
+                        SUM(lines_added) AS lines_added,
+                        SUM(lines_removed) AS lines_removed,
+                        SUM(files_modified) AS files_modified,
+                        SUM(git_commits) AS commits,
+                        SUM(duration_minutes) AS duration_minutes
+                    FROM telemetry.session_output
+                    WHERE start_time >= ?
+                    GROUP BY date(start_time)
+                """, (cutoff,)).fetchall()
 
-            pr_opened_rows = conn.execute("""
-                SELECT
-                    date(created_at) AS date,
-                    COUNT(*) AS prs_opened
-                FROM github_prs
-                WHERE created_at >= ?
-                GROUP BY date(created_at)
-            """, (cutoff,)).fetchall()
+                pr_opened_rows = conn.execute("""
+                    SELECT
+                        date(created_at) AS date,
+                        COUNT(*) AS prs_opened
+                    FROM github_prs
+                    WHERE created_at >= ?
+                    GROUP BY date(created_at)
+                """, (cutoff,)).fetchall()
 
-            pr_merged_rows = conn.execute("""
-                SELECT
-                    date(merged_at) AS date,
-                    COUNT(*) AS prs_merged,
-                    SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS pr_cycle_hours_total
-                FROM github_prs
-                WHERE merged_at IS NOT NULL AND merged_at >= ?
-                GROUP BY date(merged_at)
-            """, (cutoff,)).fetchall()
+                pr_merged_rows = conn.execute("""
+                    SELECT
+                        date(merged_at) AS date,
+                        COUNT(*) AS prs_merged,
+                        SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS pr_cycle_hours_total
+                    FROM github_prs
+                    WHERE merged_at IS NOT NULL AND merged_at >= ?
+                    GROUP BY date(merged_at)
+                """, (cutoff,)).fetchall()
+            finally:
+                conn.execute("DETACH DATABASE telemetry")
 
         for row in orchestration_rows:
             day = grouped.get(row["date"])

--- a/src/telemetry_db.py
+++ b/src/telemetry_db.py
@@ -1,0 +1,190 @@
+"""Helpers for the isolated session telemetry database."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TELEMETRY_DB_PATH = REPO_ROOT / "data" / "telemetry.db"
+DEFAULT_LEGACY_DB_PATH = REPO_ROOT / "data" / "office_climate.db"
+
+SESSION_OUTPUT_COLUMNS = """
+    session_id,
+    project,
+    start_time,
+    duration_minutes,
+    lines_added,
+    lines_removed,
+    files_modified,
+    git_commits,
+    git_pushes,
+    user_message_count,
+    assistant_message_count,
+    input_tokens,
+    output_tokens,
+    tool_counts,
+    languages,
+    is_human_session
+"""
+
+SESSION_OUTPUT_SCHEMA = f"""
+    CREATE TABLE IF NOT EXISTS session_output (
+        session_id TEXT PRIMARY KEY,
+        project TEXT NOT NULL DEFAULT 'unknown',
+        start_time DATETIME NOT NULL,
+        duration_minutes INTEGER NOT NULL DEFAULT 0,
+        lines_added INTEGER NOT NULL DEFAULT 0,
+        lines_removed INTEGER NOT NULL DEFAULT 0,
+        files_modified INTEGER NOT NULL DEFAULT 0,
+        git_commits INTEGER NOT NULL DEFAULT 0,
+        git_pushes INTEGER NOT NULL DEFAULT 0,
+        user_message_count INTEGER NOT NULL DEFAULT 0,
+        assistant_message_count INTEGER NOT NULL DEFAULT 0,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        tool_counts TEXT,
+        languages TEXT,
+        is_human_session INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE INDEX IF NOT EXISTS idx_session_output_start ON session_output(start_time);
+    CREATE INDEX IF NOT EXISTS idx_session_output_project ON session_output(project);
+"""
+
+SessionOutputRow = tuple[
+    str,
+    str,
+    str,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    Optional[str],
+    Optional[str],
+    int,
+]
+
+
+def ensure_telemetry_db(db_path: Path = DEFAULT_TELEMETRY_DB_PATH) -> None:
+    """Create the telemetry DB and schema when needed."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(SESSION_OUTPUT_SCHEMA)
+
+
+@contextmanager
+def telemetry_connection(
+    db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
+) -> Iterator[sqlite3.Connection]:
+    """Yield a row-factory SQLite connection to telemetry.db."""
+    ensure_telemetry_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def replace_session_output_rows(
+    rows: Iterable[SessionOutputRow],
+    db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
+) -> int:
+    """Insert or replace session output rows."""
+    payload = list(rows)
+    if not payload:
+        return 0
+
+    with telemetry_connection(db_path) as conn:
+        conn.executemany(
+            f"""
+            INSERT OR REPLACE INTO session_output ({SESSION_OUTPUT_COLUMNS})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            payload,
+        )
+    return len(payload)
+
+
+def upsert_collector_session_output_rows(
+    rows: Iterable[SessionOutputRow],
+    db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
+) -> int:
+    """Upsert collector-derived rows without overwriting richer session-meta rows."""
+    payload = list(rows)
+    if not payload:
+        return 0
+
+    with telemetry_connection(db_path) as conn:
+        conn.executemany(
+            f"""
+            INSERT INTO session_output ({SESSION_OUTPUT_COLUMNS})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                project = excluded.project,
+                start_time = excluded.start_time,
+                duration_minutes = excluded.duration_minutes,
+                lines_added = excluded.lines_added,
+                lines_removed = excluded.lines_removed,
+                files_modified = excluded.files_modified,
+                git_commits = excluded.git_commits,
+                git_pushes = excluded.git_pushes,
+                tool_counts = excluded.tool_counts,
+                is_human_session = excluded.is_human_session
+            WHERE session_output.user_message_count = 0
+              AND session_output.assistant_message_count = 0
+              AND session_output.input_tokens = 0
+              AND session_output.output_tokens = 0
+            """,
+            payload,
+        )
+    return len(payload)
+
+
+def migrate_legacy_session_output(
+    legacy_db_path: Path = DEFAULT_LEGACY_DB_PATH,
+    telemetry_db_path: Path = DEFAULT_TELEMETRY_DB_PATH,
+) -> int:
+    """Move legacy session_output rows out of office_climate.db and drop the old table."""
+    if legacy_db_path.resolve() == telemetry_db_path.resolve():
+        return 0
+
+    ensure_telemetry_db(telemetry_db_path)
+    if not legacy_db_path.exists():
+        return 0
+
+    conn = sqlite3.connect(legacy_db_path)
+    attached = False
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_output'"
+        ).fetchone()
+        if row is None:
+            return 0
+
+        before = conn.execute(
+            "SELECT COUNT(*) FROM session_output"
+        ).fetchone()[0]
+        conn.execute("ATTACH DATABASE ? AS telemetry", (str(telemetry_db_path),))
+        attached = True
+        conn.execute(f"""
+            INSERT OR IGNORE INTO telemetry.session_output ({SESSION_OUTPUT_COLUMNS})
+            SELECT {SESSION_OUTPUT_COLUMNS}
+            FROM session_output
+        """)
+        conn.execute("DROP TABLE IF EXISTS session_output")
+        conn.commit()
+        return int(before or 0)
+    finally:
+        if attached:
+            conn.execute("DETACH DATABASE telemetry")
+        conn.close()

--- a/tests/test_collect_session_telemetry.py
+++ b/tests/test_collect_session_telemetry.py
@@ -1,0 +1,237 @@
+import sqlite3
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+from collect_session_telemetry import collect_session_telemetry
+from src.telemetry_db import replace_session_output_rows, telemetry_connection
+
+
+def _create_tool_usage_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE tool_usage (
+            session_id TEXT,
+            session_name TEXT,
+            project_name TEXT,
+            tool_name TEXT,
+            target_file TEXT,
+            bash_command TEXT,
+            timestamp TEXT,
+            cwd TEXT,
+            hook_type TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_tool_usage_row(db_path: Path, row: tuple) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO tool_usage (
+            session_id, session_name, project_name, tool_name, target_file,
+            bash_command, timestamp, cwd, hook_type
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        row,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> None:
+    subprocess.run(cmd, cwd=cwd, env=env, check=True, capture_output=True, text=True)
+
+
+def _git_env(commit_time: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GIT_AUTHOR_DATE"] = commit_time
+    env["GIT_COMMITTER_DATE"] = commit_time
+    return env
+
+
+def _init_repo(repo: Path) -> None:
+    _run(["git", "init"], repo)
+    _run(["git", "config", "user.name", "Telemetry Test"], repo)
+    _run(["git", "config", "user.email", "telemetry@example.com"], repo)
+
+
+def test_collect_session_telemetry_attributes_commits_and_creates_synthetic_rows(tmp_path):
+    repo = tmp_path / "office-automate"
+    repo.mkdir()
+    _init_repo(repo)
+
+    tracked = repo / "tracked.py"
+    tracked.write_text("print('v1')\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py"], repo)
+    _run(["git", "commit", "-m", "tracked"], repo, env=_git_env("2026-03-27T09:00:10-07:00"))
+
+    tracked.write_text("print('v1')\nprint('v2')\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py"], repo)
+    _run(["git", "commit", "-m", "manual"], repo, env=_git_env("2026-03-27T11:15:00-07:00"))
+
+    tool_db_path = tmp_path / "tool_usage.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
+    _create_tool_usage_db(tool_db_path)
+
+    _insert_tool_usage_row(
+        tool_db_path,
+        (
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Read",
+            None,
+            None,
+            "2026-03-27 08:55:00",
+            str(repo),
+            "PreToolUse",
+        ),
+    )
+    _insert_tool_usage_row(
+        tool_db_path,
+        (
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            "git commit -m tracked",
+            "2026-03-27 09:00:00",
+            str(repo),
+            "PreToolUse",
+        ),
+    )
+    _insert_tool_usage_row(
+        tool_db_path,
+        (
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            "git push origin feature/test",
+            "2026-03-27 09:01:00",
+            str(repo),
+            "PreToolUse",
+        ),
+    )
+
+    stats = collect_session_telemetry(
+        tool_db_path=tool_db_path,
+        output_db_path=telemetry_db_path,
+        repos=[repo],
+        days=30,
+        now=datetime(2026, 3, 28, 12, 0, 0),
+    )
+
+    assert stats == {
+        "sessions": 1,
+        "rows_written": 2,
+        "synthetic_rows": 1,
+        "matched_commits": 1,
+    }
+
+    with telemetry_connection(telemetry_db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                session_id, project, lines_added, lines_removed, files_modified,
+                git_commits, git_pushes, tool_counts, is_human_session
+            FROM session_output
+            ORDER BY session_id
+            """
+        ).fetchall()
+
+    assert rows[0]["session_id"] == "session-1"
+    assert rows[0]["project"] == "office-automate"
+    assert rows[0]["lines_added"] == 1
+    assert rows[0]["lines_removed"] == 0
+    assert rows[0]["files_modified"] == 1
+    assert rows[0]["git_commits"] == 1
+    assert rows[0]["git_pushes"] == 1
+    assert rows[0]["tool_counts"] == '{"Bash": 2, "Read": 1}'
+    assert rows[0]["is_human_session"] == 1
+
+    assert rows[1]["session_id"] == "unattributed-office-automate-2026-03-27"
+    assert rows[1]["lines_added"] == 1
+    assert rows[1]["git_commits"] == 1
+    assert rows[1]["is_human_session"] == 0
+
+
+def test_collect_session_telemetry_preserves_richer_session_meta_rows(tmp_path):
+    repo = tmp_path / "office-automate"
+    repo.mkdir()
+    _init_repo(repo)
+
+    tracked = repo / "tracked.py"
+    tracked.write_text("print('v1')\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py"], repo)
+    _run(["git", "commit", "-m", "tracked"], repo, env=_git_env("2026-03-27T09:00:10-07:00"))
+
+    tool_db_path = tmp_path / "tool_usage.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
+    _create_tool_usage_db(tool_db_path)
+    _insert_tool_usage_row(
+        tool_db_path,
+        (
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            "git commit -m tracked",
+            "2026-03-27 09:00:00",
+            str(repo),
+            "PreToolUse",
+        ),
+    )
+
+    replace_session_output_rows(
+        [
+            (
+                "session-1",
+                "office-automate",
+                "2026-03-27 09:00:00",
+                25,
+                999,
+                100,
+                4,
+                2,
+                1,
+                3,
+                6,
+                1000,
+                2000,
+                '{"Read": 5}',
+                '{"Python": 120}',
+                1,
+            )
+        ],
+        telemetry_db_path,
+    )
+
+    collect_session_telemetry(
+        tool_db_path=tool_db_path,
+        output_db_path=telemetry_db_path,
+        repos=[repo],
+        days=30,
+        now=datetime(2026, 3, 28, 12, 0, 0),
+    )
+
+    with telemetry_connection(telemetry_db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT lines_added, lines_removed, git_commits, input_tokens, output_tokens
+            FROM session_output
+            WHERE session_id = 'session-1'
+            """
+        ).fetchone()
+
+    assert tuple(row) == (999, 100, 2, 1000, 2000)

--- a/tests/test_leverage_endpoint.py
+++ b/tests/test_leverage_endpoint.py
@@ -19,6 +19,7 @@ sys.modules.setdefault(
 
 from src.database import Database
 from src.orchestrator import Orchestrator
+from src.telemetry_db import replace_session_output_rows
 
 
 def _set_fixed_now(monkeypatch, now: datetime) -> None:
@@ -102,8 +103,13 @@ def _call_leverage_endpoint(db: Database, days: int) -> tuple[int, dict]:
     return response.status, json.loads(response.body.decode("utf-8"))
 
 
+def _replace_session_output(telemetry_db_path: Path, rows: list[tuple]) -> None:
+    replace_session_output_rows(rows, telemetry_db_path)
+
+
 def test_leverage_endpoint_basic_computation(monkeypatch, tmp_path):
-    db = Database(tmp_path / "history.db")
+    telemetry_db_path = tmp_path / "telemetry.db"
+    db = Database(tmp_path / "history.db", telemetry_db_path=telemetry_db_path)
     _set_fixed_now(monkeypatch, datetime(2026, 3, 27, 12, 0, 0))
 
     for minute in range(5):
@@ -122,7 +128,7 @@ def test_leverage_endpoint_basic_computation(monkeypatch, tmp_path):
             session_id="agent-session",
         )
 
-    db.replace_session_output([
+    _replace_session_output(telemetry_db_path, [
         _session_row(
             "human-session",
             "2026-03-27 09:00:00",
@@ -188,10 +194,11 @@ def test_leverage_endpoint_basic_computation(monkeypatch, tmp_path):
 
 
 def test_leverage_endpoint_returns_null_ratios_when_prompt_count_is_zero(monkeypatch, tmp_path):
-    db = Database(tmp_path / "history.db")
+    telemetry_db_path = tmp_path / "telemetry.db"
+    db = Database(tmp_path / "history.db", telemetry_db_path=telemetry_db_path)
     _set_fixed_now(monkeypatch, datetime(2026, 3, 27, 12, 0, 0))
 
-    db.replace_session_output([
+    _replace_session_output(telemetry_db_path, [
         _session_row(
             "machine-session",
             "2026-03-27 09:00:00",
@@ -222,7 +229,7 @@ def test_leverage_endpoint_returns_null_ratios_when_prompt_count_is_zero(monkeyp
 
 
 def test_leverage_endpoint_averages_pr_cycle_hours_for_merged_day(monkeypatch, tmp_path):
-    db = Database(tmp_path / "history.db")
+    db = Database(tmp_path / "history.db", telemetry_db_path=tmp_path / "telemetry.db")
     _set_fixed_now(monkeypatch, datetime(2026, 3, 27, 12, 0, 0))
 
     db.upsert_github_prs([
@@ -239,7 +246,8 @@ def test_leverage_endpoint_averages_pr_cycle_hours_for_merged_day(monkeypatch, t
 
 
 def test_leverage_endpoint_aggregates_week_from_day_totals(monkeypatch, tmp_path):
-    db = Database(tmp_path / "history.db")
+    telemetry_db_path = tmp_path / "telemetry.db"
+    db = Database(tmp_path / "history.db", telemetry_db_path=telemetry_db_path)
     _set_fixed_now(monkeypatch, datetime(2026, 3, 27, 12, 0, 0))
 
     per_day = [
@@ -272,7 +280,7 @@ def test_leverage_endpoint_aggregates_week_from_day_totals(monkeypatch, tmp_path
             )
         )
 
-    db.replace_session_output(session_rows)
+    _replace_session_output(telemetry_db_path, session_rows)
     db.upsert_github_prs([
         _pr_row(31, "2026-03-24 09:00:00", "2026-03-24 11:00:00"),
         _pr_row(32, "2026-03-25 08:00:00", "2026-03-25 12:00:00"),

--- a/tests/test_session_stats_parser.py
+++ b/tests/test_session_stats_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from session_stats_parser import collect_github_prs, import_history, import_session_meta
 from src.database import Database
+from src.telemetry_db import SESSION_OUTPUT_SCHEMA, telemetry_connection
 
 
 def _write_jsonl(path: Path, rows: list[object]) -> None:
@@ -348,6 +349,7 @@ def test_collect_github_prs_imports_prs_across_repos(tmp_path):
 
 def test_import_session_meta_basic_import_filters_zero_activity_artifacts(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -385,12 +387,15 @@ def test_import_session_meta_basic_import_filters_zero_activity_artifacts(tmp_pa
         ),
     )
 
-    imported = import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    imported = import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
     assert imported == 2
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         rows = conn.execute("""
             SELECT session_id, project, start_time, lines_added, lines_removed, tool_counts, languages
             FROM session_output
@@ -407,36 +412,52 @@ def test_import_session_meta_basic_import_filters_zero_activity_artifacts(tmp_pa
 
 def test_import_session_meta_is_idempotent(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
     _write_session_meta(session_meta_dir / "session-1.json", _session_payload())
 
-    first_import = import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
-    second_import = import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    first_import = import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
+    second_import = import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
     assert first_import == 1
     assert second_import == 1
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         assert conn.execute("SELECT COUNT(*) FROM session_output").fetchone()[0] == 1
 
 
 def test_import_session_meta_upserts_when_file_updates(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
     session_path = session_meta_dir / "session-1.json"
 
     _write_session_meta(session_path, _session_payload(lines_added=10, git_commits=0))
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
     _write_session_meta(session_path, _session_payload(lines_added=250, git_commits=3))
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         row = conn.execute("""
             SELECT lines_added, git_commits
             FROM session_output
@@ -448,6 +469,7 @@ def test_import_session_meta_upserts_when_file_updates(tmp_path):
 
 def test_import_session_meta_converts_utc_to_los_angeles_time(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -463,10 +485,13 @@ def test_import_session_meta_converts_utc_to_los_angeles_time(tmp_path):
         ),
     )
 
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         rows = conn.execute("""
             SELECT session_id, start_time
             FROM session_output
@@ -481,6 +506,7 @@ def test_import_session_meta_converts_utc_to_los_angeles_time(tmp_path):
 
 def test_import_session_meta_normalizes_project_names(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -489,10 +515,13 @@ def test_import_session_meta_normalizes_project_names(tmp_path):
         _session_payload(project_path="/Users/rajesh/Desktop/automation/office-automation"),
     )
 
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         row = conn.execute("SELECT project FROM session_output").fetchone()
 
     assert row["project"] == "office-automate"
@@ -500,6 +529,7 @@ def test_import_session_meta_normalizes_project_names(tmp_path):
 
 def test_import_session_meta_collapses_fractal_worktrees(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -508,10 +538,13 @@ def test_import_session_meta_collapses_fractal_worktrees(tmp_path):
         _session_payload(project_path="/Users/rajesh/worktrees/fractal-1808-em"),
     )
 
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         row = conn.execute("SELECT project FROM session_output").fetchone()
 
     assert row["project"] == "fractal"
@@ -519,6 +552,7 @@ def test_import_session_meta_collapses_fractal_worktrees(tmp_path):
 
 def test_import_session_meta_marks_machine_generated_sessions(tmp_path):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -538,10 +572,13 @@ def test_import_session_meta_marks_machine_generated_sessions(tmp_path):
         ),
     )
 
-    import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
-    db = Database(db_path)
-    with db._connection() as conn:
+    with telemetry_connection(telemetry_db_path) as conn:
         rows = conn.execute("""
             SELECT session_id, is_human_session
             FROM session_output
@@ -553,6 +590,7 @@ def test_import_session_meta_marks_machine_generated_sessions(tmp_path):
 
 def test_import_session_meta_skips_malformed_json_files(tmp_path, caplog):
     db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
     session_meta_dir = tmp_path / "session-meta"
     session_meta_dir.mkdir()
 
@@ -560,11 +598,78 @@ def test_import_session_meta_skips_malformed_json_files(tmp_path, caplog):
     with (session_meta_dir / "broken.json").open("w", encoding="utf-8") as handle:
         handle.write('{"session_id":"broken",')
 
-    imported = import_session_meta(db_path=db_path, session_meta_dir=session_meta_dir)
+    imported = import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
 
     assert imported == 1
     assert "Skipping malformed JSON" in caplog.text
 
+    with telemetry_connection(telemetry_db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM session_output").fetchone()[0] == 1
+
+
+def test_import_session_meta_migrates_legacy_rows_to_telemetry_db(tmp_path):
+    db_path = tmp_path / "history.db"
+    telemetry_db_path = tmp_path / "telemetry.db"
+    session_meta_dir = tmp_path / "session-meta"
+    session_meta_dir.mkdir()
+
     db = Database(db_path)
     with db._connection() as conn:
-        assert conn.execute("SELECT COUNT(*) FROM session_output").fetchone()[0] == 1
+        conn.executescript(SESSION_OUTPUT_SCHEMA)
+        conn.execute(
+            """
+            INSERT INTO session_output (
+                session_id, project, start_time, duration_minutes, lines_added, lines_removed,
+                files_modified, git_commits, git_pushes, user_message_count,
+                assistant_message_count, input_tokens, output_tokens, tool_counts,
+                languages, is_human_session
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-session",
+                "office-automate",
+                "2026-01-14 18:30:00",
+                25,
+                120,
+                15,
+                4,
+                2,
+                1,
+                3,
+                6,
+                1000,
+                2000,
+                json.dumps({"Read": 5}),
+                json.dumps({"Python": 120}),
+                1,
+            ),
+        )
+
+    _write_session_meta(session_meta_dir / "session-1.json", _session_payload(session_id="fresh-session"))
+
+    imported = import_session_meta(
+        db_path=db_path,
+        telemetry_db_path=telemetry_db_path,
+        session_meta_dir=session_meta_dir,
+    )
+
+    assert imported == 1
+
+    with telemetry_connection(telemetry_db_path) as conn:
+        rows = conn.execute(
+            "SELECT session_id FROM session_output ORDER BY session_id"
+        ).fetchall()
+
+    assert [row["session_id"] for row in rows] == ["fresh-session", "legacy-session"]
+
+    with db._connection() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'session_output'"
+        ).fetchone()
+
+    assert row is None


### PR DESCRIPTION
## Summary
- add a periodic session telemetry collector that derives session output from tool_usage.db and git into isolated data/telemetry.db
- migrate legacy session_output rows out of office_climate.db, preserve richer session-meta imports, and make leverage read from attached telemetry.db
- add launchd/sync wiring plus coverage for collector, migration, parser, and leverage behavior

## Spec Reference
- docs/working/session_telemetry_spec.md

## Test Plan
- [x] python -m pytest tests/ -v
- [ ] Manual verification done