### PR TITLE
Fix APK cache busting and hash-based update checks

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
+val officeClimateBuildHash = (
+    project.findProperty("officeClimateBuildHash") as String?
+        ?: System.getenv("OFFICE_CLIMATE_BUILD_HASH")
+        ?: ""
+)
+
 android {
     namespace = "com.rajesh.officeclimate"
     compileSdk = 35
@@ -15,6 +21,7 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
+        buildConfigField("String", "APK_HASH", "\"$officeClimateBuildHash\"")
     }
 
     buildTypes {
@@ -35,6 +42,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class AppArtifactMetadata(
+    @SerialName("artifact_hash") val artifactHash: String? = null,
     @SerialName("uploaded_at") val uploadedAt: String? = null,
     @SerialName("size_bytes") val sizeBytes: Long? = null,
     @SerialName("uploaded_by") val uploadedBy: String? = null,

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
@@ -18,10 +18,11 @@ import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.io.File
 import java.io.IOException
+import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 
 data class AvailableAppUpdate(
-    val versionCode: Long,
+    val artifactHash: String,
     val versionName: String,
     val uploadedAt: String?,
 )
@@ -31,28 +32,30 @@ class AppUpdateRepository(
     private val settingsRepository: SettingsRepository,
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    @Volatile private var cachedCurrentArtifactHash: String? = null
 
     suspend fun getAvailableUpdate(): AvailableAppUpdate? {
         val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
         val metadata = fetchMetadata(serverUrl) ?: return null
-        val serverVersionCode = metadata.versionCode ?: return null
-        if (serverVersionCode <= BuildConfig.VERSION_CODE.toLong()) {
+        val serverArtifactHash = metadata.artifactHash?.trim()?.lowercase() ?: return null
+        val currentArtifactHash = currentBuildArtifactHash()
+        if (serverArtifactHash == currentArtifactHash) {
             return null
         }
 
-        if (settingsRepository.dismissedUpdateVersionCode.first() == serverVersionCode) {
+        if (settingsRepository.dismissedUpdateArtifactHash.first() == serverArtifactHash) {
             return null
         }
 
         return AvailableAppUpdate(
-            versionCode = serverVersionCode,
-            versionName = metadata.versionName ?: serverVersionCode.toString(),
+            artifactHash = serverArtifactHash,
+            versionName = metadata.versionName ?: serverArtifactHash,
             uploadedAt = metadata.uploadedAt,
         )
     }
 
-    suspend fun dismissUpdate(versionCode: Long) {
-        settingsRepository.saveDismissedUpdateVersionCode(versionCode)
+    suspend fun dismissUpdate(artifactHash: String) {
+        settingsRepository.saveDismissedUpdateArtifactHash(artifactHash)
     }
 
     suspend fun downloadUpdate(update: AvailableAppUpdate): File = withContext(Dispatchers.IO) {
@@ -62,7 +65,7 @@ class AppUpdateRepository(
             .build()
 
         val updatesDir = File(context.cacheDir, "updates").apply { mkdirs() }
-        val apkFile = File(updatesDir, "office-climate-${update.versionCode}.apk")
+        val apkFile = File(updatesDir, "office-climate-${update.artifactHash}.apk")
 
         okHttpClient().newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
@@ -100,6 +103,37 @@ class AppUpdateRepository(
         } catch (e: HttpException) {
             if (e.code() == 404) null else throw e
         }
+    }
+
+    private suspend fun currentBuildArtifactHash(): String {
+        cachedCurrentArtifactHash?.let { return it }
+
+        val configuredHash = BuildConfig.APK_HASH.trim().lowercase()
+        if (configuredHash.isNotEmpty()) {
+            cachedCurrentArtifactHash = configuredHash
+            return configuredHash
+        }
+
+        return withContext(Dispatchers.IO) {
+            val computedHash = sha256Prefix(File(context.packageCodePath))
+            cachedCurrentArtifactHash = computedHash
+            computedHash
+        }
+    }
+
+    private fun sha256Prefix(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val bytesRead = input.read(buffer)
+                if (bytesRead <= 0) break
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        return digest.digest()
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+            .take(8)
     }
 
     private fun apiService(serverUrl: String): ApiService {

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
@@ -19,7 +18,7 @@ class SettingsRepository(private val context: Context) {
         val SERVER_URL = stringPreferencesKey("server_url")
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_EMAIL = stringPreferencesKey("user_email")
-        val DISMISSED_UPDATE_VERSION_CODE = longPreferencesKey("dismissed_update_version_code")
+        val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
 
     val serverUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -38,8 +37,8 @@ class SettingsRepository(private val context: Context) {
         !prefs[Keys.JWT_TOKEN].isNullOrBlank()
     }
 
-    val dismissedUpdateVersionCode: Flow<Long?> = context.dataStore.data.map { prefs ->
-        prefs[Keys.DISMISSED_UPDATE_VERSION_CODE]
+    val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH]
     }
 
     suspend fun saveServerUrl(serverUrl: String) {
@@ -62,9 +61,9 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun saveDismissedUpdateVersionCode(versionCode: Long) {
+    suspend fun saveDismissedUpdateArtifactHash(artifactHash: String) {
         context.dataStore.edit { prefs ->
-            prefs[Keys.DISMISSED_UPDATE_VERSION_CODE] = versionCode
+            prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] = artifactHash
         }
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -76,7 +76,7 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     fun dismissUpdateBanner() {
         val update = _updateBannerState.value.update ?: return
         viewModelScope.launch {
-            updateRepo.dismissUpdate(update.versionCode)
+            updateRepo.dismissUpdate(update.artifactHash)
             _updateBannerState.value = _updateBannerState.value.copy(update = null)
         }
     }

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -10,13 +10,15 @@ Ties together:
 """
 
 import asyncio
+import base64
+import hashlib
+import ipaddress
 import json
 import logging
-import base64
-import ipaddress
 import os
 import re
 import secrets
+import shutil
 import tempfile
 from collections import deque
 from pathlib import Path
@@ -38,6 +40,7 @@ from .oauth_service import OAuthService, UserSession
 logger = logging.getLogger(__name__)
 
 ARTIFACT_APP_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+ARTIFACT_HASH_PATTERN = re.compile(r"^[0-9a-f]{8}$")
 ARTIFACT_MAX_SIZE_BYTES = 100 * 1024 * 1024
 DEFAULT_ARTIFACTS_ROOT = Path(__file__).parent.parent / "data" / "apps"
 DEFAULT_LEGACY_APK_PATH = Path(__file__).parent.parent / "data" / "app-debug.apk"
@@ -1550,6 +1553,7 @@ class Orchestrator:
         fd, temp_path = tempfile.mkstemp(dir=str(app_dir), prefix=".tmp-artifact-", suffix=".apk")
         size_bytes = 0
         file_uploaded = False
+        sha256 = hashlib.sha256()
         version_code: Optional[int] = None
         version_name: Optional[str] = None
 
@@ -1577,6 +1581,7 @@ class Orchestrator:
                                     status=413,
                                 )
 
+                            sha256.update(chunk)
                             handle.write(chunk)
                         continue
                     if part.name == "version_code":
@@ -1602,8 +1607,13 @@ class Orchestrator:
                 return web.json_response({"ok": False, "error": "Missing multipart field 'file'"}, status=400)
 
             os.replace(temp_path, artifact_path)
+            artifact_hash = sha256.hexdigest()[:8]
+            hashed_artifact_path = self._get_hashed_app_artifact_path(app, artifact_hash)
+            if not hashed_artifact_path.exists():
+                self._copy_file_atomically(artifact_path, hashed_artifact_path)
 
             metadata = {
+                "artifact_hash": artifact_hash,
                 "uploaded_at": datetime.now().isoformat(timespec="seconds"),
                 "size_bytes": size_bytes,
                 "uploaded_by": request.get("user_email", "unknown"),
@@ -1629,18 +1639,38 @@ class Orchestrator:
             raise web.HTTPInternalServerError(text="Failed to store artifact") from e
 
     async def _handle_app_artifact_get(self, request: web.Request) -> web.Response:
-        """Handle GET /apps/{app}/latest.apk to download the latest app artifact."""
+        """Handle GET /apps/{app}/latest.apk to redirect to the hashed app artifact."""
         app = request.match_info.get("app", "")
         if not self._is_valid_artifact_app_name(app):
             raise web.HTTPNotFound(text="Artifact not found")
 
-        artifact_path = self._get_app_artifact_path(app)
+        metadata = self._read_app_artifact_metadata(app)
+        artifact_hash = metadata.get("artifact_hash")
+        if not isinstance(artifact_hash, str) or not self._is_valid_artifact_hash(artifact_hash):
+            raise web.HTTPNotFound(text="Artifact not found")
+
+        raise web.HTTPFound(
+            location=f"/apps/{app}/{artifact_hash}.apk",
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    async def _handle_hashed_app_artifact_get(self, request: web.Request) -> web.Response:
+        """Handle GET /apps/{app}/{hash}.apk to download an immutable app artifact."""
+        app = request.match_info.get("app", "")
+        artifact_hash = request.match_info.get("artifact_hash", "")
+        if not self._is_valid_artifact_app_name(app) or not self._is_valid_artifact_hash(artifact_hash):
+            raise web.HTTPNotFound(text="Artifact not found")
+
+        artifact_path = self._get_hashed_app_artifact_path(app, artifact_hash)
         if not artifact_path.exists():
             raise web.HTTPNotFound(text="Artifact not found")
 
         return web.FileResponse(
             artifact_path,
-            headers={"Content-Disposition": f"attachment; filename={app}.apk"},
+            headers={
+                "Cache-Control": "public, max-age=31536000, immutable",
+                "Content-Disposition": f"attachment; filename={app}.apk",
+            },
         )
 
     async def _handle_app_artifact_meta_get(self, request: web.Request) -> web.Response:
@@ -1649,17 +1679,7 @@ class Orchestrator:
         if not self._is_valid_artifact_app_name(app):
             raise web.HTTPNotFound(text="Artifact metadata not found")
 
-        metadata_path = self._get_app_artifact_meta_path(app)
-        if not metadata_path.exists():
-            raise web.HTTPNotFound(text="Artifact metadata not found")
-
-        try:
-            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as e:
-            logger.error(f"Failed to read artifact metadata for {app}: {e}")
-            raise web.HTTPInternalServerError(text="Artifact metadata unreadable") from e
-
-        return web.json_response(payload)
+        return web.json_response(self._read_app_artifact_metadata(app))
 
     async def _handle_apk_get(self, request: web.Request) -> web.Response:
         """Handle GET /apk for backward-compatible legacy APK downloads."""
@@ -2193,6 +2213,11 @@ class Orchestrator:
         """Return True when an artifact app name is safe for filesystem storage."""
         return bool(ARTIFACT_APP_PATTERN.fullmatch(app))
 
+    @staticmethod
+    def _is_valid_artifact_hash(artifact_hash: str) -> bool:
+        """Return True when an artifact hash is safe for filesystem storage."""
+        return bool(ARTIFACT_HASH_PATTERN.fullmatch(artifact_hash))
+
     def _get_artifacts_root(self) -> Path:
         """Return the root directory used for uploaded app artifacts."""
         return getattr(self, "_artifacts_root", DEFAULT_ARTIFACTS_ROOT)
@@ -2208,6 +2233,10 @@ class Orchestrator:
     def _get_app_artifact_path(self, app: str) -> Path:
         """Return the latest artifact path for the given app."""
         return self._get_app_artifact_dir(app) / "latest.apk"
+
+    def _get_hashed_app_artifact_path(self, app: str, artifact_hash: str) -> Path:
+        """Return the immutable hashed artifact path for the given app."""
+        return self._get_app_artifact_dir(app) / f"{artifact_hash}.apk"
 
     def _get_app_artifact_meta_path(self, app: str) -> Path:
         """Return the metadata path for the given app."""
@@ -2228,6 +2257,38 @@ class Orchestrator:
             except FileNotFoundError:
                 pass
             raise
+
+    @staticmethod
+    def _copy_file_atomically(source_path: Path, destination_path: Path) -> None:
+        """Copy a file via a temp file and os.replace."""
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(
+            dir=str(destination_path.parent),
+            prefix=".tmp-artifact-copy-",
+            suffix=destination_path.suffix,
+        )
+        os.close(fd)
+        try:
+            shutil.copyfile(source_path, temp_path)
+            os.replace(temp_path, destination_path)
+        except Exception:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def _read_app_artifact_metadata(self, app: str) -> dict[str, Any]:
+        """Read persisted metadata for a deployed app artifact."""
+        metadata_path = self._get_app_artifact_meta_path(app)
+        if not metadata_path.exists():
+            raise web.HTTPNotFound(text="Artifact metadata not found")
+
+        try:
+            return json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to read artifact metadata for {app}: {e}")
+            raise web.HTTPInternalServerError(text="Artifact metadata unreadable") from e
 
     @staticmethod
     def _resolve_redirect_scheme(request: web.Request) -> str:
@@ -2477,6 +2538,7 @@ class Orchestrator:
         self._app.router.add_get("/history", self._handle_history_get)
         self._app.router.add_get("/apk", self._handle_apk_get)
         self._app.router.add_get("/apps/{app}/latest.apk", self._handle_app_artifact_get)
+        self._app.router.add_get("/apps/{app}/{artifact_hash}.apk", self._handle_hashed_app_artifact_get)
         self._app.router.add_get("/apps/{app}/meta.json", self._handle_app_artifact_meta_get)
         self._app.router.add_post("/deploy/{app}", self._handle_deploy_post)
         self._app.router.add_get("/history/sessions", self._handle_history_sessions_get)

--- a/tests/test_artifact_server.py
+++ b/tests/test_artifact_server.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import sys
 import tempfile
 import types
@@ -129,6 +130,7 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         )
         app.router.add_post("/deploy/{app}", orchestrator._handle_deploy_post)
         app.router.add_get("/apps/{app}/latest.apk", orchestrator._handle_app_artifact_get)
+        app.router.add_get("/apps/{app}/{artifact_hash}.apk", orchestrator._handle_hashed_app_artifact_get)
         app.router.add_get("/apps/{app}/meta.json", orchestrator._handle_app_artifact_meta_get)
         app.router.add_get("/apk", orchestrator._handle_apk_get)
 
@@ -195,11 +197,16 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
 
         artifact_path = self.root / "data" / "apps" / "office-climate" / "latest.apk"
         metadata_path = self.root / "data" / "apps" / "office-climate" / "meta.json"
+        artifact_hash = hashlib.sha256(b"apk-bytes").hexdigest()[:8]
+        hashed_artifact_path = self.root / "data" / "apps" / "office-climate" / f"{artifact_hash}.apk"
         self.assertTrue(artifact_path.exists())
+        self.assertTrue(hashed_artifact_path.exists())
         self.assertTrue(metadata_path.exists())
         self.assertEqual(artifact_path.read_bytes(), b"apk-bytes")
+        self.assertEqual(hashed_artifact_path.read_bytes(), b"apk-bytes")
 
         metadata = json.loads(metadata_path.read_text())
+        self.assertEqual(metadata["artifact_hash"], artifact_hash)
         self.assertEqual(metadata["size_bytes"], len(b"apk-bytes"))
         self.assertEqual(metadata["uploaded_by"], "engineer@rajeshgo.li")
         self.assertEqual(metadata["version_code"], 7)
@@ -214,20 +221,34 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         payload = await response.json()
 
         self.assertEqual(response.status, 200)
+        self.assertEqual(payload["artifact_hash"], hashlib.sha256(b"meta-bytes").hexdigest()[:8])
         self.assertEqual(payload["size_bytes"], len(b"meta-bytes"))
         self.assertEqual(payload["version_code"], 9)
         self.assertEqual(payload["version_name"], "2.0")
         self.assertEqual(payload["uploaded_by"], "engineer@rajeshgo.li")
 
-    async def test_download_returns_uploaded_artifact(self):
+    async def test_latest_download_redirects_to_hashed_artifact(self):
         _, client = await self._make_client()
         await self._upload(client, body=b"download-me")
 
-        response = await client.get("/apps/office-climate/latest.apk")
+        response = await client.get("/apps/office-climate/latest.apk", allow_redirects=False)
+        artifact_hash = hashlib.sha256(b"download-me").hexdigest()[:8]
+
+        self.assertEqual(response.status, 302)
+        self.assertEqual(response.headers.get("Location"), f"/apps/office-climate/{artifact_hash}.apk")
+        self.assertEqual(response.headers.get("Cache-Control"), "no-cache")
+
+    async def test_hashed_download_returns_uploaded_artifact(self):
+        _, client = await self._make_client()
+        await self._upload(client, body=b"download-me")
+
+        artifact_hash = hashlib.sha256(b"download-me").hexdigest()[:8]
+        response = await client.get(f"/apps/office-climate/{artifact_hash}.apk")
         body = await response.read()
 
         self.assertEqual(response.status, 200)
         self.assertEqual(body, b"download-me")
+        self.assertEqual(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable")
         self.assertEqual(
             response.headers.get("Content-Disposition"),
             "attachment; filename=office-climate.apk",
@@ -246,7 +267,8 @@ class ArtifactServerTests(unittest.IsolatedAsyncioTestCase):
         _, client = await self._make_client()
         await self._upload(client, body=b"public-download")
 
-        response = await client.get("/apps/office-climate/latest.apk")
+        artifact_hash = hashlib.sha256(b"public-download").hexdigest()[:8]
+        response = await client.get(f"/apps/office-climate/{artifact_hash}.apk")
 
         self.assertEqual(response.status, 200)
         self.assertEqual(await response.read(), b"public-download")


### PR DESCRIPTION
## Summary
- store a short artifact hash on deploy, copy each uploaded APK to a hashed path, and redirect `latest.apk` to that immutable URL with cache headers
- add artifact server coverage for hash metadata, redirect behavior, and immutable hashed downloads
- switch the Android update checker to artifact-hash identity, including hash-based dismissals and APK filenames, with a runtime installed-APK hash fallback when `BuildConfig.APK_HASH` is unset

## Testing
- `source venv/bin/activate && python -m unittest tests.test_artifact_server`
- `./gradlew :app:compileDebugKotlin` *(fails in this environment because no Java runtime is installed)*