### PR TITLE
Fix leverage telemetry backfill and Pacific day grouping

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -244,6 +244,23 @@ class Database:
             return None
         return round(float(numerator) / float(denominator), 2)
 
+    @staticmethod
+    def _sqlite_local_datetime_expr(column: str) -> str:
+        """Return a SQLite expression that normalizes timestamps into Pacific local time."""
+        has_explicit_timezone = (
+            f"({column} LIKE '%Z' OR {column} LIKE '%+__:__' OR {column} LIKE '%-__:__')"
+        )
+        return (
+            f"CASE WHEN {has_explicit_timezone} "
+            f"THEN datetime({column}, 'localtime') "
+            f"ELSE datetime({column}) END"
+        )
+
+    @classmethod
+    def _sqlite_local_date_expr(cls, column: str) -> str:
+        """Return a SQLite expression that extracts the Pacific local calendar date."""
+        return f"date({cls._sqlite_local_datetime_expr(column)})"
+
     # --- Sensor readings ---
 
     def log_sensor_reading(
@@ -814,6 +831,14 @@ class Database:
             now.date() - timedelta(days=max(days - 1, 0)),
             datetime.min.time(),
         ))
+        orchestration_local_datetime = self._sqlite_local_datetime_expr("timestamp")
+        orchestration_local_date = self._sqlite_local_date_expr("timestamp")
+        session_local_datetime = self._sqlite_local_datetime_expr("start_time")
+        session_local_date = self._sqlite_local_date_expr("start_time")
+        pr_created_local_datetime = self._sqlite_local_datetime_expr("created_at")
+        pr_created_local_date = self._sqlite_local_date_expr("created_at")
+        pr_merged_local_datetime = self._sqlite_local_datetime_expr("merged_at")
+        pr_merged_local_date = self._sqlite_local_date_expr("merged_at")
 
         grouped: Dict[str, Dict[str, Any]] = {
             date_str: {
@@ -837,46 +862,46 @@ class Database:
             ensure_telemetry_db(self.telemetry_db_path)
             conn.execute("ATTACH DATABASE ? AS telemetry", (str(self.telemetry_db_path),))
             try:
-                orchestration_rows = conn.execute("""
+                orchestration_rows = conn.execute(f"""
                     SELECT
-                        date(timestamp) AS date,
+                        {orchestration_local_date} AS date,
                         COUNT(*) AS prompts,
                         COUNT(DISTINCT session_id) AS sessions
                     FROM orchestration_activity
-                    WHERE timestamp >= ?
-                    GROUP BY date(timestamp)
+                    WHERE {orchestration_local_datetime} >= ?
+                    GROUP BY {orchestration_local_date}
                 """, (cutoff,)).fetchall()
 
-                session_rows = conn.execute("""
+                session_rows = conn.execute(f"""
                     SELECT
-                        date(start_time) AS date,
+                        {session_local_date} AS date,
                         SUM(lines_added) AS lines_added,
                         SUM(lines_removed) AS lines_removed,
                         SUM(files_modified) AS files_modified,
                         SUM(git_commits) AS commits,
                         SUM(duration_minutes) AS duration_minutes
                     FROM telemetry.session_output
-                    WHERE start_time >= ?
-                    GROUP BY date(start_time)
+                    WHERE {session_local_datetime} >= ?
+                    GROUP BY {session_local_date}
                 """, (cutoff,)).fetchall()
 
-                pr_opened_rows = conn.execute("""
+                pr_opened_rows = conn.execute(f"""
                     SELECT
-                        date(created_at) AS date,
+                        {pr_created_local_date} AS date,
                         COUNT(*) AS prs_opened
                     FROM github_prs
-                    WHERE created_at >= ?
-                    GROUP BY date(created_at)
+                    WHERE {pr_created_local_datetime} >= ?
+                    GROUP BY {pr_created_local_date}
                 """, (cutoff,)).fetchall()
 
-                pr_merged_rows = conn.execute("""
+                pr_merged_rows = conn.execute(f"""
                     SELECT
-                        date(merged_at) AS date,
+                        {pr_merged_local_date} AS date,
                         COUNT(*) AS prs_merged,
                         SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS pr_cycle_hours_total
                     FROM github_prs
-                    WHERE merged_at IS NOT NULL AND merged_at >= ?
-                    GROUP BY date(merged_at)
+                    WHERE merged_at IS NOT NULL AND {pr_merged_local_datetime} >= ?
+                    GROUP BY {pr_merged_local_date}
                 """, (cutoff,)).fetchall()
             finally:
                 conn.execute("DETACH DATABASE telemetry")

--- a/tests/test_leverage_endpoint.py
+++ b/tests/test_leverage_endpoint.py
@@ -245,6 +245,93 @@ def test_leverage_endpoint_averages_pr_cycle_hours_for_merged_day(monkeypatch, t
     assert payload["week"]["avg_pr_cycle_hours"] == 3.0
 
 
+def test_leverage_endpoint_groups_offset_timestamps_by_pacific_day(monkeypatch, tmp_path):
+    telemetry_db_path = tmp_path / "telemetry.db"
+    db = Database(tmp_path / "history.db", telemetry_db_path=telemetry_db_path)
+    _set_fixed_now(monkeypatch, datetime(2026, 3, 28, 12, 0, 0))
+
+    _insert_orchestration(
+        db,
+        "2026-03-27 23:45:00",
+        tool="claude",
+        project="office-automate",
+        session_id="late-session",
+    )
+
+    _replace_session_output(telemetry_db_path, [
+        _session_row(
+            "late-session",
+            "2026-03-28T06:30:00+00:00",
+            duration_minutes=30,
+            lines_added=120,
+            lines_removed=30,
+            files_modified=5,
+            git_commits=4,
+        ),
+    ])
+    db.upsert_github_prs([
+        _pr_row(
+            40,
+            "2026-03-28T06:00:00+00:00",
+            "2026-03-28T06:45:00+00:00",
+        ),
+    ])
+
+    status, payload = _call_leverage_endpoint(db, 2)
+
+    assert status == 200
+    assert payload["days"] == [
+        {
+            "date": "2026-03-27",
+            "prompts": 1,
+            "sessions": 1,
+            "lines_added": 120,
+            "lines_removed": 30,
+            "lines_changed": 150,
+            "files_modified": 5,
+            "commits": 4,
+            "prs_merged": 1,
+            "prs_opened": 1,
+            "avg_pr_cycle_hours": 0.75,
+            "lines_per_prompt": 150.0,
+            "commits_per_prompt": 4.0,
+            "lines_per_session_minute": 5.0,
+        },
+        {
+            "date": "2026-03-28",
+            "prompts": 0,
+            "sessions": 0,
+            "lines_added": 0,
+            "lines_removed": 0,
+            "lines_changed": 0,
+            "files_modified": 0,
+            "commits": 0,
+            "prs_merged": 0,
+            "prs_opened": 0,
+            "avg_pr_cycle_hours": None,
+            "lines_per_prompt": None,
+            "commits_per_prompt": None,
+            "lines_per_session_minute": None,
+        },
+    ]
+    assert payload["week"] == {
+        "prompts": 1,
+        "sessions": 1,
+        "lines_added": 120,
+        "lines_removed": 30,
+        "lines_changed": 150,
+        "files_modified": 5,
+        "commits": 4,
+        "prs_merged": 1,
+        "prs_opened": 1,
+        "avg_pr_cycle_hours": 0.75,
+        "lines_per_prompt": 150.0,
+        "commits_per_prompt": 4.0,
+        "lines_per_session_minute": 5.0,
+        "active_days": 1,
+    }
+
+
 def test_leverage_endpoint_aggregates_week_from_day_totals(monkeypatch, tmp_path):
     telemetry_db_path = tmp_path / "telemetry.db"
     db = Database(tmp_path / "history.db", telemetry_db_path=telemetry_db_path)


### PR DESCRIPTION
## Summary
- normalize leverage day bucketing/filtering to Pacific local time when timestamps include UTC offsets
- add a regression test covering offset-bearing telemetry/PR timestamps near midnight
- backfilled `data/telemetry.db` for the last 30 days on the work Mac and copied it to the Mac Mini

## Verification
- `pytest tests/test_leverage_endpoint.py`
- `python3 collect_session_telemetry.py --days 30 --log-level INFO`
- `ssh rajesh@bakasura4.local "curl -s http://127.0.0.1:8080/history/leverage?days=7"` returned non-zero lines/commits/PRs

## Notes
- `config.yaml` on the work Mac already had the requested `telemetry.repos` entries
- the collector warned that `/Users/rajesh/Desktop/automation/agent-os` is missing on this machine, so that repo was skipped during backfill