### PR TITLE
Move Android presence edit below band controls

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
@@ -59,62 +59,6 @@ fun QuickControls(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        // Presence Controls
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column {
-                    Text("Presence", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
-                    Text(
-                        if (isPresent) "Detected Here" else "Detected Away",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (isPresent) Emerald else TextSecondary,
-                    )
-                }
-                TextButton(onClick = { presenceExpanded = !presenceExpanded }) {
-                    Text(if (presenceExpanded) "Hide" else "Edit")
-                }
-            }
-
-            if (presenceExpanded) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(Color.Black.copy(alpha = 0.12f))
-                        .border(1.dp, Border, RoundedCornerShape(10.dp))
-                        .padding(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text("Detected presence", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
-                        Text(
-                            if (isPresent) "Here" else "Away",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = if (isPresent) Emerald else TextSecondary,
-                        )
-                    }
-                    ControlButton(
-                        label = if (isPresent) "I'M AWAY" else "I'M HERE",
-                        isActive = false,
-                        isLoading = controlLoading == "presence",
-                        onClick = { onPresenceState(if (isPresent) "away" else "present") },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp),
-                    )
-                }
-            }
-        }
-
         // ERV Controls
         Column {
             Row(
@@ -263,6 +207,78 @@ fun QuickControls(
                         )
                     }
                 }
+            }
+        }
+
+        PresenceControls(
+            isPresent = isPresent,
+            expanded = presenceExpanded,
+            controlLoading = controlLoading,
+            onExpandedChange = { presenceExpanded = it },
+            onPresenceState = onPresenceState,
+        )
+    }
+}
+
+@Composable
+private fun PresenceControls(
+    isPresent: Boolean,
+    expanded: Boolean,
+    controlLoading: String?,
+    onExpandedChange: (Boolean) -> Unit,
+    onPresenceState: (String) -> Unit,
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text("Presence", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
+                Text(
+                    if (isPresent) "Detected Here" else "Detected Away",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isPresent) Emerald else TextSecondary,
+                )
+            }
+            TextButton(onClick = { onExpandedChange(!expanded) }) {
+                Text(if (expanded) "Hide" else "Edit")
+            }
+        }
+
+        if (expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color.Black.copy(alpha = 0.12f))
+                    .border(1.dp, Border, RoundedCornerShape(10.dp))
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Detected presence", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
+                    Text(
+                        if (isPresent) "Here" else "Away",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = if (isPresent) Emerald else TextSecondary,
+                    )
+                }
+                ControlButton(
+                    label = if (isPresent) "I'M AWAY" else "I'M HERE",
+                    isActive = false,
+                    isLoading = controlLoading == "presence",
+                    onClick = { onPresenceState(if (isPresent) "away" else "present") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- reorder Android Quick Controls to ERV, HVAC, Hysteresis Bands, Presence
- keep the presence Edit/Hide panel and button spacing unchanged
- extract the presence block into a small composable while preserving command wiring

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew --stop
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew clean :app:assembleDebug :app:testDebugUnitTest