### PR TITLE
Add Android presence and HVAC band controls

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
@@ -63,6 +63,16 @@ data class HvacStatus(
     val mode: String = "off",
     @SerialName("setpoint_c") val setpointC: Double = 0.0,
     val suspended: Boolean = false,
+    @SerialName("temperature_bands") val temperatureBands: TemperatureBands? = null,
+    @SerialName("temperature_band_defaults") val temperatureBandDefaults: TemperatureBands? = null,
+)
+
+@Serializable
+data class TemperatureBands(
+    @SerialName("heat_on_temp_f") val heatOnTempF: Int = 71,
+    @SerialName("heat_off_temp_f") val heatOffTempF: Int = 75,
+    @SerialName("cool_off_temp_f") val coolOffTempF: Int = 78,
+    @SerialName("cool_on_temp_f") val coolOnTempF: Int = 81,
 )
 
 @Serializable

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/ApiStatus.kt
@@ -76,6 +76,12 @@ data class TemperatureBands(
 )
 
 @Serializable
+data class TemperatureBandsResponse(
+    val ok: Boolean = false,
+    @SerialName("temperature_bands") val temperatureBands: TemperatureBands? = null,
+)
+
+@Serializable
 data class ManualOverride(
     val erv: Boolean = false,
     @SerialName("erv_speed") val ervSpeed: String? = null,

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -10,6 +10,7 @@ import com.rajesh.officeclimate.data.model.OrchestrationResponse
 import com.rajesh.officeclimate.data.model.ProjectLeverageResponse
 import com.rajesh.officeclimate.data.model.ProjectFocusResponse
 import com.rajesh.officeclimate.data.model.SessionsResponse
+import com.rajesh.officeclimate.data.model.TemperatureBandsResponse
 import com.rajesh.officeclimate.data.model.TemperatureResponse
 import kotlinx.serialization.json.JsonObject
 import retrofit2.http.Body
@@ -34,7 +35,7 @@ interface ApiService {
     suspend fun setPresence(@Body body: Map<String, String>): JsonObject
 
     @POST("hvac/temperature-bands")
-    suspend fun setTemperatureBands(@Body body: JsonObject): JsonObject
+    suspend fun setTemperatureBands(@Body body: JsonObject): TemperatureBandsResponse
 
     @GET("history/sessions")
     suspend fun getSessions(@Query("days") days: Int = 7): SessionsResponse

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -30,6 +30,12 @@ interface ApiService {
     @POST("hvac")
     suspend fun setHvacMode(@Body body: JsonObject): JsonObject
 
+    @POST("presence")
+    suspend fun setPresence(@Body body: Map<String, String>): JsonObject
+
+    @POST("hvac/temperature-bands")
+    suspend fun setTemperatureBands(@Body body: JsonObject): JsonObject
+
     @GET("history/sessions")
     suspend fun getSessions(@Query("days") days: Int = 7): SessionsResponse
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -10,6 +10,7 @@ import com.rajesh.officeclimate.data.model.OrchestrationResponse
 import com.rajesh.officeclimate.data.model.ProjectLeverageResponse
 import com.rajesh.officeclimate.data.model.ProjectFocusResponse
 import com.rajesh.officeclimate.data.model.SessionsResponse
+import com.rajesh.officeclimate.data.model.TemperatureBands
 import com.rajesh.officeclimate.data.model.TemperatureResponse
 import com.rajesh.officeclimate.data.remote.ApiService
 import com.rajesh.officeclimate.data.remote.AuthInterceptor
@@ -175,6 +176,22 @@ class ClimateRepository(
             if (setpointF != null) put("setpoint_f", setpointF)
         }
         apiService.setHvacMode(body)
+    }
+
+    suspend fun setPresence(state: String): Result<Unit> = runCatching {
+        apiService.setPresence(mapOf("state" to state))
+    }
+
+    suspend fun setTemperatureBands(bands: TemperatureBands): Result<Unit> = runCatching {
+        val body = buildJsonObject {
+            put("temperature_bands", buildJsonObject {
+                put("heat_on_temp_f", bands.heatOnTempF)
+                put("heat_off_temp_f", bands.heatOffTempF)
+                put("cool_off_temp_f", bands.coolOffTempF)
+                put("cool_on_temp_f", bands.coolOnTempF)
+            })
+        }
+        apiService.setTemperatureBands(body)
     }
 
     suspend fun getSessions(days: Int = 7): Result<SessionsResponse> = runCatching {

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -191,7 +191,13 @@ class ClimateRepository(
                 put("cool_on_temp_f", bands.coolOnTempF)
             })
         }
-        apiService.setTemperatureBands(body)
+        val response = apiService.setTemperatureBands(body)
+        val savedBands = response.temperatureBands ?: bands
+        _status.value = _status.value?.let { currentStatus ->
+            currentStatus.copy(
+                hvac = currentStatus.hvac.copy(temperatureBands = savedBands),
+            )
+        }
     }
 
     suspend fun getSessions(days: Int = 7): Result<SessionsResponse> = runCatching {

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
@@ -268,8 +268,11 @@ fun DashboardScreen(
             QuickControls(
                 status = currentStatus,
                 controlLoading = controlLoading,
+                onPresenceState = viewModel::setPresence,
                 onErvSpeed = viewModel::setErvSpeed,
                 onHvacMode = viewModel::setHvacMode,
+                onTemperatureBandAction = viewModel::updateTemperatureBand,
+                onTemperatureBandReset = viewModel::resetTemperatureBands,
             )
 
             Spacer(Modifier.height(16.dp))

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
@@ -68,6 +68,7 @@ fun DashboardScreen(
     val wsConnected by viewModel.wsConnected.collectAsState()
     val error by viewModel.error.collectAsState()
     val controlLoading by viewModel.controlLoading.collectAsState()
+    val bandUpdateInFlight by viewModel.bandUpdateInFlight.collectAsState()
     val controlError by viewModel.controlError.collectAsState()
     val authExpired by viewModel.authExpired.collectAsState()
     val updateBannerState by viewModel.updateBannerState.collectAsState()
@@ -268,6 +269,7 @@ fun DashboardScreen(
             QuickControls(
                 status = currentStatus,
                 controlLoading = controlLoading,
+                bandUpdateInFlight = bandUpdateInFlight,
                 onPresenceState = viewModel::setPresence,
                 onErvSpeed = viewModel::setErvSpeed,
                 onHvacMode = viewModel::setHvacMode,

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.rajesh.officeclimate.data.model.AppNotification
 import com.rajesh.officeclimate.data.model.ApiStatus
+import com.rajesh.officeclimate.data.model.TemperatureBands
 import com.rajesh.officeclimate.data.repository.AppUpdateRepository
 import com.rajesh.officeclimate.data.repository.AvailableAppUpdate
 import com.rajesh.officeclimate.data.repository.ClimateRepository
@@ -83,6 +84,45 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         }
     }
 
+    fun setPresence(state: String) {
+        _controlLoading.value = "presence"
+        viewModelScope.launch {
+            climateRepo.setPresence(state)
+                .onFailure { e ->
+                    Log.e("DashboardVM", "Presence control failed", e)
+                    _controlError.value = "Presence command failed: ${e.message}"
+                }
+            _controlLoading.value = null
+        }
+    }
+
+    fun updateTemperatureBand(band: String, action: String, delta: Int) {
+        val currentBands = status.value?.hvac?.temperatureBands ?: return
+        val nextBands = adjustTemperatureBands(currentBands, band, action, delta)
+        _controlLoading.value = "bands_$band"
+        viewModelScope.launch {
+            climateRepo.setTemperatureBands(nextBands)
+                .onFailure { e ->
+                    Log.e("DashboardVM", "Temperature band update failed", e)
+                    _controlError.value = "Band update failed: ${e.message}"
+                }
+            _controlLoading.value = null
+        }
+    }
+
+    fun resetTemperatureBands() {
+        val defaults = status.value?.hvac?.temperatureBandDefaults ?: return
+        _controlLoading.value = "bands_reset"
+        viewModelScope.launch {
+            climateRepo.setTemperatureBands(defaults)
+                .onFailure { e ->
+                    Log.e("DashboardVM", "Temperature band reset failed", e)
+                    _controlError.value = "Band reset failed: ${e.message}"
+                }
+            _controlLoading.value = null
+        }
+    }
+
     fun dismissUpdateBanner() {
         val update = _updateBannerState.value.update ?: return
         viewModelScope.launch {
@@ -155,5 +195,54 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     override fun onCleared() {
         super.onCleared()
         climateRepo.stop()
+    }
+
+    private fun adjustTemperatureBands(
+        bands: TemperatureBands,
+        band: String,
+        action: String,
+        delta: Int,
+    ): TemperatureBands {
+        var heatOn = bands.heatOnTempF
+        var heatOff = bands.heatOffTempF
+        var coolOff = bands.coolOffTempF
+        var coolOn = bands.coolOnTempF
+
+        if (band == "heat") {
+            if (action == "shift") {
+                heatOn += delta
+                heatOff += delta
+            } else {
+                heatOn -= delta
+                heatOff += delta
+            }
+            heatOn = heatOn.coerceIn(45, 85)
+            heatOff = heatOff.coerceIn(46, 90)
+            if (heatOff <= heatOn) {
+                heatOff = (heatOn + 1).coerceIn(46, 90)
+                heatOn = (heatOff - 1).coerceIn(45, 85)
+            }
+        } else {
+            if (action == "shift") {
+                coolOff += delta
+                coolOn += delta
+            } else {
+                coolOff -= delta
+                coolOn += delta
+            }
+            coolOff = coolOff.coerceIn(55, 95)
+            coolOn = coolOn.coerceIn(56, 100)
+            if (coolOn <= coolOff) {
+                coolOn = (coolOff + 1).coerceIn(56, 100)
+                coolOff = (coolOn - 1).coerceIn(55, 95)
+            }
+        }
+
+        return TemperatureBands(
+            heatOnTempF = heatOn,
+            heatOffTempF = heatOff,
+            coolOffTempF = coolOff,
+            coolOnTempF = coolOn,
+        )
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -97,6 +97,8 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     fun updateTemperatureBand(band: String, action: String, delta: Int) {
+        if (_controlLoading.value?.startsWith("bands_") == true) return
+
         val currentBands = status.value?.hvac?.temperatureBands ?: return
         val nextBands = adjustTemperatureBands(currentBands, band, action, delta)
         _controlLoading.value = "bands_$band"
@@ -111,6 +113,8 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     fun resetTemperatureBands() {
+        if (_controlLoading.value?.startsWith("bands_") == true) return
+
         val defaults = status.value?.hvac?.temperatureBandDefaults ?: return
         _controlLoading.value = "bands_reset"
         viewModelScope.launch {

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -41,6 +41,9 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     private val _controlLoading = MutableStateFlow<String?>(null)
     val controlLoading: StateFlow<String?> = _controlLoading
 
+    private val _bandUpdateInFlight = MutableStateFlow(false)
+    val bandUpdateInFlight: StateFlow<Boolean> = _bandUpdateInFlight
+
     private val _controlError = MutableStateFlow<String?>(null)
     val controlError: StateFlow<String?> = _controlError
 
@@ -97,33 +100,33 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     }
 
     fun updateTemperatureBand(band: String, action: String, delta: Int) {
-        if (_controlLoading.value?.startsWith("bands_") == true) return
+        if (_bandUpdateInFlight.value) return
 
         val currentBands = status.value?.hvac?.temperatureBands ?: return
         val nextBands = adjustTemperatureBands(currentBands, band, action, delta)
-        _controlLoading.value = "bands_$band"
+        _bandUpdateInFlight.value = true
         viewModelScope.launch {
             climateRepo.setTemperatureBands(nextBands)
                 .onFailure { e ->
                     Log.e("DashboardVM", "Temperature band update failed", e)
                     _controlError.value = "Band update failed: ${e.message}"
                 }
-            _controlLoading.value = null
+            _bandUpdateInFlight.value = false
         }
     }
 
     fun resetTemperatureBands() {
-        if (_controlLoading.value?.startsWith("bands_") == true) return
+        if (_bandUpdateInFlight.value) return
 
         val defaults = status.value?.hvac?.temperatureBandDefaults ?: return
-        _controlLoading.value = "bands_reset"
+        _bandUpdateInFlight.value = true
         viewModelScope.launch {
             climateRepo.setTemperatureBands(defaults)
                 .onFailure { e ->
                     Log.e("DashboardVM", "Temperature band reset failed", e)
                     _controlError.value = "Band reset failed: ${e.message}"
                 }
-            _controlLoading.value = null
+            _bandUpdateInFlight.value = false
         }
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
@@ -48,6 +48,7 @@ fun QuickControls(
     val shape = RoundedCornerShape(12.dp)
     val override = status.manualOverride
     val isPresent = status.state.lowercase() == "present" || status.isPresent
+    val bandLoading = controlLoading?.startsWith("bands_") == true
     var bandsExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(
@@ -206,7 +207,7 @@ fun QuickControls(
                             label = "Heat",
                             rangeLabel = "${bands.heatOnTempF}-${bands.heatOffTempF}°F",
                             helper = "Resume at ${bands.heatOnTempF}° · pause at ${bands.heatOffTempF}°",
-                            loading = controlLoading == "bands_heat",
+                            loading = bandLoading,
                             onMoveDown = { onTemperatureBandAction("heat", "shift", -1) },
                             onMoveUp = { onTemperatureBandAction("heat", "shift", 1) },
                             onTighter = { onTemperatureBandAction("heat", "spread", -1) },
@@ -216,7 +217,7 @@ fun QuickControls(
                             label = "Cool",
                             rangeLabel = "${bands.coolOffTempF}-${bands.coolOnTempF}°F",
                             helper = "Stop at ${bands.coolOffTempF}° · start at ${bands.coolOnTempF}°",
-                            loading = controlLoading == "bands_cool",
+                            loading = bandLoading,
                             onMoveDown = { onTemperatureBandAction("cool", "shift", -1) },
                             onMoveUp = { onTemperatureBandAction("cool", "shift", 1) },
                             onTighter = { onTemperatureBandAction("cool", "spread", -1) },
@@ -225,7 +226,7 @@ fun QuickControls(
                         ControlButton(
                             label = "RESET",
                             isActive = false,
-                            isLoading = controlLoading == "bands_reset",
+                            isLoading = bandLoading,
                             enabled = status.hvac.temperatureBandDefaults != null,
                             onClick = onTemperatureBandReset,
                             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
@@ -5,24 +5,27 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.rajesh.officeclimate.data.model.ApiStatus
-import com.rajesh.officeclimate.data.model.ManualOverride
 import com.rajesh.officeclimate.ui.theme.*
-import kotlin.math.roundToInt
 
 private fun ervDisplayLabel(speed: String?): String = when (speed) {
     "quiet" -> "QUIET"
@@ -35,12 +38,17 @@ private fun ervDisplayLabel(speed: String?): String = when (speed) {
 fun QuickControls(
     status: ApiStatus,
     controlLoading: String?,
+    onPresenceState: (String) -> Unit,
     onErvSpeed: (String) -> Unit,
     onHvacMode: (String, Int?) -> Unit,
+    onTemperatureBandAction: (String, String, Int) -> Unit,
+    onTemperatureBandReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(12.dp)
     val override = status.manualOverride
+    val isPresent = status.state.lowercase() == "present" || status.isPresent
+    var bandsExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -51,6 +59,31 @@ fun QuickControls(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        // Presence Controls
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Presence", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    if (isPresent) "Here" else "Away",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isPresent) Emerald else TextSecondary,
+                )
+            }
+
+            ControlButton(
+                label = if (isPresent) "I'M AWAY" else "I'M HERE",
+                isActive = false,
+                isLoading = controlLoading == "presence",
+                onClick = { onPresenceState(if (isPresent) "away" else "present") },
+                modifier = Modifier.weight(0.48f),
+            )
+        }
+
         // ERV Controls
         Column {
             Row(
@@ -137,6 +170,140 @@ fun QuickControls(
                 )
             }
         }
+
+        status.hvac.temperatureBands?.let { bands ->
+            Column {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column {
+                        Text(
+                            "Hysteresis Bands",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = TextPrimary,
+                        )
+                        Text(
+                            "Heat ${bands.heatOnTempF}-${bands.heatOffTempF}°F · Cool ${bands.coolOffTempF}-${bands.coolOnTempF}°F",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TextSecondary,
+                        )
+                    }
+                    TextButton(onClick = { bandsExpanded = !bandsExpanded }) {
+                        Text(if (bandsExpanded) "Hide" else "Edit")
+                    }
+                }
+
+                if (bandsExpanded) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        TemperatureBandRow(
+                            label = "Heat",
+                            rangeLabel = "${bands.heatOnTempF}-${bands.heatOffTempF}°F",
+                            helper = "Resume at ${bands.heatOnTempF}° · pause at ${bands.heatOffTempF}°",
+                            loading = controlLoading == "bands_heat",
+                            onMoveDown = { onTemperatureBandAction("heat", "shift", -1) },
+                            onMoveUp = { onTemperatureBandAction("heat", "shift", 1) },
+                            onTighter = { onTemperatureBandAction("heat", "spread", -1) },
+                            onWider = { onTemperatureBandAction("heat", "spread", 1) },
+                        )
+                        TemperatureBandRow(
+                            label = "Cool",
+                            rangeLabel = "${bands.coolOffTempF}-${bands.coolOnTempF}°F",
+                            helper = "Stop at ${bands.coolOffTempF}° · start at ${bands.coolOnTempF}°",
+                            loading = controlLoading == "bands_cool",
+                            onMoveDown = { onTemperatureBandAction("cool", "shift", -1) },
+                            onMoveUp = { onTemperatureBandAction("cool", "shift", 1) },
+                            onTighter = { onTemperatureBandAction("cool", "spread", -1) },
+                            onWider = { onTemperatureBandAction("cool", "spread", 1) },
+                        )
+                        ControlButton(
+                            label = "RESET",
+                            isActive = false,
+                            isLoading = controlLoading == "bands_reset",
+                            enabled = status.hvac.temperatureBandDefaults != null,
+                            onClick = onTemperatureBandReset,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TemperatureBandRow(
+    label: String,
+    rangeLabel: String,
+    helper: String,
+    loading: Boolean,
+    onMoveDown: () -> Unit,
+    onMoveUp: () -> Unit,
+    onTighter: () -> Unit,
+    onWider: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color.Black.copy(alpha = 0.12f))
+            .border(1.dp, Border, RoundedCornerShape(10.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, style = MaterialTheme.typography.labelLarge, color = TextPrimary)
+            Text(rangeLabel, style = MaterialTheme.typography.titleMedium, color = TextPrimary)
+        }
+        Text(helper, style = MaterialTheme.typography.labelSmall, color = TextSecondary)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            ControlButton(
+                label = "-1°",
+                isActive = false,
+                isLoading = loading,
+                onClick = onMoveDown,
+                modifier = Modifier.weight(1f),
+            )
+            ControlButton(
+                label = "+1°",
+                isActive = false,
+                isLoading = loading,
+                onClick = onMoveUp,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            ControlButton(
+                label = "TIGHTER",
+                isActive = false,
+                isLoading = loading,
+                onClick = onTighter,
+                modifier = Modifier.weight(1f),
+            )
+            ControlButton(
+                label = "WIDER",
+                isActive = false,
+                isLoading = loading,
+                onClick = onWider,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 
@@ -146,6 +313,7 @@ private fun ControlButton(
     isActive: Boolean,
     isLoading: Boolean = false,
     isOverride: Boolean = false,
+    enabled: Boolean = true,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -167,7 +335,7 @@ private fun ControlButton(
 
     Button(
         onClick = onClick,
-        enabled = !isLoading,
+        enabled = enabled && !isLoading,
         modifier = modifier.height(40.dp),
         shape = RoundedCornerShape(8.dp),
         colors = ButtonDefaults.buttonColors(

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
@@ -38,6 +38,7 @@ private fun ervDisplayLabel(speed: String?): String = when (speed) {
 fun QuickControls(
     status: ApiStatus,
     controlLoading: String?,
+    bandUpdateInFlight: Boolean,
     onPresenceState: (String) -> Unit,
     onErvSpeed: (String) -> Unit,
     onHvacMode: (String, Int?) -> Unit,
@@ -48,7 +49,6 @@ fun QuickControls(
     val shape = RoundedCornerShape(12.dp)
     val override = status.manualOverride
     val isPresent = status.state.lowercase() == "present" || status.isPresent
-    val bandLoading = controlLoading?.startsWith("bands_") == true
     var bandsExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(
@@ -207,7 +207,7 @@ fun QuickControls(
                             label = "Heat",
                             rangeLabel = "${bands.heatOnTempF}-${bands.heatOffTempF}°F",
                             helper = "Resume at ${bands.heatOnTempF}° · pause at ${bands.heatOffTempF}°",
-                            loading = bandLoading,
+                            loading = bandUpdateInFlight,
                             onMoveDown = { onTemperatureBandAction("heat", "shift", -1) },
                             onMoveUp = { onTemperatureBandAction("heat", "shift", 1) },
                             onTighter = { onTemperatureBandAction("heat", "spread", -1) },
@@ -217,7 +217,7 @@ fun QuickControls(
                             label = "Cool",
                             rangeLabel = "${bands.coolOffTempF}-${bands.coolOnTempF}°F",
                             helper = "Stop at ${bands.coolOffTempF}° · start at ${bands.coolOnTempF}°",
-                            loading = bandLoading,
+                            loading = bandUpdateInFlight,
                             onMoveDown = { onTemperatureBandAction("cool", "shift", -1) },
                             onMoveUp = { onTemperatureBandAction("cool", "shift", 1) },
                             onTighter = { onTemperatureBandAction("cool", "spread", -1) },
@@ -226,7 +226,7 @@ fun QuickControls(
                         ControlButton(
                             label = "RESET",
                             isActive = false,
-                            isLoading = bandLoading,
+                            isLoading = bandUpdateInFlight,
                             enabled = status.hvac.temperatureBandDefaults != null,
                             onClick = onTemperatureBandReset,
                             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
- add native Android Quick Controls row to toggle presence between I'm here / I'm away
- wire Android to the new /presence and /hvac/temperature-bands endpoints
- add collapsed native hysteresis band controls for heat/cool move and width adjustments

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:assembleDebug
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:testDebugUnitTest