### PR TITLE
Detect ERV local key rotation and notify Android app

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
@@ -14,6 +14,7 @@ data class ApiStatus(
     val erv: ErvStatus = ErvStatus(),
     val hvac: HvacStatus = HvacStatus(),
     @SerialName("manual_override") val manualOverride: ManualOverride? = null,
+    val notifications: List<AppNotification> = emptyList(),
 )
 
 @Serializable
@@ -43,6 +44,18 @@ data class AirQuality(
 data class ErvStatus(
     val running: Boolean = false,
     val speed: String? = null,
+)
+
+@Serializable
+data class AppNotification(
+    val id: String,
+    val type: String,
+    val severity: String = "info",
+    val title: String,
+    val message: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    val active: Boolean = false,
+    @SerialName("runbook_path") val runbookPath: String? = null,
 )
 
 @Serializable

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
@@ -19,6 +20,7 @@ class SettingsRepository(private val context: Context) {
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_EMAIL = stringPreferencesKey("user_email")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
+        val DISMISSED_APP_NOTIFICATION_IDS = stringSetPreferencesKey("dismissed_app_notification_ids")
     }
 
     val serverUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -39,6 +41,10 @@ class SettingsRepository(private val context: Context) {
 
     val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->
         prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH]
+    }
+
+    val dismissedAppNotificationIds: Flow<Set<String>> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DISMISSED_APP_NOTIFICATION_IDS] ?: emptySet()
     }
 
     suspend fun saveServerUrl(serverUrl: String) {
@@ -64,6 +70,14 @@ class SettingsRepository(private val context: Context) {
     suspend fun saveDismissedUpdateArtifactHash(artifactHash: String) {
         context.dataStore.edit { prefs ->
             prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] = artifactHash
+        }
+    }
+
+    suspend fun dismissAppNotification(id: String) {
+        context.dataStore.edit { prefs ->
+            val dismissed = prefs[Keys.DISMISSED_APP_NOTIFICATION_IDS].orEmpty().toMutableSet()
+            dismissed.add(id)
+            prefs[Keys.DISMISSED_APP_NOTIFICATION_IDS] = dismissed
         }
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.rajesh.officeclimate.data.model.AppNotification
 import com.rajesh.officeclimate.data.model.ApiStatus
 import com.rajesh.officeclimate.ui.theme.Background
 import com.rajesh.officeclimate.ui.theme.Blue
@@ -70,6 +71,7 @@ fun DashboardScreen(
     val controlError by viewModel.controlError.collectAsState()
     val authExpired by viewModel.authExpired.collectAsState()
     val updateBannerState by viewModel.updateBannerState.collectAsState()
+    val appNotificationBannerState by viewModel.appNotificationBannerState.collectAsState()
 
     LaunchedEffect(authExpired) {
         if (authExpired) onNavigateToSettings()
@@ -124,6 +126,14 @@ fun DashboardScreen(
                     installing = updateBannerState.installing,
                     onDismiss = viewModel::dismissUpdateBanner,
                     onInstall = viewModel::installUpdate,
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            appNotificationBannerState.notification?.let { notification ->
+                AppNotificationBanner(
+                    notification = notification,
+                    onDismiss = viewModel::dismissAppNotificationBanner,
                 )
                 Spacer(Modifier.height(16.dp))
             }
@@ -280,6 +290,56 @@ fun DashboardScreen(
                 containerColor = Color(0xFF7F1D1D),
                 contentColor = Color.White,
             )
+        }
+    }
+}
+
+@Composable
+private fun AppNotificationBanner(
+    notification: AppNotification,
+    onDismiss: () -> Unit,
+) {
+    val accentColor = when (notification.severity.lowercase()) {
+        "critical" -> Red
+        "warning" -> Yellow
+        else -> Emerald
+    }
+    val shape = RoundedCornerShape(20.dp)
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        color = accentColor.copy(alpha = 0.12f),
+        contentColor = TextPrimary,
+        tonalElevation = 0.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(1.dp, accentColor.copy(alpha = 0.35f), shape)
+                .padding(16.dp),
+        ) {
+            Text(
+                text = notification.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = TextPrimary,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = notification.message,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Dismiss")
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.rajesh.officeclimate.data.model.AppNotification
 import com.rajesh.officeclimate.data.model.ApiStatus
 import com.rajesh.officeclimate.data.repository.AppUpdateRepository
 import com.rajesh.officeclimate.data.repository.AvailableAppUpdate
@@ -11,12 +12,17 @@ import com.rajesh.officeclimate.data.repository.ClimateRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 data class UpdateBannerUiState(
     val update: AvailableAppUpdate? = null,
     val installing: Boolean = false,
     val error: String? = null,
+)
+
+data class AppNotificationBannerUiState(
+    val notification: AppNotification? = null,
 )
 
 class DashboardViewModel(application: Application) : AndroidViewModel(application) {
@@ -40,9 +46,13 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     private val _updateBannerState = MutableStateFlow(UpdateBannerUiState())
     val updateBannerState: StateFlow<UpdateBannerUiState> = _updateBannerState
 
+    private val _appNotificationBannerState = MutableStateFlow(AppNotificationBannerUiState())
+    val appNotificationBannerState: StateFlow<AppNotificationBannerUiState> = _appNotificationBannerState
+
     init {
         climateRepo.start()
         refreshUpdateBanner()
+        observeAppNotifications()
     }
 
     fun clearControlError() {
@@ -107,6 +117,14 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         _updateBannerState.value = _updateBannerState.value.copy(error = null)
     }
 
+    fun dismissAppNotificationBanner() {
+        val notification = _appNotificationBannerState.value.notification ?: return
+        viewModelScope.launch {
+            settingsRepo.dismissAppNotification(notification.id)
+            _appNotificationBannerState.value = AppNotificationBannerUiState()
+        }
+    }
+
     private fun refreshUpdateBanner() {
         viewModelScope.launch {
             runCatching { updateRepo.getAvailableUpdate() }
@@ -117,6 +135,18 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
                     Log.w("DashboardVM", "Update check failed", e)
                     _updateBannerState.value = UpdateBannerUiState()
                 }
+        }
+    }
+
+    private fun observeAppNotifications() {
+        viewModelScope.launch {
+            combine(status, settingsRepo.dismissedAppNotificationIds) { currentStatus, dismissedIds ->
+                currentStatus
+                    ?.notifications
+                    ?.firstOrNull { notification -> notification.id !in dismissedIds }
+            }.collect { notification ->
+                _appNotificationBannerState.value = AppNotificationBannerUiState(notification = notification)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -143,7 +143,9 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
             combine(status, settingsRepo.dismissedAppNotificationIds) { currentStatus, dismissedIds ->
                 currentStatus
                     ?.notifications
-                    ?.firstOrNull { notification -> notification.id !in dismissedIds }
+                    ?.firstOrNull { notification ->
+                        notification.active && notification.id !in dismissedIds
+                    }
             }.collect { notification ->
                 _appNotificationBannerState.value = AppNotificationBannerUiState(notification = notification)
             }

--- a/src/erv_client.py
+++ b/src/erv_client.py
@@ -1,7 +1,7 @@
 """
 Pioneer Airlink ERV Client (Tuya-based)
 
-Controls the ERV via local Tuya protocol with cloud fallback.
+Controls the ERV via local Tuya protocol and reports local key health.
 
 DPS Mapping (discovered via Smart Life):
 - DP 1: Power on/off (bool)
@@ -21,7 +21,7 @@ import time
 from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Callable, Optional
 
 import tinytuya
 
@@ -50,8 +50,8 @@ class ERVClient:
     """
     Client for controlling Pioneer Airlink ERV.
 
-    Tries local Tuya protocol first, falls back to cloud API.
-    Note: Cloud API only supports on/off, not fan speed control.
+    The orchestrator configures this for local-only control so fan speeds stay
+    available and local key rotation is surfaced immediately.
     """
 
     # Data Point mappings
@@ -62,6 +62,8 @@ class ERVClient:
 
     # Delay before read-back verification to allow the device to process commands
     VERIFY_DELAY_SECONDS = 1
+    LOCAL_KEY_ERROR_THRESHOLD = 5
+    LOCAL_KEY_ERROR_CODE = "914"
 
     # Fan speed presets: (supply, exhaust)
     SPEED_PRESETS = {
@@ -91,6 +93,11 @@ class ERVClient:
         self.last_error: Optional[str] = None
         self.last_error_at: Optional[datetime] = None
         self.last_ok_at: Optional[datetime] = None
+        self.last_local_ok_at: Optional[datetime] = None
+        self.consecutive_local_key_errors: int = 0
+        self.local_key_invalid: bool = False
+        self.local_key_invalid_since: Optional[datetime] = None
+        self._health_event_callback: Optional[Callable[[dict], None]] = None
 
         # Set up cloud fallback if credentials provided
         if cloud_api_key and cloud_api_secret:
@@ -100,8 +107,12 @@ class ERVClient:
                 apiSecret=cloud_api_secret
             )
 
+    def on_health_event(self, callback: Callable[[dict], None]):
+        """Register a callback for ERV control health transitions."""
+        self._health_event_callback = callback
+
     def connect(self):
-        """Connect to the ERV device. Tries local first, falls back to cloud."""
+        """Connect to the ERV device over local Tuya."""
         # Try local connection first
         logger.info(f"Connecting to ERV at {self.ip} (local)...")
         self._device = tinytuya.Device(
@@ -115,12 +126,12 @@ class ERVClient:
         if "Error" not in status:
             logger.info(f"Connected to ERV via local API. Status: {status}")
             self._use_cloud = False
-            self._record_success()
+            self._record_local_success()
             return status
 
         # Local failed, try cloud
         logger.warning(f"Local connection failed: {status}")
-        self._record_error(f"Local connection failed: {status}")
+        self._record_local_failure("Local connection failed", status)
         if self._cloud:
             logger.info("Falling back to cloud API...")
             cloud_status = self._cloud.getstatus(self.device_id)
@@ -149,7 +160,7 @@ class ERVClient:
 
         status = self._device.status()
         if "Error" in status:
-            self._record_error(f"Local status failed: {status}")
+            self._record_local_failure("Local status failed", status)
             raise RuntimeError(f"Failed to get status: {status}")
 
         dps = status.get("dps", {})
@@ -166,7 +177,7 @@ class ERVClient:
                     fan_speed = preset
                     break
 
-        self._record_success()
+        self._record_local_success()
         return ERVStatus(
             power=power,
             fan_speed=fan_speed,
@@ -251,20 +262,24 @@ class ERVClient:
             result = self._device.set_value(self.DP_POWER, False)
             if "Error" in str(result):
                 logger.error(f"Failed to set power off: {result}")
+                self._record_local_failure("Local set power off failed", result)
                 return False
         else:
             supply, exhaust = self.SPEED_PRESETS[speed]
             r1 = self._device.set_value(self.DP_POWER, True)
             if "Error" in str(r1):
                 logger.error(f"Failed to set power on: {r1}")
+                self._record_local_failure("Local set power on failed", r1)
                 return False
             r2 = self._device.set_value(self.DP_SUPPLY_SPEED, supply)
             if "Error" in str(r2):
                 logger.error(f"Failed to set supply speed: {r2}")
+                self._record_local_failure("Local set supply speed failed", r2)
                 return False
             r3 = self._device.set_value(self.DP_EXHAUST_SPEED, exhaust)
             if "Error" in str(r3):
                 logger.error(f"Failed to set exhaust speed: {r3}")
+                self._record_local_failure("Local set exhaust speed failed", r3)
                 return False
 
         # Read-back verification: confirm the device actually changed state
@@ -296,7 +311,7 @@ class ERVClient:
             return False
 
         logger.info(f"ERV speed set to {speed.value} (verified)")
-        self._record_success()
+        self._record_local_success()
         return True
 
     def _set_speed_cloud(self, speed: FanSpeed) -> bool:
@@ -339,9 +354,13 @@ class ERVClient:
         """Return ERV control health info."""
         return {
             "last_ok_at": self.last_ok_at.isoformat() if self.last_ok_at else None,
+            "last_local_ok_at": self.last_local_ok_at.isoformat() if self.last_local_ok_at else None,
             "last_error": self.last_error,
             "last_error_at": self.last_error_at.isoformat() if self.last_error_at else None,
             "using_cloud": self._use_cloud,
+            "local_key_invalid": self.local_key_invalid,
+            "local_key_invalid_since": self.local_key_invalid_since.isoformat() if self.local_key_invalid_since else None,
+            "consecutive_local_key_errors": self.consecutive_local_key_errors,
         }
 
     def _record_error(self, message: str):
@@ -351,6 +370,76 @@ class ERVClient:
     def _record_success(self):
         self.last_ok_at = datetime.now()
         self.last_error = None
+
+    def _record_local_failure(self, context: str, result):
+        self._record_error(f"{context}: {result}")
+
+        if not self._is_local_key_error(result):
+            self.consecutive_local_key_errors = 0
+            return
+
+        self.consecutive_local_key_errors += 1
+        if (
+            self.consecutive_local_key_errors >= self.LOCAL_KEY_ERROR_THRESHOLD and
+            not self.local_key_invalid
+        ):
+            self.local_key_invalid = True
+            self.local_key_invalid_since = datetime.now()
+            logger.error(
+                "ERV local Tuya key appears invalid after %s consecutive Err 914 failures",
+                self.consecutive_local_key_errors,
+            )
+            self._emit_health_event({
+                "type": "erv_local_key_invalid",
+                "started_at": self.local_key_invalid_since.isoformat(),
+                "consecutive_errors": self.consecutive_local_key_errors,
+                "last_local_ok_at": self.last_local_ok_at.isoformat() if self.last_local_ok_at else None,
+                "last_error": self.last_error,
+            })
+
+    def _record_local_success(self):
+        was_invalid = self.local_key_invalid
+        invalid_since = self.local_key_invalid_since
+
+        self._record_success()
+        self.last_local_ok_at = self.last_ok_at
+        self.consecutive_local_key_errors = 0
+        self.local_key_invalid = False
+        self.local_key_invalid_since = None
+
+        if was_invalid:
+            logger.info("ERV local Tuya control recovered after local key invalid state")
+            self._emit_health_event({
+                "type": "erv_local_key_recovered",
+                "recovered_at": self.last_local_ok_at.isoformat() if self.last_local_ok_at else None,
+                "invalid_since": invalid_since.isoformat() if invalid_since else None,
+            })
+
+    def _emit_health_event(self, event: dict):
+        if not self._health_event_callback:
+            return
+        try:
+            self._health_event_callback(event)
+        except Exception as e:
+            logger.error(f"ERV health event callback failed: {e}")
+
+    @classmethod
+    def _is_local_key_error(cls, value) -> bool:
+        if isinstance(value, dict):
+            err = value.get("Err") or value.get("err")
+            if str(err) == cls.LOCAL_KEY_ERROR_CODE:
+                return True
+            error = str(value.get("Error") or value.get("error") or "")
+            if "Check device key or version" in error:
+                return True
+            return any(cls._is_local_key_error(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(cls._is_local_key_error(item) for item in value)
+        text = str(value)
+        return (
+            cls.LOCAL_KEY_ERROR_CODE in text and
+            ("Err" in text or "Check device key or version" in text)
+        )
 
 
 # Standalone test

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -277,7 +277,7 @@ class Orchestrator:
                 "title": "ERV local control recovered",
                 "message": "Local Tuya control is working again.",
                 "created_at": created_at,
-                "active": False,
+                "active": True,
                 "runbook_path": "docs/tuya-local-key.md",
             }
             logger.info("ERV local key recovered; notifying Android app")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -95,14 +95,11 @@ class Orchestrator:
             report_interval=config.qingping.report_interval,
         )
 
-        # ERV client (Tuya local with cloud fallback)
+        # ERV client (Tuya local only)
         self.erv = ERVClient(
             device_id=config.erv.device_id,
             ip=config.erv.ip,
             local_key=config.erv.local_key,
-            cloud_api_key=config.tuya_cloud.access_id if config.tuya_cloud else None,
-            cloud_api_secret=config.tuya_cloud.access_secret if config.tuya_cloud else None,
-            cloud_region=config.tuya_cloud.region if config.tuya_cloud else "us",
         )
 
         # Kumo client (Mitsubishi HVAC)
@@ -196,12 +193,16 @@ class Orchestrator:
         self._manual_hvac_override_at: Optional[datetime] = None
         self._manual_override_timeout: int = 30 * 60  # 30 minutes default
 
+        # App notification state exposed through /status and WebSocket.
+        self._erv_control_notification: Optional[dict] = None
+
         # Background task for HVAC polling
         self._hvac_poll_task: Optional[asyncio.Task] = None
         self._main_loop: Optional[asyncio.AbstractEventLoop] = None
 
         # Database for persistence and analysis
         self.db = Database()
+        self.erv.on_health_event(self._handle_erv_health_event)
 
     def _schedule_task(self, task_factory: Callable[[], Awaitable[None]], *, context: str) -> None:
         """Schedule async work on the orchestrator loop, even from callback threads."""
@@ -249,6 +250,43 @@ class Orchestrator:
 
         # Register event handler
         self.yolink.on_event(self._handle_yolink_event)
+
+    def _handle_erv_health_event(self, event: dict):
+        """Translate ERV control health transitions into in-app notifications."""
+        event_type = event.get("type")
+        if event_type == "erv_local_key_invalid":
+            created_at = event.get("started_at") or datetime.now().isoformat()
+            self._erv_control_notification = {
+                "id": f"erv_local_key_invalid:{created_at}",
+                "type": "erv_local_key_invalid",
+                "severity": "critical",
+                "title": "ERV local key rotated",
+                "message": "Local Tuya control is failing with Err 914. Run docs/tuya-local-key.md to recover it.",
+                "created_at": created_at,
+                "active": True,
+                "runbook_path": "docs/tuya-local-key.md",
+            }
+            logger.error("ERV local key invalid; notifying Android app")
+            self.db.log_device_event("erv", "local_key_invalid", "Pioneer ECOasis 150", details=event)
+        elif event_type == "erv_local_key_recovered":
+            created_at = event.get("recovered_at") or datetime.now().isoformat()
+            self._erv_control_notification = {
+                "id": f"erv_local_key_recovered:{created_at}",
+                "type": "erv_local_key_recovered",
+                "severity": "info",
+                "title": "ERV local control recovered",
+                "message": "Local Tuya control is working again.",
+                "created_at": created_at,
+                "active": False,
+                "runbook_path": "docs/tuya-local-key.md",
+            }
+            logger.info("ERV local key recovered; notifying Android app")
+            self.db.log_device_event("erv", "local_key_recovered", "Pioneer ECOasis 150", details=event)
+        else:
+            logger.debug(f"Ignoring ERV health event: {event}")
+            return
+
+        self._schedule_task(self._broadcast_status, context="erv_health_notification")
 
     async def _handle_yolink_event(self, device: YoLinkDevice, event_data: dict):
         """Handle YoLink sensor events."""
@@ -2036,6 +2074,9 @@ class Orchestrator:
             "hvac_setpoint_f": self._manual_hvac_setpoint_f,
             "hvac_expires_in": int(self._manual_override_timeout - (datetime.now() - self._manual_hvac_override_at).total_seconds()) if self._manual_hvac_override and self._manual_hvac_override_at else None,
         }
+
+        notification = getattr(self, "_erv_control_notification", None)
+        sm_status["notifications"] = [notification] if notification else []
 
         return sm_status
 

--- a/tests/test_erv_client.py
+++ b/tests/test_erv_client.py
@@ -1,0 +1,73 @@
+"""Unit tests for ERV local Tuya control health tracking."""
+
+from types import ModuleType
+import sys
+
+
+if "tinytuya" not in sys.modules:
+    tinytuya = ModuleType("tinytuya")
+    tinytuya.Device = object
+    tinytuya.Cloud = object
+    sys.modules["tinytuya"] = tinytuya
+
+
+from src.erv_client import ERVClient
+
+
+def _client() -> ERVClient:
+    return ERVClient(device_id="device-id", ip="192.0.2.10", local_key="local-key")
+
+
+def _local_key_error() -> dict:
+    return {"Error": "Check device key or version", "Err": "914", "Payload": None}
+
+
+def test_local_key_error_emits_once_when_threshold_crosses():
+    client = _client()
+    events: list[dict] = []
+    client.on_health_event(events.append)
+
+    for _ in range(client.LOCAL_KEY_ERROR_THRESHOLD - 1):
+        client._record_local_failure("Local status failed", _local_key_error())
+
+    assert client.local_key_invalid is False
+    assert events == []
+
+    client._record_local_failure("Local status failed", _local_key_error())
+
+    assert client.local_key_invalid is True
+    assert len(events) == 1
+    assert events[0]["type"] == "erv_local_key_invalid"
+
+    client._record_local_failure("Local status failed", _local_key_error())
+
+    assert len(events) == 1
+
+
+def test_local_success_after_invalid_state_emits_recovery():
+    client = _client()
+    events: list[dict] = []
+    client.on_health_event(events.append)
+
+    for _ in range(client.LOCAL_KEY_ERROR_THRESHOLD):
+        client._record_local_failure("Local status failed", _local_key_error())
+
+    client._record_local_success()
+
+    assert client.local_key_invalid is False
+    assert client.consecutive_local_key_errors == 0
+    assert client.local_key_invalid_since is None
+    assert [event["type"] for event in events] == [
+        "erv_local_key_invalid",
+        "erv_local_key_recovered",
+    ]
+
+
+def test_non_key_local_error_resets_consecutive_key_errors():
+    client = _client()
+
+    client._record_local_failure("Local status failed", _local_key_error())
+    client._record_local_failure("Local status failed", {"Error": "network timeout"})
+
+    assert client.consecutive_local_key_errors == 0
+    assert client.local_key_invalid is False


### PR DESCRIPTION
## Summary
- Detect persistent ERV local Tuya Err 914 responses and emit edge-triggered invalid/recovered health events.
- Expose the current ERV notification through `/status` and WebSocket payloads, then render it in the Android dashboard with persisted dismissal.
- Keep orchestrator ERV control local-only by no longer wiring Tuya cloud credentials into production ERV control.

## Validation
- `source venv/bin/activate && python -m pytest tests/ -q`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:assembleDebug`

Fixes #52