### PR TITLE
Add presence and HVAC band controls

### DIFF
--- a/docs/ui-mockups/presence-and-hvac-band-controls.html
+++ b/docs/ui-mockups/presence-and-hvac-band-controls.html
@@ -1,0 +1,1485 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Office Climate - Presence and Temperature Bands Mockup</title>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap");
+
+      :root {
+        color-scheme: dark;
+        --bg: #09090b;
+        --panel: rgba(24, 24, 27, 0.42);
+        --panel-strong: rgba(24, 24, 27, 0.7);
+        --border: rgba(63, 63, 70, 0.62);
+        --border-soft: rgba(63, 63, 70, 0.4);
+        --text: #fafafa;
+        --muted: #71717a;
+        --muted-2: #52525b;
+        --emerald: #10b981;
+        --emerald-soft: rgba(16, 185, 129, 0.12);
+        --blue: #3b82f6;
+        --blue-soft: rgba(59, 130, 246, 0.12);
+        --amber: #f59e0b;
+        --amber-soft: rgba(245, 158, 11, 0.12);
+        --orange: #fb923c;
+        --orange-soft: rgba(251, 146, 60, 0.12);
+        --red: #ef4444;
+        --cool: #38bdf8;
+        --heat: #fb7185;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        min-height: 100%;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        overflow-x: hidden;
+      }
+
+      button,
+      input {
+        font: inherit;
+      }
+
+      button {
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      .page {
+        width: min(100%, 1088px);
+        margin: 0 auto;
+        padding: 32px 24px 96px;
+      }
+
+      .app-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
+        margin-bottom: 22px;
+      }
+
+      .title {
+        margin: 0;
+        color: #a1a1aa;
+        font-size: 18px;
+        font-weight: 800;
+        letter-spacing: -0.04em;
+        text-transform: uppercase;
+      }
+
+      .header-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 14px;
+        color: #d4d4d8;
+      }
+
+      .user {
+        color: #a1a1aa;
+        font-size: 14px;
+      }
+
+      .tiny-button,
+      .ambient-button,
+      .logout-button {
+        border: 1px solid var(--border-soft);
+        border-radius: 8px;
+        background: rgba(39, 39, 42, 0.7);
+        color: #d4d4d8;
+        cursor: pointer;
+        transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+      }
+
+      .logout-button {
+        padding: 5px 12px;
+        font-size: 12px;
+      }
+
+      .ambient-button {
+        padding: 6px 10px;
+        color: var(--muted);
+        font-size: 10px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .tiny-button:hover,
+      .ambient-button:hover,
+      .logout-button:hover {
+        background: rgba(63, 63, 70, 0.75);
+        border-color: rgba(82, 82, 91, 0.8);
+        color: #f4f4f5;
+      }
+
+      .time {
+        color: #e4e4e7;
+        font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 24px;
+        font-weight: 500;
+      }
+
+      .hero {
+        position: relative;
+        overflow: hidden;
+        border: 2px solid rgba(59, 130, 246, 0.34);
+        border-radius: 24px;
+        background: var(--panel);
+        padding: 32px 40px 38px;
+        transition: border-color 220ms ease;
+      }
+
+      .hero.present {
+        border-color: rgba(16, 185, 129, 0.34);
+      }
+
+      .hero-top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 20px;
+        margin-bottom: 20px;
+      }
+
+      .primary-label,
+      .section-label,
+      .tile-label,
+      .control-label,
+      .dial-caption,
+      .footer-label {
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .primary-label {
+        color: var(--blue);
+        margin-top: 8px;
+      }
+
+      .hero.present .primary-label {
+        color: var(--emerald);
+      }
+
+      .here-button {
+        min-width: 164px;
+        border: 1px solid rgba(16, 185, 129, 0.55);
+        border-radius: 12px;
+        background: var(--emerald);
+        color: #031a12;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 13px 18px;
+        font-size: 14px;
+        font-weight: 900;
+        text-transform: uppercase;
+        box-shadow: 0 0 28px rgba(16, 185, 129, 0.18);
+        transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+      }
+
+      .here-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 0 34px rgba(16, 185, 129, 0.3);
+      }
+
+      .here-button.is-present {
+        background: rgba(16, 185, 129, 0.16);
+        color: #86efac;
+        border-color: rgba(16, 185, 129, 0.42);
+        box-shadow: none;
+      }
+
+      .here-icon {
+        width: 18px;
+        height: 18px;
+        display: inline-grid;
+        place-items: center;
+        border-radius: 999px;
+        background: rgba(3, 26, 18, 0.16);
+        font-size: 12px;
+        line-height: 1;
+      }
+
+      .hero-main {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+      }
+
+      .status-line {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 14px;
+        color: var(--blue);
+        font-size: clamp(34px, 5vw, 52px);
+        font-weight: 900;
+        letter-spacing: -0.04em;
+        line-height: 1.04;
+        margin-bottom: 26px;
+      }
+
+      .hero.present .status-line {
+        color: var(--emerald);
+      }
+
+      .status-dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        background: var(--blue);
+        box-shadow: 0 0 18px rgba(59, 130, 246, 0.5);
+      }
+
+      #statusText {
+        min-width: 0;
+      }
+
+      .hero.present .status-dot {
+        background: var(--emerald);
+        box-shadow: 0 0 18px rgba(16, 185, 129, 0.5);
+      }
+
+      .co2 {
+        color: #fbbf24;
+        font-size: clamp(86px, 14vw, 156px);
+        font-weight: 900;
+        letter-spacing: -0.08em;
+        line-height: 0.9;
+      }
+
+      .co2-label {
+        margin-top: -2px;
+        color: var(--muted-2);
+        font-size: clamp(15px, 2vw, 22px);
+        font-weight: 800;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+
+      .grid {
+        display: grid;
+        gap: 16px;
+      }
+
+      .vitals {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-top: 24px;
+      }
+
+      .tile {
+        min-height: 104px;
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(24, 24, 27, 0.32);
+        padding: 16px;
+      }
+
+      .tile-head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
+
+      .tile-icon {
+        font-size: 20px;
+        line-height: 1;
+      }
+
+      .tile-value {
+        display: flex;
+        align-items: baseline;
+        gap: 4px;
+        color: #f4f4f5;
+        font-size: 28px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+      }
+
+      .tile-unit {
+        color: var(--muted);
+        font-size: 14px;
+        font-weight: 700;
+        letter-spacing: 0;
+      }
+
+      .controls {
+        border: 1px solid var(--border-soft);
+        border-radius: 24px;
+        background: rgba(24, 24, 27, 0.3);
+        padding: 24px;
+        margin-top: 24px;
+      }
+
+      .section-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 18px;
+      }
+
+      .section-head h2,
+      .band-head h3,
+      .control-panel h3 {
+        margin: 0;
+      }
+
+      .override-chip,
+      .save-chip {
+        border-radius: 999px;
+        background: var(--amber-soft);
+        color: var(--amber);
+        padding: 5px 9px;
+        font-size: 10px;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .control-stack {
+        display: grid;
+        gap: 14px;
+      }
+
+      .control-row {
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(9, 9, 11, 0.26);
+        padding: 16px;
+      }
+
+      .row-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        margin-bottom: 12px;
+      }
+
+      .row-head h3 {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        color: #a1a1aa;
+        font-size: 14px;
+        font-weight: 800;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        margin: 0;
+      }
+
+      .row-sub {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+        margin-top: 5px;
+      }
+
+      .row-status {
+        flex: 0 0 auto;
+        border-radius: 999px;
+        background: var(--blue-soft);
+        color: #93c5fd;
+        padding: 5px 9px;
+        font-size: 10px;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .row-status.present {
+        background: var(--emerald-soft);
+        color: #86efac;
+      }
+
+      .button-grid {
+        display: grid;
+        gap: 8px;
+      }
+
+      .button-grid.four {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      .button-grid.three {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .quick-button {
+        min-height: 39px;
+        border: 0;
+        border-radius: 8px;
+        background: rgba(39, 39, 42, 0.86);
+        color: #a1a1aa;
+        cursor: pointer;
+        padding: 9px 10px;
+        font-size: 12px;
+        font-weight: 900;
+        text-transform: uppercase;
+        transition: background 160ms ease, color 160ms ease;
+      }
+
+      .quick-button:hover {
+        background: rgba(63, 63, 70, 0.9);
+        color: #e4e4e7;
+      }
+
+      .quick-button.active {
+        background: var(--amber);
+        color: #18100a;
+        box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
+      }
+
+      .presence-row {
+        border: 1px solid rgba(16, 185, 129, 0.18);
+        background: rgba(16, 185, 129, 0.06);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 12px 16px;
+      }
+
+      .presence-action {
+        flex: 1 1 240px;
+        min-height: 36px;
+        border: 0;
+        border-radius: 9px;
+        background: var(--emerald);
+        color: #031a12;
+        cursor: pointer;
+        padding: 8px 16px;
+        font-size: 12px;
+        font-weight: 900;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        box-shadow: 0 0 28px rgba(16, 185, 129, 0.18);
+        transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+      }
+
+      .presence-action:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 0 34px rgba(16, 185, 129, 0.3);
+      }
+
+      .presence-action.away-action {
+        background: rgba(59, 130, 246, 0.18);
+        color: #bfdbfe;
+        box-shadow: none;
+      }
+
+      .presence-line {
+        min-width: 0;
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .presence-label {
+        color: #a1a1aa;
+        font-size: 13px;
+        font-weight: 850;
+        letter-spacing: 0.02em;
+      }
+
+      .bands {
+        border-top: 1px solid rgba(63, 63, 70, 0.48);
+        margin-top: 24px;
+        padding-top: 24px;
+      }
+
+      .bands[open] {
+        padding-bottom: 2px;
+      }
+
+      .band-summary {
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(9, 9, 11, 0.32);
+        cursor: pointer;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+        list-style: none;
+        padding: 16px;
+      }
+
+      .band-summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .band-summary::before {
+        content: "›";
+        color: var(--muted);
+        font-size: 24px;
+        font-weight: 600;
+        line-height: 1;
+        transform: rotate(0deg);
+        transition: transform 160ms ease;
+      }
+
+      .bands[open] .band-summary::before {
+        transform: rotate(90deg);
+      }
+
+      .band-summary-title {
+        color: #d4d4d8;
+        font-size: 14px;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .band-summary-value {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 750;
+        text-align: right;
+      }
+
+      .band-body {
+        padding-top: 16px;
+      }
+
+      .band-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 18px;
+        margin-bottom: 18px;
+      }
+
+      .band-title {
+        color: #d4d4d8;
+        font-size: 15px;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .band-sub {
+        margin-top: 5px;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      .band-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      .band-rows {
+        display: grid;
+        gap: 12px;
+      }
+
+      .band-row {
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(24, 24, 27, 0.28);
+        display: grid;
+        grid-template-columns: minmax(190px, 1fr) minmax(0, 1.5fr);
+        align-items: center;
+        gap: 16px;
+        padding: 16px;
+      }
+
+      .band-row.heat {
+        border-color: rgba(251, 113, 133, 0.22);
+      }
+
+      .band-row.cool {
+        border-color: rgba(56, 189, 248, 0.22);
+      }
+
+      .band-name {
+        color: #e4e4e7;
+        font-size: 15px;
+        font-weight: 900;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      .band-range {
+        color: #f4f4f5;
+        font-size: 30px;
+        font-weight: 900;
+        letter-spacing: -0.05em;
+        margin-top: 4px;
+      }
+
+      .band-detail {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+        margin-top: 4px;
+      }
+
+      .band-controls {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .band-control {
+        border: 1px solid rgba(63, 63, 70, 0.44);
+        border-radius: 12px;
+        background: rgba(9, 9, 11, 0.24);
+        padding: 10px;
+      }
+
+      .band-control-title {
+        color: var(--muted);
+        font-size: 10px;
+        font-weight: 900;
+        letter-spacing: 0.1em;
+        margin-bottom: 8px;
+        text-transform: uppercase;
+      }
+
+      .segmented {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 6px;
+      }
+
+      .segmented button {
+        min-height: 38px;
+        border: 0;
+        border-radius: 9px;
+        background: rgba(39, 39, 42, 0.86);
+        color: #d4d4d8;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 900;
+        text-transform: uppercase;
+      }
+
+      .segmented button:hover {
+        background: rgba(63, 63, 70, 0.9);
+        color: #f4f4f5;
+      }
+
+      .save-row {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-top: 14px;
+      }
+
+      .save-button {
+        border: 0;
+        border-radius: 10px;
+        background: #e4e4e7;
+        color: #18181b;
+        cursor: pointer;
+        padding: 10px 14px;
+        font-size: 12px;
+        font-weight: 900;
+        text-transform: uppercase;
+      }
+
+      .save-button:disabled {
+        cursor: default;
+        background: rgba(63, 63, 70, 0.72);
+        color: var(--muted);
+      }
+
+      .thermo {
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(9, 9, 11, 0.44);
+        padding: 18px 16px 14px;
+        margin-bottom: 18px;
+      }
+
+      .thermo-track {
+        position: relative;
+        height: 12px;
+        border-radius: 999px;
+        background:
+          linear-gradient(90deg, rgba(251, 113, 133, 0.26) 0 34%, rgba(113, 113, 122, 0.26) 34% 70%, rgba(56, 189, 248, 0.26) 70% 100%);
+      }
+
+      .thermo-marker {
+        position: absolute;
+        top: -7px;
+        width: 3px;
+        height: 26px;
+        border-radius: 999px;
+        background: currentColor;
+        transform: translateX(-50%);
+      }
+
+      .thermo-marker::after {
+        content: attr(data-label);
+        position: absolute;
+        top: 30px;
+        left: 50%;
+        transform: translateX(-50%);
+        color: #a1a1aa;
+        font-size: 10px;
+        font-weight: 800;
+        white-space: nowrap;
+        text-transform: uppercase;
+      }
+
+      .thermo-marker.heat {
+        color: var(--heat);
+      }
+
+      .thermo-marker.cool {
+        color: var(--cool);
+      }
+
+      .thermo-marker.current {
+        color: #e4e4e7;
+        width: 5px;
+        height: 30px;
+        top: -9px;
+        box-shadow: 0 0 14px rgba(244, 244, 245, 0.26);
+      }
+
+      .thermo-scale {
+        display: flex;
+        justify-content: space-between;
+        color: var(--muted-2);
+        font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11px;
+        margin-top: 38px;
+      }
+
+      .dial-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .dial-card {
+        min-width: 0;
+        border: 1px solid var(--border-soft);
+        border-radius: 16px;
+        background: rgba(24, 24, 27, 0.32);
+        padding: 14px;
+      }
+
+      .dial-card.heat {
+        border-color: rgba(251, 113, 133, 0.24);
+      }
+
+      .dial-card.cool {
+        border-color: rgba(56, 189, 248, 0.24);
+      }
+
+      .dial-caption {
+        color: #d4d4d8;
+        margin-bottom: 4px;
+      }
+
+      .dial-note {
+        min-height: 16px;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+
+      .dial-row {
+        display: grid;
+        grid-template-columns: 34px minmax(82px, 1fr) 34px;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .step-button {
+        width: 34px;
+        height: 34px;
+        border: 1px solid var(--border-soft);
+        border-radius: 999px;
+        background: rgba(39, 39, 42, 0.86);
+        color: #e4e4e7;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        font-size: 18px;
+        font-weight: 800;
+      }
+
+      .step-button:hover {
+        border-color: rgba(113, 113, 122, 0.75);
+        background: rgba(63, 63, 70, 0.86);
+      }
+
+      .knob {
+        --dial-color: var(--emerald);
+        --pct: 50%;
+        position: relative;
+        width: 100%;
+        aspect-ratio: 1;
+        max-width: 106px;
+        margin: 0 auto;
+        border-radius: 999px;
+        background: conic-gradient(var(--dial-color) var(--pct), rgba(63, 63, 70, 0.82) 0);
+        display: grid;
+        place-items: center;
+      }
+
+      .knob::before {
+        content: "";
+        position: absolute;
+        inset: 9px;
+        border-radius: inherit;
+        background: #18181b;
+        box-shadow: inset 0 0 0 1px rgba(63, 63, 70, 0.62);
+      }
+
+      .knob-value {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: baseline;
+        justify-content: center;
+        gap: 2px;
+      }
+
+      .knob-number {
+        color: #f4f4f5;
+        font-size: 28px;
+        font-weight: 900;
+        letter-spacing: -0.05em;
+      }
+
+      .knob-unit {
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 800;
+      }
+
+      .activity {
+        border: 1px solid var(--border-soft);
+        border-radius: 24px;
+        background: rgba(24, 24, 27, 0.3);
+        padding: 24px;
+        margin-top: 24px;
+        margin-bottom: 24px;
+      }
+
+      .activity-list {
+        display: grid;
+        gap: 14px;
+        margin-top: 18px;
+      }
+
+      .event {
+        display: grid;
+        grid-template-columns: 58px 1fr auto;
+        align-items: center;
+        gap: 16px;
+        color: #d4d4d8;
+        font-size: 14px;
+      }
+
+      .event-time {
+        color: var(--muted-2);
+        font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+
+      .now-chip {
+        border-radius: 999px;
+        background: var(--emerald-soft);
+        color: var(--emerald);
+        padding: 3px 8px;
+        font-size: 10px;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .footer {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 18px;
+        border-top: 1px solid var(--border-soft);
+        background: rgba(0, 0, 0, 0.82);
+        backdrop-filter: blur(16px);
+        padding: 13px 18px;
+      }
+
+      .connection {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .connection-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 999px;
+        background: var(--emerald);
+        box-shadow: 0 0 8px rgba(16, 185, 129, 0.5);
+      }
+
+      .sep {
+        color: #27272a;
+      }
+
+      @media (max-width: 900px) {
+        .page {
+          padding: 20px 16px 96px;
+        }
+
+        .app-header {
+          align-items: flex-start;
+        }
+
+        .header-actions {
+          flex-wrap: wrap;
+        }
+
+        .vitals {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .band-head {
+          flex-direction: column;
+        }
+
+        .band-actions {
+          width: 100%;
+          justify-content: space-between;
+        }
+
+        .band-row {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .page {
+          padding-left: 12px;
+          padding-right: 12px;
+        }
+
+        .app-header {
+          display: grid;
+          grid-template-columns: 1fr;
+        }
+
+        .header-actions {
+          justify-content: flex-start;
+          gap: 10px;
+        }
+
+        .user {
+          width: 100%;
+        }
+
+        .time {
+          font-size: 20px;
+        }
+
+        .hero {
+          padding: 20px 16px 28px;
+          border-radius: 20px;
+        }
+
+        .hero-top {
+          flex-direction: column;
+          gap: 14px;
+          align-items: stretch;
+        }
+
+        .primary-label {
+          margin-top: 0;
+        }
+
+        .here-button {
+          width: 100%;
+          min-width: 0;
+        }
+
+        .status-line {
+          align-items: flex-start;
+          font-size: 28px;
+          gap: 10px;
+          text-align: center;
+        }
+
+        .status-dot {
+          margin-top: 6px;
+          flex: 0 0 auto;
+        }
+
+        .vitals {
+          gap: 10px;
+        }
+
+        .tile {
+          min-height: 92px;
+          padding: 13px;
+        }
+
+        .tile-value {
+          font-size: 23px;
+        }
+
+        .controls,
+        .activity {
+          border-radius: 20px;
+          padding: 18px 14px;
+        }
+
+        .section-head {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        .button-grid.four {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .button-grid.three {
+          grid-template-columns: 1fr;
+        }
+
+        .row-head {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        .row-status {
+          align-self: flex-start;
+        }
+
+        .presence-row {
+          align-items: stretch;
+          flex-direction: column;
+        }
+
+        .presence-action {
+          flex-basis: auto;
+          width: 100%;
+        }
+
+        .band-summary {
+          grid-template-columns: auto 1fr;
+        }
+
+        .band-summary-value {
+          grid-column: 2;
+          text-align: left;
+        }
+
+        .band-controls {
+          grid-template-columns: 1fr;
+        }
+
+        .save-row {
+          justify-content: stretch;
+        }
+
+        .save-row > * {
+          flex: 1;
+        }
+
+        .event {
+          grid-template-columns: 54px 1fr;
+        }
+
+        .now-chip {
+          display: none;
+        }
+
+        .footer {
+          gap: 10px;
+          overflow-x: auto;
+          justify-content: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header class="app-header">
+        <h1 class="title">Office Climate</h1>
+        <div class="header-actions">
+          <span class="user">Local Network</span>
+          <button class="logout-button" type="button">Logout</button>
+          <button class="ambient-button" type="button">Ambient Mode</button>
+          <div class="time" id="clock">02:41 PM</div>
+        </div>
+      </header>
+
+      <section class="hero" id="hero">
+        <div class="hero-top">
+          <div class="primary-label">Primary Status</div>
+        </div>
+
+        <div class="hero-main">
+          <div class="status-line">
+            <span class="status-dot" aria-hidden="true"></span>
+            <span id="statusText">AWAY · CLEARING</span>
+          </div>
+          <div class="co2">1248</div>
+          <div class="co2-label">parts per million</div>
+        </div>
+      </section>
+
+      <section class="grid vitals" aria-label="Vitals">
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">🌡️</span><span class="tile-label">Temperature</span></div>
+          <div class="tile-value">74<span class="tile-unit">&deg;F</span></div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">💧</span><span class="tile-label">Humidity</span></div>
+          <div class="tile-value">45<span class="tile-unit">%</span></div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">🌫️</span><span class="tile-label">tVOC</span></div>
+          <div class="tile-value">31</div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">🔊</span><span class="tile-label">Noise</span></div>
+          <div class="tile-value">36<span class="tile-unit">dB</span></div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">💨</span><span class="tile-label">PM2.5</span></div>
+          <div class="tile-value">2<span class="tile-unit">&micro;g/m&sup3;</span></div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">💨</span><span class="tile-label">PM10</span></div>
+          <div class="tile-value">5<span class="tile-unit">&micro;g/m&sup3;</span></div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">🚪</span><span class="tile-label">Door</span></div>
+          <div class="tile-value">CLOSED</div>
+        </div>
+        <div class="tile">
+          <div class="tile-head"><span class="tile-icon">🪟</span><span class="tile-label">Window</span></div>
+          <div class="tile-value">CLOSED</div>
+        </div>
+      </section>
+
+      <section class="controls">
+        <div class="section-head">
+          <h2 class="section-label">Quick Controls</h2>
+        </div>
+
+        <div class="control-stack">
+          <div class="control-row presence-row">
+            <div class="presence-line">
+              <span class="presence-label">Detected presence:</span>
+              <span class="row-status" id="presencePill">Away</span>
+            </div>
+            <button class="presence-action" id="presenceToggle" type="button">I'm here</button>
+          </div>
+
+          <div class="control-row">
+            <div class="row-head">
+              <div>
+                <h3>🌀 Ventilation</h3>
+                <div class="row-sub">Manual ERV control expires in 24m</div>
+              </div>
+              <span class="override-chip">Manual Override Active</span>
+            </div>
+            <div class="button-grid four">
+              <button class="quick-button" type="button">Off</button>
+              <button class="quick-button" type="button">Quiet</button>
+              <button class="quick-button" type="button">Medium</button>
+              <button class="quick-button active" type="button">Turbo</button>
+            </div>
+          </div>
+
+          <div class="control-row">
+            <div class="row-head">
+              <div>
+                <h3>🔥 HVAC</h3>
+                <div class="row-sub">Manual HVAC control expires in 24m</div>
+              </div>
+              <span class="override-chip">Manual Override Active</span>
+            </div>
+            <div class="button-grid three">
+              <button class="quick-button" type="button">Off</button>
+              <button class="quick-button" type="button">Heat 70&deg;F</button>
+              <button class="quick-button" type="button">Cool 78&deg;F</button>
+            </div>
+          </div>
+        </div>
+
+        <details class="bands" id="bandsDetails">
+          <summary class="band-summary">
+            <span class="band-summary-title">Hysteresis Bands</span>
+            <span class="band-summary-value" id="bandSummary">Heat 71-75&deg;F · Cool 78-81&deg;F</span>
+          </summary>
+
+          <div class="band-body">
+            <div class="band-head">
+              <div>
+                <h3 class="band-title">Temperature Bands</h3>
+                <div class="band-sub">Current Qingping temp 74&deg;F</div>
+              </div>
+              <div class="band-actions">
+                <button class="tiny-button" id="resetButton" type="button">Reset</button>
+              </div>
+            </div>
+
+            <div class="band-rows">
+              <div class="band-row heat">
+                <div>
+                  <div class="band-name">Heat</div>
+                  <div class="band-range" id="heatRange">71-75&deg;F</div>
+                  <div class="band-detail" id="heatDetail">Resume at or below 71&deg; · pause at or above 75&deg;</div>
+                </div>
+                <div class="band-controls">
+                  <div class="band-control">
+                    <div class="band-control-title">Move Band</div>
+                    <div class="segmented">
+                      <button type="button" data-band="heat" data-band-action="shift" data-delta="-1">−1&deg;</button>
+                      <button type="button" data-band="heat" data-band-action="shift" data-delta="1">+1&deg;</button>
+                    </div>
+                  </div>
+                  <div class="band-control">
+                    <div class="band-control-title">Band Width</div>
+                    <div class="segmented">
+                      <button type="button" data-band="heat" data-band-action="spread" data-delta="-1">Tighter</button>
+                      <button type="button" data-band="heat" data-band-action="spread" data-delta="1">Wider</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="band-row cool">
+                <div>
+                  <div class="band-name">Cool</div>
+                  <div class="band-range" id="coolRange">78-81&deg;F</div>
+                  <div class="band-detail" id="coolDetail">Stop at or below 78&deg; · start above 81&deg;</div>
+                </div>
+                <div class="band-controls">
+                  <div class="band-control">
+                    <div class="band-control-title">Move Band</div>
+                    <div class="segmented">
+                      <button type="button" data-band="cool" data-band-action="shift" data-delta="-1">−1&deg;</button>
+                      <button type="button" data-band="cool" data-band-action="shift" data-delta="1">+1&deg;</button>
+                    </div>
+                  </div>
+                  <div class="band-control">
+                    <div class="band-control-title">Band Width</div>
+                    <div class="segmented">
+                      <button type="button" data-band="cool" data-band-action="spread" data-delta="-1">Tighter</button>
+                      <button type="button" data-band="cool" data-band-action="spread" data-delta="1">Wider</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <section class="activity">
+        <h2 class="section-label">Today's Activity</h2>
+        <div class="activity-list" id="activityList">
+          <div class="event">
+            <span class="event-time">01:54</span>
+            <span>ERV TURBO</span>
+            <span></span>
+          </div>
+          <div class="event">
+            <span class="event-time">01:54</span>
+            <span>Away - CO2 1287 ppm</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span class="connection"><span class="connection-dot"></span><span class="footer-label">API</span></span>
+      <span class="sep">•</span>
+      <span class="connection"><span class="connection-dot"></span><span class="footer-label">WebSocket</span></span>
+      <span class="sep">•</span>
+      <span class="connection"><span class="connection-dot"></span><span class="footer-label">Qingping</span></span>
+      <span class="sep">•</span>
+      <span class="connection"><span class="connection-dot"></span><span class="footer-label">YoLink</span></span>
+    </footer>
+
+    <script>
+      const defaults = {
+        heatOn: 71,
+        heatOff: 75,
+        coolOff: 78,
+        coolOn: 81
+      };
+
+      const ranges = {
+        heatOn: { min: 55, max: 78 },
+        heatOff: { min: 60, max: 82 },
+        coolOff: { min: 68, max: 84 },
+        coolOn: { min: 72, max: 90 }
+      };
+
+      const values = { ...defaults };
+      const currentTemp = 74;
+      let present = false;
+
+      function setClock() {
+        const clock = document.getElementById("clock");
+        clock.textContent = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+      }
+
+      function renderBands() {
+        document.getElementById("bandSummary").innerHTML =
+          `Heat ${values.heatOn}-${values.heatOff}&deg;F · Cool ${values.coolOff}-${values.coolOn}&deg;F`;
+        document.getElementById("heatRange").innerHTML = `${values.heatOn}-${values.heatOff}&deg;F`;
+        document.getElementById("coolRange").innerHTML = `${values.coolOff}-${values.coolOn}&deg;F`;
+        document.getElementById("heatDetail").innerHTML =
+          `Resume at or below ${values.heatOn}&deg; · pause at or above ${values.heatOff}&deg;`;
+        document.getElementById("coolDetail").innerHTML =
+          `Stop at or below ${values.coolOff}&deg; · start above ${values.coolOn}&deg;`;
+
+      }
+
+      function clamp(value, range) {
+        return Math.max(range.min, Math.min(range.max, value));
+      }
+
+      function setBand(band, lower, upper) {
+        const lowerKey = band === "heat" ? "heatOn" : "coolOff";
+        const upperKey = band === "heat" ? "heatOff" : "coolOn";
+        const minGap = 1;
+
+        lower = clamp(lower, ranges[lowerKey]);
+        upper = clamp(upper, ranges[upperKey]);
+
+        if (upper - lower < minGap) {
+          if (values[upperKey] !== upper) {
+            lower = upper - minGap;
+          } else {
+            upper = lower + minGap;
+          }
+        }
+
+        values[lowerKey] = clamp(lower, ranges[lowerKey]);
+        values[upperKey] = clamp(upper, ranges[upperKey]);
+      }
+
+      function adjustBand(band, action, delta) {
+        const lowerKey = band === "heat" ? "heatOn" : "coolOff";
+        const upperKey = band === "heat" ? "heatOff" : "coolOn";
+        let lower = values[lowerKey];
+        let upper = values[upperKey];
+
+        if (action === "shift") {
+          lower += delta;
+          upper += delta;
+        } else if (action === "spread") {
+          lower -= delta;
+          upper += delta;
+        }
+
+        setBand(band, lower, upper);
+        renderBands();
+      }
+
+      function renderPresence() {
+        const hero = document.getElementById("hero");
+        const button = document.getElementById("presenceToggle");
+        const pill = document.getElementById("presencePill");
+
+        hero.classList.toggle("present", present);
+        button.classList.toggle("away-action", present);
+        pill.classList.toggle("present", present);
+
+        document.getElementById("statusText").textContent = present ? "PRESENT · QUIET" : "AWAY · CLEARING";
+        pill.textContent = present ? "Here" : "Away";
+        button.textContent = present ? "I'm away" : "I'm here";
+        button.setAttribute(
+          "aria-label",
+          present ? "Set office occupancy to away" : "Set office occupancy to present"
+        );
+      }
+
+      function togglePresence() {
+        present = !present;
+        const message = present ? "I'm here - set PRESENT" : "I'm away - set AWAY";
+        renderPresence();
+
+        const activityList = document.getElementById("activityList");
+        for (const chip of activityList.querySelectorAll(".now-chip")) {
+          chip.remove();
+        }
+
+        const row = document.createElement("div");
+        row.className = "event";
+        row.innerHTML = `
+          <span class="event-time">${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
+          <span>${message}</span>
+          <span class="now-chip">now</span>
+        `;
+        activityList.appendChild(row);
+      }
+
+      document.addEventListener("click", (event) => {
+        const bandButton = event.target.closest("[data-band]");
+        if (bandButton) {
+          adjustBand(
+            bandButton.dataset.band,
+            bandButton.dataset.bandAction,
+            Number(bandButton.dataset.delta)
+          );
+          return;
+        }
+
+        if (event.target.closest("#presenceToggle")) {
+          togglePresence();
+          return;
+        }
+
+        if (event.target.closest("#resetButton")) {
+          Object.assign(values, defaults);
+          renderBands();
+        }
+      });
+
+      setClock();
+      setInterval(setClock, 1000);
+      renderPresence();
+      renderBands();
+    </script>
+  </body>
+</html>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -37,7 +37,7 @@ const DEFAULT_STATE: OfficeState = {
   isSystemError: true
 };
 
-const DEFAULT_TEMPERATURE_BANDS: HVACTemperatureBands = {
+const FALLBACK_TEMPERATURE_BANDS: HVACTemperatureBands = {
   heat_on_temp_f: 71,
   heat_off_temp_f: 75,
   cool_off_temp_f: 78,
@@ -62,8 +62,16 @@ function mapERVSpeed(apiSpeed: string | undefined): ERVSpeed {
   }
 }
 
+function statusToOccupancy(api: ApiStatus): OccupancyState {
+  if (api.state === 'present') return OccupancyState.PRESENT;
+  if (api.state === 'away') return OccupancyState.AWAY;
+  return api.is_present ? OccupancyState.PRESENT : OccupancyState.AWAY;
+}
+
 // Convert API response to OfficeState
 function apiToState(api: ApiStatus): OfficeState {
+  const occupancy = statusToOccupancy(api);
+
   return {
     co2: api.air_quality.co2_ppm ?? api.sensors.co2_ppm ?? 0,
     temperature: api.air_quality.temp_c ? toFahrenheit(api.air_quality.temp_c) : 0,
@@ -80,7 +88,7 @@ function apiToState(api: ApiStatus): OfficeState {
               api.hvac?.mode === 'off' ? DeviceStatus.OFF : DeviceStatus.OFF,
     hvacTarget: api.hvac?.setpoint_c ? toFahrenheit(api.hvac.setpoint_c) : 70,
     ventMode: mapERVSpeed(api.erv.speed),
-    occupancy: api.is_present ? OccupancyState.PRESENT : OccupancyState.AWAY,
+    occupancy,
     lastUpdated: api.air_quality.last_update ? new Date(api.air_quality.last_update) : new Date(),
     isSystemError: false
   };
@@ -94,7 +102,8 @@ const App: React.FC = () => {
   const [isAmbient, setIsAmbient] = useState(false);
   const [wsConnected, setWsConnected] = useState(false);
   const [apiConnected, setApiConnected] = useState(false);
-  const [temperatureBands, setTemperatureBands] = useState<HVACTemperatureBands>(DEFAULT_TEMPERATURE_BANDS);
+  const [temperatureBands, setTemperatureBands] = useState<HVACTemperatureBands>(FALLBACK_TEMPERATURE_BANDS);
+  const [temperatureBandDefaults, setTemperatureBandDefaults] = useState<HVACTemperatureBands | null>(null);
   const [manualOverride, setManualOverride] = useState<{
     erv: boolean;
     erv_speed: string | null;
@@ -189,6 +198,9 @@ const App: React.FC = () => {
           if (status.hvac?.temperature_bands) {
             setTemperatureBands(status.hvac.temperature_bands);
           }
+          if (status.hvac?.temperature_band_defaults) {
+            setTemperatureBandDefaults(status.hvac.temperature_band_defaults);
+          }
           setState(prev => {
             // Only log events after initial load (avoid spurious "Arrived" on page load)
             if (!initialLoadRef.current) {
@@ -215,7 +227,7 @@ const App: React.FC = () => {
           // Add to history every update
           addHistoryPoint(
             status.air_quality.co2_ppm ?? status.sensors.co2_ppm ?? 0,
-            status.is_present ? OccupancyState.PRESENT : OccupancyState.AWAY,
+            statusToOccupancy(status),
             status.erv.running
           );
         }
@@ -263,6 +275,9 @@ const App: React.FC = () => {
       if (status.hvac?.temperature_bands) {
         setTemperatureBands(status.hvac.temperature_bands);
       }
+      if (status.hvac?.temperature_band_defaults) {
+        setTemperatureBandDefaults(status.hvac.temperature_band_defaults);
+      }
       setState(prev => {
         // Only log real changes (compare against last known occupancy, not stale state)
         if (lastOccupancyRef.current !== null && lastOccupancyRef.current !== newState.occupancy) {
@@ -278,7 +293,7 @@ const App: React.FC = () => {
 
       addHistoryPoint(
         status.air_quality.co2_ppm ?? status.sensors.co2_ppm ?? 0,
-        status.is_present ? OccupancyState.PRESENT : OccupancyState.AWAY,
+        statusToOccupancy(status),
         status.erv.running
       );
     });
@@ -405,6 +420,9 @@ const App: React.FC = () => {
         setTemperatureBands(previousBands);
       } else {
         setTemperatureBands(result.temperature_bands);
+        if (result.temperature_band_defaults) {
+          setTemperatureBandDefaults(result.temperature_band_defaults);
+        }
         addEvent(
           'hvac',
           `Bands: heat ${result.temperature_bands.heat_on_temp_f}-${result.temperature_bands.heat_off_temp_f}°F, cool ${result.temperature_bands.cool_off_temp_f}-${result.temperature_bands.cool_on_temp_f}°F`
@@ -419,16 +437,21 @@ const App: React.FC = () => {
   }, [addEvent, clampTemperatureBand, temperatureBands]);
 
   const resetTemperatureBands = useCallback(() => {
+    if (!temperatureBandDefaults) return;
+
     const previousBands = temperatureBands;
-    setTemperatureBands(DEFAULT_TEMPERATURE_BANDS);
+    setTemperatureBands(temperatureBandDefaults);
     setControlLoading('bands-reset');
 
-    setHVACTemperatureBands(DEFAULT_TEMPERATURE_BANDS).then((result) => {
+    setHVACTemperatureBands(temperatureBandDefaults).then((result) => {
       if (!result.ok || !result.temperature_bands) {
         console.error('HVAC temperature band reset failed:', result.error);
         setTemperatureBands(previousBands);
       } else {
         setTemperatureBands(result.temperature_bands);
+        if (result.temperature_band_defaults) {
+          setTemperatureBandDefaults(result.temperature_band_defaults);
+        }
         addEvent('hvac', 'Bands reset to defaults');
       }
     }).catch((e) => {
@@ -437,7 +460,7 @@ const App: React.FC = () => {
     }).finally(() => {
       setControlLoading(null);
     });
-  }, [addEvent, temperatureBands]);
+  }, [addEvent, temperatureBandDefaults, temperatureBands]);
 
   const currentStatus = getPrimaryStatus();
 
@@ -779,7 +802,7 @@ const App: React.FC = () => {
                 </div>
                 <button
                   onClick={resetTemperatureBands}
-                  disabled={controlLoading !== null}
+                  disabled={controlLoading !== null || temperatureBandDefaults === null}
                   className="px-3 py-2 text-xs font-bold uppercase rounded-lg bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Reset

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -12,7 +12,7 @@ import {
 import { STATUS_CONFIG } from './constants';
 import VitalTile from './components/VitalTile';
 import CO2Chart from './components/CO2Chart';
-import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, ERVSpeed as ApiERVSpeed, HVACMode, isAuthenticated, logout, getUserEmail, checkTrustedNetwork } from './api';
+import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, setPresence, setHVACTemperatureBands, ERVSpeed as ApiERVSpeed, HVACMode, HVACTemperatureBands, isAuthenticated, logout, getUserEmail, checkTrustedNetwork } from './api';
 import Login from './Login';
 import HistoricalCharts from './HistoricalCharts';
 import OfficeReplay from './OfficeReplay';
@@ -35,6 +35,20 @@ const DEFAULT_STATE: OfficeState = {
   occupancy: OccupancyState.AWAY,
   lastUpdated: new Date(),
   isSystemError: true
+};
+
+const DEFAULT_TEMPERATURE_BANDS: HVACTemperatureBands = {
+  heat_on_temp_f: 71,
+  heat_off_temp_f: 75,
+  cool_off_temp_f: 78,
+  cool_on_temp_f: 81,
+};
+
+const TEMPERATURE_BAND_LIMITS: Record<keyof HVACTemperatureBands, { min: number; max: number }> = {
+  heat_on_temp_f: { min: 45, max: 85 },
+  heat_off_temp_f: { min: 46, max: 90 },
+  cool_off_temp_f: { min: 55, max: 95 },
+  cool_on_temp_f: { min: 56, max: 100 },
 };
 
 // Map API ERV speed to display speed
@@ -80,6 +94,7 @@ const App: React.FC = () => {
   const [isAmbient, setIsAmbient] = useState(false);
   const [wsConnected, setWsConnected] = useState(false);
   const [apiConnected, setApiConnected] = useState(false);
+  const [temperatureBands, setTemperatureBands] = useState<HVACTemperatureBands>(DEFAULT_TEMPERATURE_BANDS);
   const [manualOverride, setManualOverride] = useState<{
     erv: boolean;
     erv_speed: string | null;
@@ -171,6 +186,9 @@ const App: React.FC = () => {
           if (status.manual_override) {
             setManualOverride(status.manual_override);
           }
+          if (status.hvac?.temperature_bands) {
+            setTemperatureBands(status.hvac.temperature_bands);
+          }
           setState(prev => {
             // Only log events after initial load (avoid spurious "Arrived" on page load)
             if (!initialLoadRef.current) {
@@ -241,6 +259,9 @@ const App: React.FC = () => {
       // Update manual override state
       if (status.manual_override) {
         setManualOverride(status.manual_override);
+      }
+      if (status.hvac?.temperature_bands) {
+        setTemperatureBands(status.hvac.temperature_bands);
       }
       setState(prev => {
         // Only log real changes (compare against last known occupancy, not stale state)
@@ -330,6 +351,93 @@ const App: React.FC = () => {
       setControlLoading(null);
     }
   }, [addEvent]);
+
+  const handlePresenceToggle = useCallback(async () => {
+    const requestedState = state.occupancy === OccupancyState.PRESENT ? 'away' : 'present';
+    setControlLoading('presence');
+    try {
+      const result = await setPresence(requestedState);
+      if (!result.ok) {
+        console.error('Presence control failed:', result.error);
+      } else {
+        addEvent('state', `Manual: ${requestedState === 'present' ? "I'm here" : "I'm away"}`, state.co2);
+      }
+    } catch (e) {
+      console.error('Presence control error:', e);
+    } finally {
+      setControlLoading(null);
+    }
+  }, [addEvent, state.co2, state.occupancy]);
+
+  const clampTemperatureBand = useCallback((key: keyof HVACTemperatureBands, value: number) => {
+    const limit = TEMPERATURE_BAND_LIMITS[key];
+    return Math.max(limit.min, Math.min(limit.max, value));
+  }, []);
+
+  const updateTemperatureBand = useCallback((band: 'heat' | 'cool', action: 'shift' | 'spread', delta: number) => {
+    const previousBands = temperatureBands;
+    const nextBands: HVACTemperatureBands = { ...temperatureBands };
+    const lowerKey: keyof HVACTemperatureBands = band === 'heat' ? 'heat_on_temp_f' : 'cool_off_temp_f';
+    const upperKey: keyof HVACTemperatureBands = band === 'heat' ? 'heat_off_temp_f' : 'cool_on_temp_f';
+
+    if (action === 'shift') {
+      nextBands[lowerKey] += delta;
+      nextBands[upperKey] += delta;
+    } else {
+      nextBands[lowerKey] -= delta;
+      nextBands[upperKey] += delta;
+    }
+
+    nextBands[lowerKey] = clampTemperatureBand(lowerKey, nextBands[lowerKey]);
+    nextBands[upperKey] = clampTemperatureBand(upperKey, nextBands[upperKey]);
+
+    if (nextBands[upperKey] <= nextBands[lowerKey]) {
+      nextBands[upperKey] = clampTemperatureBand(upperKey, nextBands[lowerKey] + 1);
+      nextBands[lowerKey] = clampTemperatureBand(lowerKey, nextBands[upperKey] - 1);
+    }
+
+    setTemperatureBands(nextBands);
+    setControlLoading(`bands-${band}`);
+
+    setHVACTemperatureBands(nextBands).then((result) => {
+      if (!result.ok || !result.temperature_bands) {
+        console.error('HVAC temperature band update failed:', result.error);
+        setTemperatureBands(previousBands);
+      } else {
+        setTemperatureBands(result.temperature_bands);
+        addEvent(
+          'hvac',
+          `Bands: heat ${result.temperature_bands.heat_on_temp_f}-${result.temperature_bands.heat_off_temp_f}°F, cool ${result.temperature_bands.cool_off_temp_f}-${result.temperature_bands.cool_on_temp_f}°F`
+        );
+      }
+    }).catch((e) => {
+      console.error('HVAC temperature band update error:', e);
+      setTemperatureBands(previousBands);
+    }).finally(() => {
+      setControlLoading(null);
+    });
+  }, [addEvent, clampTemperatureBand, temperatureBands]);
+
+  const resetTemperatureBands = useCallback(() => {
+    const previousBands = temperatureBands;
+    setTemperatureBands(DEFAULT_TEMPERATURE_BANDS);
+    setControlLoading('bands-reset');
+
+    setHVACTemperatureBands(DEFAULT_TEMPERATURE_BANDS).then((result) => {
+      if (!result.ok || !result.temperature_bands) {
+        console.error('HVAC temperature band reset failed:', result.error);
+        setTemperatureBands(previousBands);
+      } else {
+        setTemperatureBands(result.temperature_bands);
+        addEvent('hvac', 'Bands reset to defaults');
+      }
+    }).catch((e) => {
+      console.error('HVAC temperature band reset error:', e);
+      setTemperatureBands(previousBands);
+    }).finally(() => {
+      setControlLoading(null);
+    });
+  }, [addEvent, temperatureBands]);
 
   const currentStatus = getPrimaryStatus();
 
@@ -518,21 +626,53 @@ const App: React.FC = () => {
       <section className="bg-zinc-900/30 border border-zinc-800/50 rounded-3xl p-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xs font-bold uppercase tracking-widest text-zinc-500">Quick Controls</h2>
-          {(manualOverride?.erv || manualOverride?.hvac) && (
-            <span className="text-[10px] font-bold uppercase text-amber-500 bg-amber-500/10 px-2 py-1 rounded animate-pulse">
-              Manual Override Active
-            </span>
-          )}
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          {/* Presence Correction */}
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-sm font-bold text-zinc-400">Detected presence:</span>
+              <span className={`text-[10px] font-bold uppercase px-2 py-1 rounded-full ${
+                state.occupancy === OccupancyState.PRESENT
+                  ? 'text-emerald-300 bg-emerald-500/10'
+                  : 'text-blue-300 bg-blue-500/10'
+              }`}>
+                {state.occupancy === OccupancyState.PRESENT ? 'Here' : 'Away'}
+              </span>
+            </div>
+            <button
+              onClick={handlePresenceToggle}
+              disabled={controlLoading !== null}
+              className={`flex-1 min-h-[38px] px-4 py-2 text-xs font-black uppercase rounded-lg transition-all
+                ${state.occupancy === OccupancyState.PRESENT
+                  ? 'bg-blue-500/15 text-blue-200 hover:bg-blue-500/25'
+                  : 'bg-emerald-500 text-black hover:bg-emerald-400'
+                }
+                ${controlLoading === 'presence' ? 'opacity-50 cursor-wait' : ''}
+                disabled:opacity-50 disabled:cursor-not-allowed
+              `}
+            >
+              {controlLoading === 'presence'
+                ? '...'
+                : state.occupancy === OccupancyState.PRESENT ? "I'm away" : "I'm here"}
+            </button>
+          </div>
+
           {/* ERV Controls */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-bold text-zinc-400 uppercase tracking-wide">🌀 Ventilation</span>
-              {manualOverride?.erv && manualOverride.erv_expires_in && (
-                <span className="text-[10px] text-zinc-500">
-                  Expires in {Math.round(manualOverride.erv_expires_in / 60)}m
+          <div className="rounded-2xl border border-zinc-800/70 bg-black/20 p-4 space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+              <div>
+                <div className="text-sm font-bold text-zinc-400 uppercase tracking-wide">🌀 Ventilation</div>
+                {manualOverride?.erv && manualOverride.erv_expires_in && (
+                  <div className="text-xs font-semibold text-zinc-500 mt-1">
+                    Manual ERV control expires in {Math.round(manualOverride.erv_expires_in / 60)}m
+                  </div>
+                )}
+              </div>
+              {manualOverride?.erv && (
+                <span className="self-start sm:self-auto text-[10px] font-bold uppercase text-amber-500 bg-amber-500/10 px-2 py-1 rounded animate-pulse">
+                  Manual Override Active
                 </span>
               )}
             </div>
@@ -558,12 +698,19 @@ const App: React.FC = () => {
           </div>
 
           {/* HVAC Controls */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-bold text-zinc-400 uppercase tracking-wide">🔥 HVAC</span>
-              {manualOverride?.hvac && manualOverride.hvac_expires_in && (
-                <span className="text-[10px] text-zinc-500">
-                  Expires in {Math.round(manualOverride.hvac_expires_in / 60)}m
+          <div className="rounded-2xl border border-zinc-800/70 bg-black/20 p-4 space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+              <div>
+                <div className="text-sm font-bold text-zinc-400 uppercase tracking-wide">🔥 HVAC</div>
+                {manualOverride?.hvac && manualOverride.hvac_expires_in && (
+                  <div className="text-xs font-semibold text-zinc-500 mt-1">
+                    Manual HVAC control expires in {Math.round(manualOverride.hvac_expires_in / 60)}m
+                  </div>
+                )}
+              </div>
+              {manualOverride?.hvac && (
+                <span className="self-start sm:self-auto text-[10px] font-bold uppercase text-amber-500 bg-amber-500/10 px-2 py-1 rounded animate-pulse">
+                  Manual Override Active
                 </span>
               )}
             </div>
@@ -612,6 +759,92 @@ const App: React.FC = () => {
               </button>
             </div>
           </div>
+
+          {/* HVAC Temperature Bands */}
+          <details className="border-t border-zinc-800/70 pt-4">
+            <summary className="cursor-pointer rounded-2xl border border-zinc-800/70 bg-black/20 p-4 text-sm font-black uppercase tracking-wider text-zinc-200 flex items-center justify-between gap-3">
+              <span>Hysteresis Bands</span>
+              <span className="text-xs font-bold normal-case tracking-normal text-zinc-500">
+                Heat {temperatureBands.heat_on_temp_f}-{temperatureBands.heat_off_temp_f}°F · Cool {temperatureBands.cool_off_temp_f}-{temperatureBands.cool_on_temp_f}°F
+              </span>
+            </summary>
+
+            <div className="pt-4 space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-black uppercase tracking-wider text-zinc-300">Temperature Bands</h3>
+                  <div className="text-xs font-semibold text-zinc-500 mt-1">
+                    Current Qingping temp {state.temperature || '---'}°F
+                  </div>
+                </div>
+                <button
+                  onClick={resetTemperatureBands}
+                  disabled={controlLoading !== null}
+                  className="px-3 py-2 text-xs font-bold uppercase rounded-lg bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Reset
+                </button>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3">
+                <div className="grid grid-cols-1 lg:grid-cols-[minmax(180px,1fr)_minmax(0,1.5fr)] gap-4 rounded-2xl border border-rose-400/20 bg-zinc-900/30 p-4">
+                  <div>
+                    <div className="text-sm font-black uppercase tracking-wider text-zinc-200">Heat</div>
+                    <div className="text-3xl font-black tracking-tighter text-zinc-100 mt-1">
+                      {temperatureBands.heat_on_temp_f}-{temperatureBands.heat_off_temp_f}°F
+                    </div>
+                    <div className="text-xs font-semibold text-zinc-500 mt-1">
+                      Resume at or below {temperatureBands.heat_on_temp_f}° · pause at or above {temperatureBands.heat_off_temp_f}°
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="rounded-xl border border-zinc-800/70 bg-black/20 p-3">
+                      <div className="text-[10px] font-black uppercase tracking-wider text-zinc-500 mb-2">Move Band</div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button onClick={() => updateTemperatureBand('heat', 'shift', -1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">-1°</button>
+                        <button onClick={() => updateTemperatureBand('heat', 'shift', 1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">+1°</button>
+                      </div>
+                    </div>
+                    <div className="rounded-xl border border-zinc-800/70 bg-black/20 p-3">
+                      <div className="text-[10px] font-black uppercase tracking-wider text-zinc-500 mb-2">Band Width</div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button onClick={() => updateTemperatureBand('heat', 'spread', -1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">Tighter</button>
+                        <button onClick={() => updateTemperatureBand('heat', 'spread', 1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">Wider</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 lg:grid-cols-[minmax(180px,1fr)_minmax(0,1.5fr)] gap-4 rounded-2xl border border-sky-400/20 bg-zinc-900/30 p-4">
+                  <div>
+                    <div className="text-sm font-black uppercase tracking-wider text-zinc-200">Cool</div>
+                    <div className="text-3xl font-black tracking-tighter text-zinc-100 mt-1">
+                      {temperatureBands.cool_off_temp_f}-{temperatureBands.cool_on_temp_f}°F
+                    </div>
+                    <div className="text-xs font-semibold text-zinc-500 mt-1">
+                      Stop at or below {temperatureBands.cool_off_temp_f}° · start above {temperatureBands.cool_on_temp_f}°
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="rounded-xl border border-zinc-800/70 bg-black/20 p-3">
+                      <div className="text-[10px] font-black uppercase tracking-wider text-zinc-500 mb-2">Move Band</div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button onClick={() => updateTemperatureBand('cool', 'shift', -1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">-1°</button>
+                        <button onClick={() => updateTemperatureBand('cool', 'shift', 1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">+1°</button>
+                      </div>
+                    </div>
+                    <div className="rounded-xl border border-zinc-800/70 bg-black/20 p-3">
+                      <div className="text-[10px] font-black uppercase tracking-wider text-zinc-500 mb-2">Band Width</div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button onClick={() => updateTemperatureBand('cool', 'spread', -1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">Tighter</button>
+                        <button onClick={() => updateTemperatureBand('cool', 'spread', 1)} disabled={controlLoading !== null} className="px-3 py-2 text-xs font-black uppercase rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 disabled:opacity-50">Wider</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </details>
         </div>
       </section>
 

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -93,6 +93,7 @@ export interface ApiStatus {
     temp_c: number | null;
     humidity: number | null;
     pm25: number | null;
+    pm10: number | null;
     tvoc: number | null;
     noise_db: number | null;
     last_update: string | null;
@@ -104,6 +105,7 @@ export interface ApiStatus {
   hvac: {
     mode: string;
     setpoint_c: number;
+    temperature_bands?: HVACTemperatureBands;
   };
   manual_override?: {
     erv: boolean;
@@ -114,6 +116,13 @@ export interface ApiStatus {
     hvac_setpoint_f: number | null;
     hvac_expires_in: number | null;
   };
+}
+
+export interface HVACTemperatureBands {
+  heat_on_temp_f: number;
+  heat_off_temp_f: number;
+  cool_off_temp_f: number;
+  cool_on_temp_f: number;
 }
 
 export interface ApiEvent {
@@ -220,6 +229,7 @@ export async function setERVSpeed(speed: ERVSpeed): Promise<{ ok: boolean; error
 }
 
 export type HVACMode = 'off' | 'heat' | 'cool';
+export type PresenceState = 'present' | 'away';
 
 /**
  * Set HVAC mode manually
@@ -236,6 +246,58 @@ export async function setHVACMode(mode: HVACMode, setpoint_f: number = 70): Prom
     method: 'POST',
     headers,
     body: JSON.stringify({ mode, setpoint_f }),
+  });
+
+  if (response.status === 401) {
+    clearAuthToken();
+    throw new Error('Authentication required');
+  }
+
+  return response.json();
+}
+
+/**
+ * Manually correct detected presence.
+ */
+export async function setPresence(state: PresenceState): Promise<{ ok: boolean; error?: string; state?: string; is_present?: boolean }> {
+  const token = getAuthToken();
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE}/presence`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ state }),
+  });
+
+  if (response.status === 401) {
+    clearAuthToken();
+    throw new Error('Authentication required');
+  }
+
+  return response.json();
+}
+
+/**
+ * Update HVAC temperature hysteresis bands.
+ */
+export async function setHVACTemperatureBands(
+  temperature_bands: HVACTemperatureBands
+): Promise<{ ok: boolean; error?: string; temperature_bands?: HVACTemperatureBands }> {
+  const token = getAuthToken();
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE}/hvac/temperature-bands`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ temperature_bands }),
   });
 
   if (response.status === 401) {

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -106,6 +106,7 @@ export interface ApiStatus {
     mode: string;
     setpoint_c: number;
     temperature_bands?: HVACTemperatureBands;
+    temperature_band_defaults?: HVACTemperatureBands;
   };
   manual_override?: {
     erv: boolean;
@@ -286,7 +287,12 @@ export async function setPresence(state: PresenceState): Promise<{ ok: boolean; 
  */
 export async function setHVACTemperatureBands(
   temperature_bands: HVACTemperatureBands
-): Promise<{ ok: boolean; error?: string; temperature_bands?: HVACTemperatureBands }> {
+): Promise<{
+  ok: boolean;
+  error?: string;
+  temperature_bands?: HVACTemperatureBands;
+  temperature_band_defaults?: HVACTemperatureBands;
+}> {
   const token = getAuthToken();
   const headers: HeadersInit = { 'Content-Type': 'application/json' };
 

--- a/frontend/mockData.ts
+++ b/frontend/mockData.ts
@@ -1,5 +1,5 @@
 
-import { OfficeState, DeviceStatus, OccupancyState, ActivityEvent, ClimateDataPoint } from './types';
+import { OfficeState, DeviceStatus, OccupancyState, ActivityEvent, ClimateDataPoint, ERVSpeed } from './types';
 
 export const generateMockHistory = (): ClimateDataPoint[] => {
   const history: ClimateDataPoint[] = [];
@@ -40,7 +40,11 @@ export const INITIAL_STATE: OfficeState = {
   window: DeviceStatus.CLOSED,
   hvacMode: DeviceStatus.COOL,
   hvacTarget: 70,
-  ventMode: DeviceStatus.OFF,
+  tvoc: 0,
+  noise: 0,
+  pm25: 0,
+  pm10: 0,
+  ventMode: ERVSpeed.OFF,
   occupancy: OccupancyState.PRESENT,
   lastUpdated: new Date(),
   isSystemError: false

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/database.py
+++ b/src/database.py
@@ -153,6 +153,13 @@ class Database:
                 CREATE INDEX IF NOT EXISTS idx_prs_created ON github_prs(created_at);
                 CREATE INDEX IF NOT EXISTS idx_prs_merged ON github_prs(merged_at);
 
+                -- Runtime app settings that override static config.yaml values.
+                CREATE TABLE IF NOT EXISTS app_settings (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                );
+
             """)
             logger.info(f"Database initialized at {self.db_path}")
 
@@ -170,6 +177,33 @@ class Database:
     def _parse_timestamp(value: str) -> datetime:
         """Parse timestamps read back from SQLite."""
         return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+
+    def get_setting(self, key: str) -> Optional[Any]:
+        """Read a JSON setting value by key."""
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT value FROM app_settings WHERE key = ?",
+                (key,),
+            ).fetchone()
+
+        if not row:
+            return None
+
+        return json.loads(row["value"])
+
+    def set_setting(self, key: str, value: Any) -> None:
+        """Persist a JSON setting value by key."""
+        with self._connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO app_settings (key, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                (key, json.dumps(value), self._format_timestamp(self._now())),
+            )
 
     @staticmethod
     def _accumulate_duration_by_date(

--- a/src/hvac_temperature_bands.py
+++ b/src/hvac_temperature_bands.py
@@ -1,0 +1,71 @@
+"""Helpers for editable HVAC temperature hysteresis bands."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TemperatureBandLimits:
+    min_temp_f: int
+    max_temp_f: int
+
+
+HVAC_TEMPERATURE_BAND_LIMITS = {
+    "heat_on_temp_f": TemperatureBandLimits(45, 85),
+    "heat_off_temp_f": TemperatureBandLimits(46, 90),
+    "cool_off_temp_f": TemperatureBandLimits(55, 95),
+    "cool_on_temp_f": TemperatureBandLimits(56, 100),
+}
+
+HVAC_TEMPERATURE_BAND_KEYS = tuple(HVAC_TEMPERATURE_BAND_LIMITS.keys())
+
+
+def get_default_temperature_bands(thresholds: Any) -> dict[str, int]:
+    """Return HVAC temperature bands from the loaded threshold config."""
+    return {
+        "heat_on_temp_f": int(thresholds.hvac_heat_on_temp_f),
+        "heat_off_temp_f": int(thresholds.hvac_heat_off_temp_f),
+        "cool_off_temp_f": int(thresholds.hvac_cool_off_temp_f),
+        "cool_on_temp_f": int(thresholds.hvac_cool_on_temp_f),
+    }
+
+
+def validate_temperature_bands(data: dict[str, Any]) -> dict[str, int]:
+    """Validate and normalize editable HVAC temperature bands."""
+    bands: dict[str, int] = {}
+    for key in HVAC_TEMPERATURE_BAND_KEYS:
+        if key not in data:
+            raise ValueError(f"Missing temperature band: {key}")
+
+        value = data[key]
+        if isinstance(value, bool):
+            raise ValueError(f"{key} must be a number")
+
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{key} must be a number") from exc
+
+        limits = HVAC_TEMPERATURE_BAND_LIMITS[key]
+        if normalized < limits.min_temp_f or normalized > limits.max_temp_f:
+            raise ValueError(
+                f"{key} must be between {limits.min_temp_f} and {limits.max_temp_f}"
+            )
+
+        bands[key] = normalized
+
+    if bands["heat_on_temp_f"] >= bands["heat_off_temp_f"]:
+        raise ValueError("heat_on_temp_f must be below heat_off_temp_f")
+
+    if bands["cool_off_temp_f"] >= bands["cool_on_temp_f"]:
+        raise ValueError("cool_off_temp_f must be below cool_on_temp_f")
+
+    return bands
+
+
+def apply_temperature_bands(thresholds: Any, bands: dict[str, int]) -> None:
+    """Apply validated HVAC temperature bands to the mutable threshold config."""
+    thresholds.hvac_heat_on_temp_f = bands["heat_on_temp_f"]
+    thresholds.hvac_heat_off_temp_f = bands["heat_off_temp_f"]
+    thresholds.hvac_cool_off_temp_f = bands["cool_off_temp_f"]
+    thresholds.hvac_cool_on_temp_f = bands["cool_on_temp_f"]

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -208,12 +208,22 @@ class Orchestrator:
 
         # Database for persistence and analysis
         self.db = Database()
+        self._default_hvac_temperature_bands = get_default_temperature_bands(config.thresholds)
         self._load_hvac_temperature_bands()
         self.erv.on_health_event(self._handle_erv_health_event)
 
     def _get_hvac_temperature_bands(self) -> dict[str, int]:
         """Return the active HVAC temperature hysteresis bands."""
-        return get_default_temperature_bands(self.config.thresholds)
+        return dict(get_default_temperature_bands(self.config.thresholds))
+
+    def _get_default_hvac_temperature_bands(self) -> dict[str, int]:
+        """Return the HVAC temperature bands loaded from config.yaml."""
+        defaults = getattr(
+            self,
+            "_default_hvac_temperature_bands",
+            get_default_temperature_bands(self.config.thresholds),
+        )
+        return dict(defaults)
 
     def _load_hvac_temperature_bands(self) -> None:
         """Load persisted HVAC temperature bands over config.yaml defaults."""
@@ -1441,6 +1451,7 @@ class Orchestrator:
         return web.json_response({
             "ok": True,
             "temperature_bands": self._get_hvac_temperature_bands(),
+            "temperature_band_defaults": self._get_default_hvac_temperature_bands(),
         })
 
     async def _handle_hvac_temperature_bands_post(self, request: web.Request) -> web.Response:
@@ -1464,6 +1475,7 @@ class Orchestrator:
             return web.json_response({
                 "ok": True,
                 "temperature_bands": self._get_hvac_temperature_bands(),
+                "temperature_band_defaults": self._get_default_hvac_temperature_bands(),
             })
         except ValueError as e:
             return web.json_response({"ok": False, "error": str(e)}, status=400)
@@ -2170,6 +2182,7 @@ class Orchestrator:
             "setpoint_c": self._hvac_setpoint_c,
             "suspended": self._hvac_suspended,
             "temperature_bands": self._get_hvac_temperature_bands(),
+            "temperature_band_defaults": self._get_default_hvac_temperature_bands(),
         }
 
         # Add manual override status

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -34,6 +34,11 @@ from .qingping_client import QingpingMQTTClient, QingpingReading
 from .erv_client import ERVClient, FanSpeed
 from .kumo_client import KumoClient, OperationMode as HVACMode
 from .hvac_hysteresis import get_hvac_band_action
+from .hvac_temperature_bands import (
+    apply_temperature_bands,
+    get_default_temperature_bands,
+    validate_temperature_bands,
+)
 from .database import Database
 from .oauth_service import OAuthService, UserSession
 
@@ -44,6 +49,7 @@ ARTIFACT_HASH_PATTERN = re.compile(r"^[0-9a-f]{8}$")
 ARTIFACT_MAX_SIZE_BYTES = 100 * 1024 * 1024
 DEFAULT_ARTIFACTS_ROOT = Path(__file__).parent.parent / "data" / "apps"
 DEFAULT_LEGACY_APK_PATH = Path(__file__).parent.parent / "data" / "app-debug.apk"
+HVAC_TEMPERATURE_BANDS_SETTING = "hvac_temperature_bands"
 
 PROJECT_LEVERAGE_METRICS = {
     "session-manager": [
@@ -202,7 +208,32 @@ class Orchestrator:
 
         # Database for persistence and analysis
         self.db = Database()
+        self._load_hvac_temperature_bands()
         self.erv.on_health_event(self._handle_erv_health_event)
+
+    def _get_hvac_temperature_bands(self) -> dict[str, int]:
+        """Return the active HVAC temperature hysteresis bands."""
+        return get_default_temperature_bands(self.config.thresholds)
+
+    def _load_hvac_temperature_bands(self) -> None:
+        """Load persisted HVAC temperature bands over config.yaml defaults."""
+        stored = self.db.get_setting(HVAC_TEMPERATURE_BANDS_SETTING)
+        if stored is None:
+            return
+
+        try:
+            bands = validate_temperature_bands(stored)
+        except ValueError as e:
+            logger.warning(f"Ignoring invalid stored HVAC temperature bands: {e}")
+            return
+
+        apply_temperature_bands(self.config.thresholds, bands)
+        logger.info(f"Loaded HVAC temperature bands from database: {bands}")
+
+    def _save_hvac_temperature_bands(self, bands: dict[str, int]) -> None:
+        """Persist and activate HVAC temperature bands."""
+        apply_temperature_bands(self.config.thresholds, bands)
+        self.db.set_setting(HVAC_TEMPERATURE_BANDS_SETTING, bands)
 
     def _schedule_task(self, task_factory: Callable[[], Awaitable[None]], *, context: str) -> None:
         """Schedule async work on the orchestrator loop, even from callback threads."""
@@ -1364,6 +1395,82 @@ class Orchestrator:
         """Handle GET /status for debugging."""
         return web.json_response(self._get_status_dict())
 
+    async def _handle_presence_post(self, request: web.Request) -> web.Response:
+        """Handle POST /presence for manual presence correction.
+
+        Body: {"state": "present|away"}
+        """
+        try:
+            data = await request.json()
+            requested_state = str(data.get("state", "")).lower()
+
+            if requested_state not in ("present", "away"):
+                return web.json_response(
+                    {"ok": False, "error": "state must be present or away"},
+                    status=400,
+                )
+
+            present = requested_state == "present"
+            logger.info(f"MANUAL: Presence correction to {requested_state.upper()}")
+            self.db.log_device_event(
+                "presence",
+                f"manual_{requested_state}",
+                "Dashboard",
+            )
+            await self.state_machine.set_manual_presence(present)
+
+            # Re-evaluate in case the state did not change but the signal did.
+            self._evaluate_erv_state()
+            await self._evaluate_hvac_state()
+            await self._broadcast_status()
+
+            status = self.state_machine.get_status()
+            return web.json_response(
+                {
+                    "ok": True,
+                    "state": status["state"],
+                    "is_present": status["is_present"],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error handling presence POST: {e}")
+            return web.json_response({"ok": False, "error": str(e)}, status=400)
+
+    async def _handle_hvac_temperature_bands_get(self, request: web.Request) -> web.Response:
+        """Handle GET /hvac/temperature-bands."""
+        return web.json_response({
+            "ok": True,
+            "temperature_bands": self._get_hvac_temperature_bands(),
+        })
+
+    async def _handle_hvac_temperature_bands_post(self, request: web.Request) -> web.Response:
+        """Handle POST /hvac/temperature-bands."""
+        try:
+            data = await request.json()
+            raw_bands = data.get("temperature_bands", data)
+            if not isinstance(raw_bands, dict):
+                return web.json_response(
+                    {"ok": False, "error": "temperature_bands must be an object"},
+                    status=400,
+                )
+
+            bands = validate_temperature_bands(raw_bands)
+            self._save_hvac_temperature_bands(bands)
+            logger.info(f"Updated HVAC temperature bands: {bands}")
+
+            await self._evaluate_hvac_state()
+            await self._broadcast_status()
+
+            return web.json_response({
+                "ok": True,
+                "temperature_bands": self._get_hvac_temperature_bands(),
+            })
+        except ValueError as e:
+            return web.json_response({"ok": False, "error": str(e)}, status=400)
+        except Exception as e:
+            logger.error(f"Error handling HVAC temperature bands POST: {e}")
+            return web.json_response({"ok": False, "error": str(e)}, status=400)
+
     async def _handle_erv_post(self, request: web.Request) -> web.Response:
         """Handle POST /erv for manual ERV control.
 
@@ -2062,6 +2169,7 @@ class Orchestrator:
             "mode": self._hvac_mode,
             "setpoint_c": self._hvac_setpoint_c,
             "suspended": self._hvac_suspended,
+            "temperature_bands": self._get_hvac_temperature_bands(),
         }
 
         # Add manual override status
@@ -2575,6 +2683,7 @@ class Orchestrator:
 
         # API routes
         self._app.router.add_post("/occupancy", self._handle_occupancy_post)
+        self._app.router.add_post("/presence", self._handle_presence_post)
         self._app.router.add_get("/status", self._handle_status_get)
         self._app.router.add_get("/history", self._handle_history_get)
         self._app.router.add_get("/apk", self._handle_apk_get)
@@ -2594,6 +2703,8 @@ class Orchestrator:
         self._app.router.add_get("/ws", self._handle_websocket)
         self._app.router.add_post("/erv", self._handle_erv_post)
         self._app.router.add_post("/hvac", self._handle_hvac_post)
+        self._app.router.add_get("/hvac/temperature-bands", self._handle_hvac_temperature_bands_get)
+        self._app.router.add_post("/hvac/temperature-bands", self._handle_hvac_temperature_bands_post)
         self._app.router.add_post("/qingping/interval", self._handle_qingping_interval_post)
         self._app.router.add_get("/localtunnel/password", self._handle_localtunnel_password)
 

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -88,6 +88,7 @@ class StateMachine:
         self._departure_verification_task: Optional[asyncio.Task] = None
         self._verifying_departure: bool = False
         self._door_open_away_task: Optional[asyncio.Task] = None  # Timer for door open mode AWAY transition
+        self._suppress_next_door_close_departure: bool = False
         self._last_activity_time: float = time.time()  # Track last Mac or motion activity for door open mode
 
     @property
@@ -365,7 +366,11 @@ class StateMachine:
         logger.debug(f"Door: {'open' if is_open else 'closed'}")
 
         # Door closing exits door open mode - return to normal door-event logic
-        if was_open is True and is_open is False:
+        if is_open is False and self._suppress_next_door_close_departure:
+            logger.info("Door closed after manual presence correction - skipping departure verification")
+            self._cancel_door_open_away_timer("door closed")
+            self._suppress_next_door_close_departure = False
+        elif was_open is True and is_open is False:
             logger.info("Door closed - exiting door open mode, starting departure verification")
             # Cancel door open mode timer if active
             self._cancel_door_open_away_timer("door closed")
@@ -384,9 +389,10 @@ class StateMachine:
     async def set_manual_presence(self, present: bool):
         """Manually correct presence from the app.
 
-        Setting PRESENT behaves like a fresh motion event. Setting AWAY resets stale
-        activity by treating the correction time as the latest door boundary, so old
-        Mac or motion timestamps do not immediately restore PRESENT.
+        Setting PRESENT behaves like a fresh inside-room activity signal and forces
+        the occupancy state immediately. Setting AWAY resets stale activity by
+        treating the correction time as the latest door boundary, so old Mac or
+        motion timestamps do not immediately restore PRESENT.
         """
         now = time.time()
         old_state = self.state
@@ -397,13 +403,21 @@ class StateMachine:
             self._last_activity_time = now
             if self._verifying_departure:
                 self._cancel_departure_verification("manual presence")
+            if self.sensors.door_open:
+                self._suppress_next_door_close_departure = True
             self.sensors.last_updated = now
-            await self.evaluate()
+            self.state = OccupancyState.PRESENT
+            self._last_door_state = self.sensors.door_open
+            if self.sensors.door_open:
+                self._start_door_open_away_timer()
+            if old_state != self.state:
+                await self._notify_state_change(old_state, self.state)
             return
 
         self._cancel_departure_verification("manual away")
         self._cancel_door_open_away_timer("manual away")
         self._verifying_departure = False
+        self._suppress_next_door_close_departure = False
         self.sensors.motion_detected = False
         self.sensors.motion_last_seen = 0
         self.sensors.door_last_changed = now
@@ -425,7 +439,8 @@ class StateMachine:
         """Get current status summary."""
         return {
             "state": self.state.value,
-            "is_present": self.is_present,
+            "is_present": self.state == OccupancyState.PRESENT,
+            "presence_signal_active": self.is_present,
             "safety_interlock": self.safety_interlock_active,
             "erv_should_run": self.erv_should_run,
             "verifying_departure": self._verifying_departure,

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -381,6 +381,39 @@ class StateMachine:
         logger.debug(f"Window: {'open' if is_open else 'closed'}")
         await self.evaluate()
 
+    async def set_manual_presence(self, present: bool):
+        """Manually correct presence from the app.
+
+        Setting PRESENT behaves like a fresh motion event. Setting AWAY resets stale
+        activity by treating the correction time as the latest door boundary, so old
+        Mac or motion timestamps do not immediately restore PRESENT.
+        """
+        now = time.time()
+        old_state = self.state
+
+        if present:
+            self.sensors.motion_detected = True
+            self.sensors.motion_last_seen = now
+            self._last_activity_time = now
+            if self._verifying_departure:
+                self._cancel_departure_verification("manual presence")
+            self.sensors.last_updated = now
+            await self.evaluate()
+            return
+
+        self._cancel_departure_verification("manual away")
+        self._cancel_door_open_away_timer("manual away")
+        self._verifying_departure = False
+        self.sensors.motion_detected = False
+        self.sensors.motion_last_seen = 0
+        self.sensors.door_last_changed = now
+        self.sensors.last_updated = now
+        self.state = OccupancyState.AWAY
+        self._last_door_state = self.sensors.door_open
+
+        if old_state != self.state:
+            await self._notify_state_change(old_state, self.state)
+
     def update_co2(self, ppm: int):
         """Update CO2 reading (sync - no state transitions needed)."""
         self.sensors.co2_ppm = ppm

--- a/tests/test_database_settings.py
+++ b/tests/test_database_settings.py
@@ -1,0 +1,18 @@
+"""Unit tests for runtime app settings persistence."""
+
+from src.database import Database
+
+
+def test_runtime_setting_round_trips_json(tmp_path):
+    db = Database(db_path=tmp_path / "office.db", telemetry_db_path=tmp_path / "telemetry.db")
+
+    value = {
+        "heat_on_temp_f": 70,
+        "heat_off_temp_f": 74,
+        "cool_off_temp_f": 77,
+        "cool_on_temp_f": 82,
+    }
+    db.set_setting("hvac_temperature_bands", value)
+
+    assert db.get_setting("hvac_temperature_bands") == value
+    assert db.get_setting("missing") is None

--- a/tests/test_hvac_temperature_bands.py
+++ b/tests/test_hvac_temperature_bands.py
@@ -1,0 +1,66 @@
+"""Unit tests for editable HVAC temperature bands."""
+
+import pytest
+
+from src.config import ThresholdsConfig
+from src.hvac_temperature_bands import (
+    apply_temperature_bands,
+    get_default_temperature_bands,
+    validate_temperature_bands,
+)
+
+
+def test_validate_temperature_bands_accepts_ordered_values():
+    bands = validate_temperature_bands(
+        {
+            "heat_on_temp_f": 70,
+            "heat_off_temp_f": 74,
+            "cool_off_temp_f": 77,
+            "cool_on_temp_f": 82,
+        }
+    )
+
+    assert bands == {
+        "heat_on_temp_f": 70,
+        "heat_off_temp_f": 74,
+        "cool_off_temp_f": 77,
+        "cool_on_temp_f": 82,
+    }
+
+
+def test_validate_temperature_bands_rejects_collapsed_heat_band():
+    with pytest.raises(ValueError, match="heat_on_temp_f must be below"):
+        validate_temperature_bands(
+            {
+                "heat_on_temp_f": 75,
+                "heat_off_temp_f": 75,
+                "cool_off_temp_f": 78,
+                "cool_on_temp_f": 81,
+            }
+        )
+
+
+def test_validate_temperature_bands_rejects_collapsed_cool_band():
+    with pytest.raises(ValueError, match="cool_off_temp_f must be below"):
+        validate_temperature_bands(
+            {
+                "heat_on_temp_f": 71,
+                "heat_off_temp_f": 75,
+                "cool_off_temp_f": 81,
+                "cool_on_temp_f": 81,
+            }
+        )
+
+
+def test_apply_temperature_bands_updates_threshold_config():
+    thresholds = ThresholdsConfig()
+    bands = {
+        "heat_on_temp_f": 69,
+        "heat_off_temp_f": 73,
+        "cool_off_temp_f": 76,
+        "cool_on_temp_f": 80,
+    }
+
+    apply_temperature_bands(thresholds, bands)
+
+    assert get_default_temperature_bands(thresholds) == bands

--- a/tests/test_hvac_temperature_bands.py
+++ b/tests/test_hvac_temperature_bands.py
@@ -64,3 +64,36 @@ def test_apply_temperature_bands_updates_threshold_config():
     apply_temperature_bands(thresholds, bands)
 
     assert get_default_temperature_bands(thresholds) == bands
+
+
+def test_temperature_band_default_snapshot_survives_active_band_changes():
+    thresholds = ThresholdsConfig(
+        hvac_heat_on_temp_f=68,
+        hvac_heat_off_temp_f=72,
+        hvac_cool_off_temp_f=79,
+        hvac_cool_on_temp_f=83,
+    )
+    defaults = get_default_temperature_bands(thresholds)
+
+    apply_temperature_bands(
+        thresholds,
+        {
+            "heat_on_temp_f": 70,
+            "heat_off_temp_f": 74,
+            "cool_off_temp_f": 77,
+            "cool_on_temp_f": 81,
+        },
+    )
+
+    assert defaults == {
+        "heat_on_temp_f": 68,
+        "heat_off_temp_f": 72,
+        "cool_off_temp_f": 79,
+        "cool_on_temp_f": 83,
+    }
+    assert get_default_temperature_bands(thresholds) == {
+        "heat_on_temp_f": 70,
+        "heat_off_temp_f": 74,
+        "cool_off_temp_f": 77,
+        "cool_on_temp_f": 81,
+    }

--- a/tests/test_manual_presence.py
+++ b/tests/test_manual_presence.py
@@ -17,6 +17,24 @@ def test_manual_present_behaves_like_motion_after_door_event():
     assert state_machine.sensors.motion_last_seen > state_machine.sensors.door_last_changed
 
 
+def test_manual_present_forces_presence_while_door_is_open():
+    state_machine = StateMachine(StateConfig())
+    state_machine.sensors.door_open = True
+    state_machine.sensors.door_last_changed = time.time()
+    state_machine._last_door_state = True
+
+    async def run_scenario():
+        await state_machine.set_manual_presence(True)
+        assert state_machine.state == OccupancyState.PRESENT
+        assert state_machine.get_status()["is_present"] is True
+
+        await state_machine.update_door(False)
+        assert state_machine.state == OccupancyState.PRESENT
+        assert state_machine._verifying_departure is False
+
+    asyncio.run(run_scenario())
+
+
 def test_manual_away_resets_stale_activity_boundary():
     state_machine = StateMachine(StateConfig())
     now = time.time()

--- a/tests/test_manual_presence.py
+++ b/tests/test_manual_presence.py
@@ -1,0 +1,36 @@
+"""Unit tests for manual presence correction."""
+
+import asyncio
+import time
+
+from src.state_machine import OccupancyState, StateConfig, StateMachine
+
+
+def test_manual_present_behaves_like_motion_after_door_event():
+    state_machine = StateMachine(StateConfig())
+    state_machine.sensors.door_last_changed = time.time()
+
+    asyncio.run(state_machine.set_manual_presence(True))
+
+    assert state_machine.state == OccupancyState.PRESENT
+    assert state_machine.sensors.motion_detected is True
+    assert state_machine.sensors.motion_last_seen > state_machine.sensors.door_last_changed
+
+
+def test_manual_away_resets_stale_activity_boundary():
+    state_machine = StateMachine(StateConfig())
+    now = time.time()
+    state_machine.state = OccupancyState.PRESENT
+    state_machine.sensors.external_monitor = True
+    state_machine.sensors.mac_last_active = now
+    state_machine.sensors.door_last_changed = now - 60
+    state_machine.sensors.motion_detected = True
+    state_machine.sensors.motion_last_seen = now
+
+    asyncio.run(state_machine.set_manual_presence(False))
+
+    assert state_machine.state == OccupancyState.AWAY
+    assert state_machine.sensors.motion_detected is False
+    assert state_machine.sensors.motion_last_seen == 0
+    assert state_machine.sensors.door_last_changed > now
+    assert state_machine.is_present is False


### PR DESCRIPTION
## Summary
- Add dashboard presence correction control backed by a new /presence API.
- Add editable HVAC hysteresis bands backed by persisted SQLite runtime settings.
- Replace the approved Quick Controls mockup with the production UI and keep ERV/HVAC manual override indicators scoped to those rows.

## Test Plan
- [x] python -m pytest tests/ -q
- [x] npx tsc --noEmit
- [x] npm --prefix frontend run build

## Notes
- The requested repo-relative .agent-os/workflows/pr_review_protocol.md file was not present; I used ~/.agent-os/workflows/pr_review_process.md for the Codex review loop.