### PR TITLE
Add AWAY settle window to suppress false ERV activations

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -99,6 +99,7 @@ class ThresholdsConfig:
     co2_rate_quiet_threshold: float = 0.5    # 0.5-2 ppm/min → QUIET (1/1)
                                               # < 0.5 ppm/min for 10 min → OFF (plateau)
     co2_turbo_duration_minutes: int = 30     # Force TURBO for first N minutes after departure
+    min_away_seconds_before_erv: int = 60    # Hold ERV off after AWAY transition for N seconds; rides out brief door-open false positives
 
     # tVOC AWAY mode ventilation (similar to CO2 adaptive control)
     # NOTE: tVOC is IGNORED when PRESENT - only triggers ventilation when AWAY

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -829,6 +829,17 @@ class Orchestrator:
                     logger.error("ERV OFF failed (present air quality OK)")
 
         elif state == OccupancyState.AWAY:
+            # Settle window: roughly 1 in 3 historical AWAY transitions were
+            # false positives (door cycled, user still here) and got reversed
+            # within seconds. Hold ERV at its prior state for the first N
+            # seconds of AWAY so we don't fire TURBO on those.
+            settle_seconds = self.config.thresholds.min_away_seconds_before_erv
+            if settle_seconds > 0 and self._away_start_time is not None:
+                elapsed = (datetime.now() - self._away_start_time).total_seconds()
+                if elapsed < settle_seconds:
+                    self._schedule_task(self._evaluate_hvac_state, context="erv_hvac_coordination")
+                    return
+
             # AWAY mode: aggressive ventilation with adaptive speed control
             # Both CO2 > 500 and tVOC > 200 trigger ventilation
             # Periodic stale-air flush also runs while continuously closed.
@@ -1336,6 +1347,9 @@ class Orchestrator:
                 interval = timedelta(hours=max(1, self.config.thresholds.away_stale_flush_interval_hours))
                 first_due = self._room_closed_since + interval
                 self._away_stale_flush_next_due_at = now if now >= first_due else first_due
+            settle_seconds = self.config.thresholds.min_away_seconds_before_erv
+            if settle_seconds > 0:
+                logger.info(f"AWAY settle window: holding ERV for {settle_seconds}s before ventilating")
             logger.info(f"TURBO mode for {self.config.thresholds.co2_turbo_duration_minutes} min, then adaptive")
 
         # Clear AWAY mode state on arrival


### PR DESCRIPTION
## Summary

Analysis of 4 months of occupancy data (Jan 5 → May 15, 2026; 422 AWAY-triggered ERV activations) shows the ERV is firing on a lot of false-positive AWAY transitions:

| ERV runtime before shutting back off | Count | % |
|---|---|---|
| < 30 sec | 62 | 14.7% |
| < 1 min | 104 | 24.7% |
| < 3 min | 146 | 34.6% |
| < 5 min | 173 | 41.0% |

Of the <3 min cohort, 84 ended via `state_present` (user came back via keyboard/motion within seconds) and 58 ended via `safety_interlock` (door reopened immediately). The classic pattern: someone briefly opens the door, I'm still at my desk, they close it, state flips to AWAY, ERV TURBO fires, I move my mouse 20s later, state flips back, ERV stops.

Root cause: `state_machine.departure_verification_seconds = 10` — only 10s of post-door-close verification before committing to AWAY. ERV then fires immediately on the AWAY transition.

## Approach

Rather than slow the state machine itself (which would lag HVAC and other AWAY consumers), gate just the ERV: hold it at its prior state for the first N seconds of AWAY. State machine flips to AWAY immediately as before; the next sensor event (Qingping reports every 30s) re-evaluates after the gate clears.

- New threshold: `min_away_seconds_before_erv: int = 60` in `ThresholdsConfig`
- Early-return in the AWAY branch of `_evaluate_erv_state` while inside the settle window
- Log line on AWAY entry so the gate is visible in operator logs
- Safety interlock and manual override still run before the gate, so emergency-off and manual control are unaffected
- HVAC coordination still scheduled during the gate so HVAC state stays consistent

Expected impact at 60s: eliminates the ~25% of activations that ended within 60s (104 of 422 historically). Real departures see ERV start 60–90s later — negligible vs. the 30-min TURBO phase.

## Test plan
- [ ] Service starts cleanly on bakasura4 after deploy
- [ ] Trigger AWAY via door cycle while staying at desk → ERV stays off; AWAY→PRESENT within 60s leaves ERV at prior state
- [ ] Real departure (door close + walk away for >60s) → ERV fires TURBO after ~60-90s (next CO2 reading)
- [ ] Safety interlock still trumps gate (door opens during AWAY → ERV off immediately)
- [ ] Manual override still trumps gate
- [ ] Log shows `AWAY settle window: holding ERV for 60s before ventilating` on AWAY entry