### PR TITLE
Fix Projects tab showing zeroes (schedule project_leverage collector)

### DIFF
--- a/collect_and_push.sh
+++ b/collect_and_push.sh
@@ -29,6 +29,13 @@ $VENV collect_session_telemetry.py 2>&1
 # Collect GitHub PRs (needs gh CLI)
 $VENV session_stats_parser.py --mode github-prs 2>&1
 
+# Collect tool_usage-derived project leverage metrics
+# (work Mac has fresh tool_usage.db; office_automation + engram run on the Mini
+# below, since their inputs live there)
+$VENV project_leverage_collector.py \
+    --sources tool_usage \
+    --tool-usage-db "$HOME/.local/share/claude-sessions/tool_usage.db" 2>&1
+
 # Push to Mac Mini
 if ssh -o ConnectTimeout=5 "$MINI" true 2>/dev/null; then
     rsync -az data/telemetry.db "$MINI:~/office-automate/data/telemetry.db"
@@ -61,6 +68,39 @@ if ssh -o ConnectTimeout=5 "$MINI" true 2>/dev/null; then
         cat "$INDEXES"
         echo "COMMIT;"
     } | ssh "$MINI" "sqlite3 ~/office-automate/data/office_climate.db"
+
+    # Push project_leverage rows derived from tool_usage (session-manager,
+    # agent-os) inside one transaction. INSERT OR REPLACE on UNIQUE(date,
+    # project, metric) keeps it idempotent and works on the Mini's sqlite3
+    # 3.19 CLI, which predates the ON CONFLICT DO UPDATE syntax.
+    # office_automation + engram rows are produced on the Mini below, so we
+    # don't ship them from here.
+    LEVERAGE_DUMP=$(mktemp -t project_leverage_dump.XXXXXX)
+    trap 'rm -f "$DUMP" "$INDEXES" "$LEVERAGE_DUMP"' EXIT
+    sqlite3 data/office_climate.db <<'SQL' > "$LEVERAGE_DUMP"
+SELECT 'INSERT OR REPLACE INTO project_leverage(date,project,metric,value) VALUES('
+    || quote(date) || ',' || quote(project) || ',' || quote(metric) || ','
+    || value
+    || ');'
+FROM project_leverage
+WHERE project IN ('session-manager', 'agent-os');
+SQL
+    if [ -s "$LEVERAGE_DUMP" ]; then
+        {
+            echo "BEGIN;"
+            cat "$LEVERAGE_DUMP"
+            echo "COMMIT;"
+        } | ssh "$MINI" "sqlite3 ~/office-automate/data/office_climate.db"
+    fi
+
+    # Trigger the Mini to compute office_automation + engram leverage rows
+    # against its own DB (orchestrator writes climate_actions / occupancy_log
+    # there; engram source files also live on the Mini). Push the collector
+    # script first so the remote pick up any code changes without a separate
+    # deploy step.
+    rsync -az project_leverage_collector.py "$MINI:~/office-automate/project_leverage_collector.py"
+    ssh "$MINI" "cd ~/office-automate && venv/bin/python project_leverage_collector.py --sources office_automation,engram"
+
     echo "Pushed to Mac Mini"
 else
     echo "Mac Mini unreachable, skipping push"

--- a/project_leverage_collector.py
+++ b/project_leverage_collector.py
@@ -19,6 +19,7 @@ DEFAULT_TOOL_USAGE_DB_PATH = Path(__file__).parent / "data" / "tool_usage.db"
 DEFAULT_ENGRAM_DB_PATH = Path(__file__).parent / "data" / "engram_state.db"
 DEFAULT_ENGRAM_REGISTRY_PATH = Path(__file__).parent / "data" / "engram_concept_registry.md"
 PERSONA_PROJECT_METRIC_PREFIX = "persona_project::"
+ALL_SOURCES = ("tool_usage", "engram", "office_automation")
 CONCEPT_HEADER_RE = re.compile(r"^##\s+C\d{3}:.*\((ACTIVE|DEAD)\b", re.IGNORECASE)
 
 
@@ -296,16 +297,23 @@ def collect_project_leverage(
     engram_db_path: Path = DEFAULT_ENGRAM_DB_PATH,
     concept_registry_path: Path = DEFAULT_ENGRAM_REGISTRY_PATH,
     now: Optional[datetime] = None,
+    sources: tuple[str, ...] = ALL_SOURCES,
 ) -> list[tuple[str, str, str, float]]:
     """Collect all project leverage metrics and upsert them into the office DB."""
     now = now or datetime.now()
+    unknown = [s for s in sources if s not in ALL_SOURCES]
+    if unknown:
+        raise ValueError(f"Unknown source(s) {unknown}; valid: {ALL_SOURCES}")
     db = Database(db_path)
     rows: list[tuple[str, str, str, float]] = []
-    rows.extend(_collect_tool_usage_metrics(tool_usage_db_path))
-    rows.extend(_collect_engram_metrics(engram_db_path, concept_registry_path, now))
-    rows.extend(_collect_office_automation_metrics(db_path))
+    if "tool_usage" in sources:
+        rows.extend(_collect_tool_usage_metrics(tool_usage_db_path))
+    if "engram" in sources:
+        rows.extend(_collect_engram_metrics(engram_db_path, concept_registry_path, now))
+    if "office_automation" in sources:
+        rows.extend(_collect_office_automation_metrics(db_path))
     db.upsert_project_leverage(rows)
-    logger.info("Upserted %s project leverage rows", len(rows))
+    logger.info("Upserted %s project leverage rows from sources=%s", len(rows), ",".join(sources))
     return rows
 
 
@@ -315,6 +323,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--tool-usage-db", type=Path, default=DEFAULT_TOOL_USAGE_DB_PATH)
     parser.add_argument("--engram-db", type=Path, default=DEFAULT_ENGRAM_DB_PATH)
     parser.add_argument("--engram-registry", type=Path, default=DEFAULT_ENGRAM_REGISTRY_PATH)
+    parser.add_argument(
+        "--sources",
+        default=",".join(ALL_SOURCES),
+        help=f"Comma-separated subset of {ALL_SOURCES}",
+    )
     return parser.parse_args()
 
 
@@ -325,11 +338,13 @@ def main() -> int:
         format="%(asctime)s [%(levelname)s] %(message)s",
         datefmt="%H:%M:%S",
     )
+    sources = tuple(s.strip() for s in args.sources.split(",") if s.strip())
     collect_project_leverage(
         db_path=args.db_path,
         tool_usage_db_path=args.tool_usage_db,
         engram_db_path=args.engram_db,
         concept_registry_path=args.engram_registry,
+        sources=sources,
     )
     return 0
 


### PR DESCRIPTION
## Summary

- The Projects tab on the Android app was returning all zeroes because the `project_leverage` table on Mac Mini stopped getting fresh rows on 2026-04-03. Root cause: `project_leverage_collector.py` existed but had no scheduler — no LaunchAgent, no cron, no caller in any pipeline script.
- The collector's three sources live on different machines, so a single host can't see all the inputs. This PR splits the work: add a `--sources` flag, run `tool_usage` on the work Mac, stream the resulting `session-manager` + `agent-os` rows to the Mini, then SSH-trigger `office_automation,engram` on the Mini against its production DB.
- Same TCC-aware scheduling pattern as PR #50 — runs every 2h via the existing `com.office-automate.collect.plist` LaunchAgent.

## Changes

- `project_leverage_collector.py` — new `--sources` flag (`tool_usage|engram|office_automation`, default all), with validation against unknown source names. Updated log line includes the active source set.
- `collect_and_push.sh`:
  - Run `project_leverage_collector.py --sources tool_usage` after the existing collectors, pointing at `~/.local/share/claude-sessions/tool_usage.db` (the actual work-Mac path).
  - Atomically push `session-manager` + `agent-os` rows to the Mini using `INSERT OR REPLACE` inside one `BEGIN/COMMIT`. (Mini's CLI `sqlite3` is 3.19 — too old for `ON CONFLICT DO UPDATE`. Python's binding on the Mini is newer, so `Database.upsert_project_leverage` is unchanged.)
  - rsync `project_leverage_collector.py` to the Mini before SSH-invoking it, so collector changes auto-deploy.
  - Trigger `--sources office_automation,engram` on the Mini against its own `office_climate.db` and engram source files.
  - `LEVERAGE_DUMP` added to the existing `trap` so the temp file is always cleaned up.

## Test plan

- [x] Existing tests pass: `pytest tests/test_project_leverage.py` (5/5)
- [x] `bash collect_and_push.sh` runs end-to-end with exit 0; log shows both upserts (`707 rows from sources=tool_usage` on work Mac, `65 rows from sources=office_automation,engram` on Mini)
- [x] On Mac Mini, `project_leverage` has fresh rows for today across all four projects
- [x] `/history/project-leverage?days=7` returns non-zero summaries for every project tile
- [ ] Visual check on the Android Projects tab once merged + LaunchAgent next fires (user-side)

## Out of scope

- Engram source data on the Mini hasn't been touched since February — that's a separate upstream issue. This PR makes the engram tile reflect whatever's there (currently 161 active concepts, no recent folds), not zeros.
- Pagination warning on `Fractal-Market-Simulator` PR list (existing, unrelated).