### PR TITLE
Fix ERV plateau thrash with dwell guard

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,8 @@ mitsubishi:
 thresholds:
   co2_critical_ppm: 2000      # ERV on even when present
   co2_refresh_target_ppm: 500  # Target for away-mode ventilation
+  co2_plateau_release_delta_ppm: 100 # Resume ventilation if CO2 climbs this far above learned outdoor baseline
+  erv_min_dwell_seconds: 180   # Minimum time between automated ERV speed changes within stable presence state
   hvac_heat_off_temp_f: 75     # Turn heat off at/above this Qingping temp
   hvac_heat_on_temp_f: 71      # Turn heat back on at/below this temp (hysteresis)
   hvac_cool_on_temp_f: 81      # Start cooling above this Qingping temp

--- a/docs/tuya-local-key.md
+++ b/docs/tuya-local-key.md
@@ -11,7 +11,8 @@ Always start with Path A. Drop to Path B only if the diagnostic in step 4 says s
 
 - Local control fails with Err 914 (“Check device key or version”).
 - Dashboard or automations can’t turn on the ERV but the Smart Life app still works locally.
-- The device firmware was updated (most common trigger for key rotation).
+- The device firmware was updated.
+- Orchestrator (or another local Tuya client) issued a rapid burst of commands that the device interpreted as adversarial. This is what happened on 2026-05-21 and is fixed by issue #59.
 
 ## ERV Hardware (Site-Specific)
 
@@ -223,13 +224,14 @@ Tuya cloud projects need devices linked via the IoT Platform asset model. Don't 
 
 ## Prevention
 
-The 914 error is almost always triggered by an ERV firmware OTA. To minimize occurrences:
+Known Err 914 triggers for this ERV:
 
-- **Disable auto firmware updates on the ERV** in Smart Life device settings if the toggle exists (look for "Check for firmware updates" or similar).
+- **Firmware OTA** — disabling auto firmware updates in Smart Life is still useful if the toggle exists (look for "Check for firmware updates" or similar), though we have not confirmed that Smart Life reliably honors it.
+- **Command burst from a misbehaving local client** — the orchestrator-side cause from 2026-05-21 was fixed in issue #59 with CO2 plateau latching and a minimum ERV dwell timer.
 - **Alert on 914** in the orchestrator logs so you catch the rotation immediately, not days/weeks later when CO2 is high and the dashboard is silent.
 
 ## Notes
 
-- Local keys can change after re-pair, factory reset, or firmware OTA.
+- Local keys can change after re-pair, factory reset, firmware OTA, or after the device interprets local Tuya traffic as adversarial (see issue #59 for one observed example).
 - Keep local keys private (don’t commit them to Git). `docs/tuya-local-key-private.md` is gitignored for this.
 - Site-specific values (device ID, server IP, repo path on server, last-known UID) live in `docs/tuya-local-key-private.md`. The UID can shift between installs (saw `u0_a166` and `u0_a167` on consecutive installs in the same session).

--- a/docs/working/erv-thrash-fix.md
+++ b/docs/working/erv-thrash-fix.md
@@ -1,0 +1,193 @@
+# Fix orchestrator thrashing ERV → triggers device local-key drift
+
+## Summary
+
+The orchestrator's AWAY-mode adaptive speed logic toggles the ERV between QUIET and OFF every 15–60 seconds when CO2 hovers near the plateau threshold. Each toggle issues 2–4 local Tuya commands. Sustained over ~5 minutes, this command burst is followed by the ERV beginning to reject the previously valid local key, breaking subsequent local control with Err 914. (Background section discusses the inferred device-side mechanism.)
+
+Today's incident: ~10 toggles between 07:51 and 07:59 → first 914 at 08:03:24 → orchestrator notification fired at the 5th consecutive failure threshold.
+
+## Background — what's known
+
+- The local key drift is **not** caused by Tuya firmware OTA. Confirmed via:
+  - User has Smart Life "auto update" disabled for this device.
+  - Smart Life MMKV cache and Tuya cloud HA-sharing API both hold the **same** localKey as the orchestrator (redacted); the device rejects all three. So the rotation is device-side, not cloud-side.
+  - Smart Life's `localConnectLastUpdateTime` for this device is from Dec 2025 (~5 months ago). Smart Life has been entirely cloud-relayed for fan control since then. During those 5 months, drift has continued — and the orchestrator was the only thing doing local Tuya protocol against the device.
+- The MMKV dump confirms `wifi.verSw=2.7.7`, `mcu.verSw=1.0.0` — no in-flight OTA at the time of today's failure.
+- The 4-minute gap between last successful local op (07:59:17) and first 914 (08:03:24) is inconsistent with OTA (which would involve a reboot and version bump).
+
+The most defensible explanation: the ERV's local Tuya stack began rejecting the previously valid local key after the command burst. The exact device-side mechanism (defensive rotation, session-state corruption, watchdog reset, etc.) is inferred, not directly observed.
+
+## Root cause — three bugs that compound
+
+All in `src/orchestrator.py`.
+
+### Bug 1: `_plateau_detected` is set but never consulted (lines 538–574, 586–588)
+
+`_detect_co2_plateau()` re-evaluates from scratch each tick. It returns `True` only when the current 10-min rolling rate is `< 0.5 ppm/min`. The `self._plateau_detected = True` assignment on line 588 has no effect on subsequent ticks — the function never reads it. Today it is consulted only for log-string formatting (line 887) and cleared on PRESENT (lines 1365-1368).
+
+Result: plateau "detection" is purely instantaneous, not latching.
+
+### Bug 2: Adaptive logic returns "quiet" when plateau-not-declared but rate-very-low (line 618)
+
+`_get_adaptive_erv_speed_for_away()` returns `"quiet"` whenever rate < 0.5 but `_detect_co2_plateau()` returned False (e.g. due to insufficient readings, rate at exactly the threshold, or noise-floor jitter). Combined with Bug 1, the function alternates `off` / `quiet` on every sample as the rolling rate crosses the 0.5 ppm/min line.
+
+### Aggravator: `erv_client.py` does multiple local ops per `set_speed` (`_set_speed_local`, lines 256–315)
+
+- `set_speed(OFF)` = 2 local round-trips: `set_value(power=False)` + `get_status` verify
+- `set_speed(QUIET / MEDIUM / TURBO)` = 4 local round-trips: `set_value(power=True)` + `set_value(supply)` + `set_value(exhaust)` + `get_status` verify
+
+A single `quiet → off` toggle pair is ~6 round-trips. The observed 10 toggles in ~5 minutes amounts to roughly 30–40 local round-trips against a device that was sitting in steady state.
+
+## Proposed fix
+
+Two layered changes in `src/orchestrator.py` plus a configurable catch-all. (A previously proposed "rate hysteresis" change was dropped — release semantics are handled by Change 1's baseline-delta release; layering a release-rate on first-entry detection was muddled.)
+
+### Change 1: Use `_plateau_detected` as actual sticky state with a release condition
+
+Add a config field in `src/config.py`:
+
+```python
+co2_plateau_release_delta_ppm: int = 100   # release plateau when CO2 climbs this far above learned baseline
+```
+
+In `_detect_co2_plateau()`:
+
+```python
+def _detect_co2_plateau(self) -> bool:
+    if not self.config.thresholds.co2_plateau_enabled:
+        return False
+
+    # Inconsistent state guard: if detected is True but baseline is None,
+    # something cleared baseline without clearing detected. Reset both and recompute.
+    if self._plateau_detected and self._outdoor_co2_baseline is None:
+        self._plateau_detected = False
+
+    # Sticky: once latched, stay latched until CO2 climbs meaningfully above baseline.
+    if self._plateau_detected and self._outdoor_co2_baseline is not None:
+        current_co2 = self._co2_history[-1][1] if self._co2_history else None
+        if current_co2 is not None and current_co2 < (
+            self._outdoor_co2_baseline + self.config.thresholds.co2_plateau_release_delta_ppm
+        ):
+            return True
+        # CO2 climbed past the release delta — break out and recompute fresh
+        self._plateau_detected = False
+        self._outdoor_co2_baseline = None
+
+    # ... existing first-time detection logic unchanged ...
+```
+
+**State reset on presence transitions:** today, `_plateau_detected` and `_outdoor_co2_baseline` are cleared on PRESENT but not on AWAY entry. Add clearing of both on AWAY entry so a stale plateau from an earlier AWAY session doesn't carry over.
+
+### Change 2 (was Change 3): Minimum dwell time on automated within-state transitions
+
+Add to `ThresholdsConfig`:
+
+```python
+erv_min_dwell_seconds: int = 180   # minimum interval between automated ERV speed changes within a stable presence state
+```
+
+Add to orchestrator state:
+
+```python
+self._erv_speed_changed_at: Optional[datetime] = None
+```
+
+**Centralize all ERV speed changes through one helper** to avoid scattering dwell logic across call sites:
+
+```python
+def _apply_erv_speed(
+    self,
+    target_speed: str,                # "off"|"quiet"|"medium"|"turbo"
+    fan_speed: Optional[FanSpeed],    # None when target_speed=="off"
+    reason: str,
+    co2: Optional[int],
+    bypass_dwell: bool = False,
+) -> bool:
+    # Dwell check
+    if not bypass_dwell and self._erv_speed_changed_at is not None:
+        elapsed = (datetime.now() - self._erv_speed_changed_at).total_seconds()
+        if elapsed < self.config.thresholds.erv_min_dwell_seconds:
+            logger.info(
+                f"ERV transition to {target_speed} suppressed by dwell "
+                f"({elapsed:.0f}s < {self.config.thresholds.erv_min_dwell_seconds}s, reason={reason})"
+            )
+            return False  # do not write a climate_actions row — no device action occurred
+
+    # Issue the device command via self.erv (turn_off / turn_on)
+    if target_speed == "off":
+        ok = self.erv.turn_off()
+    else:
+        ok = self.erv.turn_on(fan_speed)
+
+    if ok:
+        self._erv_running = target_speed != "off"
+        self._erv_speed = target_speed
+        self._erv_speed_changed_at = datetime.now()   # update only on success
+        self.db.log_climate_action("erv", target_speed, co2_ppm=co2, reason=reason)
+    return ok
+```
+
+Refactor all current call sites (`_evaluate_erv_state` and friends — see grep for `self.erv.turn_on` / `self.erv.turn_off`) to route through `_apply_erv_speed`, passing `bypass_dwell=True` from the appropriate paths.
+
+**Dwell bypass list** (`bypass_dwell=True`):
+
+1. **Safety interlocks** — window/door open → OFF
+2. **Manual override** — explicit user action via API / dashboard
+3. **Shutdown** — orchestrator clean exit
+4. **PRESENT critical CO2** — entering ELEVATED at CO2 ≥ 2000 ppm. This is a safety-tier event; stale ventilation is worse than a brief command-rate concern.
+5. **Presence state transitions** — any ERV change initiated by AWAY → PRESENT or PRESENT → AWAY (including the AWAY-mode initial 30-min TURBO at state entry, and PRESENT cleanup).
+
+**Dwell-enforced paths** (`bypass_dwell=False`, the default):
+
+- AWAY-mode adaptive speed changes within a stable AWAY state.
+- PRESENT-mode hysteresis-driven on/off around the 1800–2000 CO2 band.
+- tVOC adaptive within-state changes.
+- Stale-air periodic flush.
+
+**Rule of thumb:** dwell applies to automated transitions within a stable presence state. Any transition caused by — or coincident with — a presence event, safety event, or explicit user action bypasses dwell.
+
+### (Dropped) Rate hysteresis
+
+The previously sketched "release rate" threshold was conflating entry semantics with release semantics. Change 1's baseline-delta release is the correct latching mechanism. If post-fix observation shows entry chatter (rare oscillation right at first plateau detection), revisit with proper sticky-state-release semantics — but do not ship it in this PR.
+
+### Optional follow-up: trim `erv_client.py` read-back verify
+
+The per-`set_speed` command multiplier is real but secondary. Once Changes 1–2 stop the thrash, this is optimization. Defer unless local protocol abuse symptoms persist after the fix.
+
+## Acceptance criteria
+
+1. With CO2 history representing 510–519 ppm noise (matching today's 07:51–07:59 sensor sequence) and AWAY state post-30-min, the orchestrator emits **at most 1** ERV transition after plateau first latches.
+2. AWAY mode active for >30 min with CO2 at outdoor baseline → no ERV toggles for at least 30 minutes under noisy-but-stable readings.
+3. CO2 climbing by ≥ `co2_plateau_release_delta_ppm` (default 100) above the learned baseline must break plateau and allow ventilation to resume (regression check against locking OFF forever).
+4. Safety interlocks (window/door open → OFF) fire immediately regardless of dwell timer state.
+5. Walking into the room (AWAY → PRESENT) takes effect immediately regardless of dwell timer state.
+6. Manual override commands take effect immediately regardless of dwell timer state.
+
+## Test plan
+
+- **Unit test `_detect_co2_plateau()` sticky behavior**: synthesize a `_co2_history` sequence at ~512 ppm with ±2 ppm noise, manually set `_plateau_detected = True` and `_outdoor_co2_baseline = 512`, assert function returns True across many ticks even as rate jitters. Then push CO2 to 612 and assert it transitions to False.
+- **Unit test `_apply_erv_speed` dwell suppression**: with injected fake clock (see below), set `_erv_speed_changed_at = now()`, call helper with `bypass_dwell=False`, assert it returns False AND no `climate_actions` row was written. Advance fake clock past `erv_min_dwell_seconds`, call again, assert it proceeds.
+- **Unit test dwell bypass**: with the same fresh dwell timer, call helper with `bypass_dwell=True`, assert it proceeds and writes a climate_actions row.
+- **Integration test against today's sensor data**: replay the production `sensor_readings` sequence from 2026-05-21 07:45–08:08 (CO2 510–519 ppm range, ~30s cadence) through the fixed orchestrator in AWAY state, post-initial-TURBO window. Assert ≤1 ERV state transition emitted.
+- **Test fake clock**: before testing dwell or the 30-minute turbo-window, introduce a `_now()` helper on the orchestrator (or accept an injectable clock) so tests don't depend on `datetime.now()` directly. Several existing tests will benefit from this too.
+- **Audit existing stale-flush tests**: they currently perform repeated state changes in quick succession; with dwell central, some assertions may need to assert "suppressed by dwell" rather than "transition occurred."
+
+## Out of scope
+
+- The network/WAN block at the BGW (was previously proposed; no longer justified — see Background).
+- Cloud-relay rewrite of `erv_client.py` to use `tuya_sharing.Manager.send_commands` (was previously proposed; not needed if local control isn't being abused).
+- Daemon (`scripts/refresh-erv-key.py`) changes — already working; remains the recovery tool after a re-pair.
+- The eero → BGW bridge cutover (independent project, on its own merits).
+- `erv_client.py` read-back verify trim — deferred, see "Optional follow-up" above.
+
+## Runbook docs cleanup
+
+This PR also updates `docs/tuya-local-key.md`. Its previous "When To Run This" and "Prevention" sections attributed Err 914 almost entirely to firmware OTA. That phrasing is now stale and misleading. The runbook now notes:
+
+- This incident's diagnosis showed orchestrator command-burst as a real cause distinct from OTA.
+- Re-pair (Path B) is the only path to a working local key once the device starts rejecting it.
+- The thrash-fix PR (this spec) eliminates the orchestrator-side trigger going forward.
+
+## Ticket classification
+
+**Single ticket.** One agent can complete both changes, the centralization refactor, and the tests without context compaction. Recommend filing as a GH issue with this spec linked, then implementing in one PR.

--- a/src/config.py
+++ b/src/config.py
@@ -90,6 +90,7 @@ class ThresholdsConfig:
     co2_plateau_rate_threshold: float = 0.5  # ppm/min - slower than this = plateau
     co2_plateau_window_minutes: int = 10     # sustained slow rate for this long
     co2_plateau_min_co2: int = 600           # don't declare plateau above this (safety, allows winter ~490ppm + margin)
+    co2_plateau_release_delta_ppm: int = 100 # release plateau when CO2 climbs above learned baseline by this much
     co2_history_size: int = 40               # CO2 readings in sliding window (20 min at 30s intervals)
 
     # Adaptive ERV speed control (AWAY mode)
@@ -100,6 +101,7 @@ class ThresholdsConfig:
                                               # < 0.5 ppm/min for 10 min → OFF (plateau)
     co2_turbo_duration_minutes: int = 30     # Force TURBO for first N minutes after departure
     min_away_seconds_before_erv: int = 60    # Hold ERV off after AWAY transition for N seconds; rides out brief door-open false positives
+    erv_min_dwell_seconds: int = 180         # Minimum interval between automated ERV speed changes within a stable presence state
 
     # tVOC AWAY mode ventilation (similar to CO2 adaptive control)
     # NOTE: tVOC is IGNORED when PRESENT - only triggers ventilation when AWAY

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -132,6 +132,7 @@ class Orchestrator:
         # Track if ERV is currently running and at what speed
         self._erv_running: bool = False
         self._erv_speed: str = "off"  # "off", "quiet", "medium", "turbo"
+        self._erv_speed_changed_at: Optional[datetime] = None
 
         # CO2 plateau detection state (AWAY mode optimization)
         self._co2_history: deque[tuple[datetime, int]] = deque(
@@ -211,6 +212,10 @@ class Orchestrator:
         self._default_hvac_temperature_bands = get_default_temperature_bands(config.thresholds)
         self._load_hvac_temperature_bands()
         self.erv.on_health_event(self._handle_erv_health_event)
+
+    def _now(self) -> datetime:
+        """Return current local time; tests can override this for deterministic timing."""
+        return datetime.now()
 
     def _get_hvac_temperature_bands(self) -> dict[str, int]:
         """Return the active HVAC temperature hysteresis bands."""
@@ -296,7 +301,7 @@ class Orchestrator:
         """Translate ERV control health transitions into in-app notifications."""
         event_type = event.get("type")
         if event_type == "erv_local_key_invalid":
-            created_at = event.get("started_at") or datetime.now().isoformat()
+            created_at = event.get("started_at") or self._now().isoformat()
             self._erv_control_notification = {
                 "id": f"erv_local_key_invalid:{created_at}",
                 "type": "erv_local_key_invalid",
@@ -310,7 +315,7 @@ class Orchestrator:
             logger.error("ERV local key invalid; notifying Android app")
             self.db.log_device_event("erv", "local_key_invalid", "Pioneer ECOasis 150", details=event)
         elif event_type == "erv_local_key_recovered":
-            created_at = event.get("recovered_at") or datetime.now().isoformat()
+            created_at = event.get("recovered_at") or self._now().isoformat()
             self._erv_control_notification = {
                 "id": f"erv_local_key_recovered:{created_at}",
                 "type": "erv_local_key_recovered",
@@ -382,12 +387,12 @@ class Orchestrator:
 
         # Update tVOC history for AWAY mode adaptive control
         if reading.tvoc is not None:
-            now = datetime.now()
+            now = self._now()
             self._tvoc_away_history.append((now, reading.tvoc))
 
         # Update CO2 history for plateau detection
         if reading.co2_ppm is not None:
-            now = datetime.now()
+            now = self._now()
             self._co2_history.append((now, reading.co2_ppm))
 
         # Update state machine with CO2 reading
@@ -402,7 +407,7 @@ class Orchestrator:
 
     def _check_manual_override_expiry(self):
         """Check if manual overrides have expired and clear them."""
-        now = datetime.now()
+        now = self._now()
         if self._manual_erv_override and self._manual_erv_override_at:
             elapsed = (now - self._manual_erv_override_at).total_seconds()
             if elapsed > self._manual_override_timeout:
@@ -429,7 +434,7 @@ class Orchestrator:
 
     def _update_room_closed_tracking(self, now: Optional[datetime] = None, mark_state_known: bool = False):
         """Track continuous closed period and clear stale-flush timers on open events."""
-        now = now or datetime.now()
+        now = now or self._now()
         if mark_state_known:
             self._room_closed_state_known = True
 
@@ -471,7 +476,7 @@ class Orchestrator:
             self._away_stale_flush_next_due_at = None
             return False
 
-        now = now or datetime.now()
+        now = now or self._now()
 
         # Keep closed/open tracking current before making decisions.
         self._update_room_closed_tracking(now)
@@ -546,13 +551,40 @@ class Orchestrator:
         if not self.config.thresholds.co2_plateau_enabled:
             return False
 
+        current_co2 = self._co2_history[-1][1] if self._co2_history else None
+
+        # Defensive cleanup for partially reset plateau state.
+        if self._plateau_detected and self._outdoor_co2_baseline is None:
+            logger.warning("CO2 plateau state had no baseline; resetting and recomputing")
+            self._plateau_detected = False
+
+        # Sticky plateau: once outdoor baseline is learned, stay off through
+        # sensor noise until CO2 climbs meaningfully above that baseline.
+        if self._plateau_detected and self._outdoor_co2_baseline is not None:
+            if current_co2 is None:
+                return True
+
+            release_threshold = (
+                self._outdoor_co2_baseline +
+                self.config.thresholds.co2_plateau_release_delta_ppm
+            )
+            if current_co2 < release_threshold:
+                return True
+
+            logger.info(
+                "CO2 plateau released: %sppm >= %sppm baseline+delta",
+                current_co2,
+                release_threshold,
+            )
+            self._plateau_detected = False
+            self._outdoor_co2_baseline = None
+
         # Need enough data to calculate rate over window
         min_readings = max(20, int(self.config.thresholds.co2_plateau_window_minutes * 2))
         if len(self._co2_history) < min_readings:
             return False
 
         # Safety: Don't declare plateau if CO2 is still high
-        current_co2 = self._co2_history[-1][1]
         if current_co2 > self.config.thresholds.co2_plateau_min_co2:
             return False
 
@@ -568,6 +600,7 @@ class Orchestrator:
         if is_plateau:
             # Remember this as outdoor baseline
             self._outdoor_co2_baseline = current_co2
+            self._plateau_detected = True
             logger.info(f"CO2 plateau detected at {current_co2}ppm (rate: {rate:.2f} ppm/min, "
                        f"outdoor baseline learned)")
 
@@ -584,15 +617,18 @@ class Orchestrator:
 
         # Check for plateau first
         if self._detect_co2_plateau():
-            logger.info(f"CO2 plateau detected at {co2}ppm, stopping ERV (outdoor baseline: {self._outdoor_co2_baseline}ppm)")
-            self._plateau_detected = True
+            logger.debug(
+                "CO2 plateau active at %sppm, stopping ERV (outdoor baseline: %sppm)",
+                co2,
+                self._outdoor_co2_baseline,
+            )
             return "off"
 
         # Force TURBO for first N minutes after departure
         # This ensures aggressive initial purge before switching to adaptive
         turbo_duration = self.config.thresholds.co2_turbo_duration_minutes
         if self._away_start_time:
-            minutes_away = (datetime.now() - self._away_start_time).total_seconds() / 60.0
+            minutes_away = (self._now() - self._away_start_time).total_seconds() / 60.0
             if minutes_away < turbo_duration:
                 return "turbo"  # Still in initial TURBO window
 
@@ -693,7 +729,7 @@ class Orchestrator:
         # Force TURBO for first N minutes after departure (same as CO2)
         turbo_duration = self.config.thresholds.co2_turbo_duration_minutes
         if self._away_start_time:
-            minutes_away = (datetime.now() - self._away_start_time).total_seconds() / 60.0
+            minutes_away = (self._now() - self._away_start_time).total_seconds() / 60.0
             if minutes_away < turbo_duration:
                 return "turbo"  # Still in initial TURBO window
 
@@ -723,7 +759,60 @@ class Orchestrator:
             # Approaching plateau
             return "quiet"
 
-    def _evaluate_erv_state(self):
+    def _initial_away_turbo_active(self, now: Optional[datetime] = None) -> bool:
+        """True while a new AWAY state is in its configured initial TURBO window."""
+        if self._away_start_time is None:
+            return False
+        now = now or self._now()
+        minutes_away = (now - self._away_start_time).total_seconds() / 60.0
+        return minutes_away < self.config.thresholds.co2_turbo_duration_minutes
+
+    def _apply_erv_speed(
+        self,
+        target_speed: str,
+        fan_speed: Optional[FanSpeed],
+        reason: str,
+        co2: Optional[int],
+        bypass_dwell: bool = False,
+    ) -> bool:
+        """Apply an ERV speed change with dwell protection and consistent logging."""
+        if target_speed not in ("off", "quiet", "medium", "turbo"):
+            raise ValueError(f"Invalid ERV target speed: {target_speed}")
+        if target_speed != "off" and fan_speed is None:
+            raise ValueError(f"fan_speed is required for ERV target speed: {target_speed}")
+
+        now = self._now()
+        last_changed_at = getattr(self, "_erv_speed_changed_at", None)
+        dwell_seconds = self.config.thresholds.erv_min_dwell_seconds
+        if not bypass_dwell and last_changed_at is not None and dwell_seconds > 0:
+            elapsed = (now - last_changed_at).total_seconds()
+            if elapsed < dwell_seconds:
+                logger.info(
+                    "ERV transition to %s suppressed by dwell (%.0fs < %ss, reason=%s)",
+                    target_speed,
+                    elapsed,
+                    dwell_seconds,
+                    reason,
+                )
+                return False
+
+        if target_speed == "off":
+            logger.info(f"ACTION: ERV OFF ({reason})")
+            ok = self.erv.turn_off()
+        else:
+            logger.info(f"ACTION: ERV {target_speed.upper()} ({reason})")
+            ok = self.erv.turn_on(fan_speed)
+
+        if ok:
+            self._erv_running = target_speed != "off"
+            self._erv_speed = target_speed
+            self._erv_speed_changed_at = now
+            self.db.log_climate_action("erv", target_speed, co2_ppm=co2, reason=reason)
+        else:
+            logger.error(f"ERV {target_speed.upper()} failed ({reason})")
+        return ok
+
+    def _evaluate_erv_state(self, bypass_dwell: bool = False):
         """Evaluate whether ERV should be on or off based on current state.
 
         Priority:
@@ -736,6 +825,7 @@ class Orchestrator:
         self._check_manual_override_expiry()
 
         state = self.state_machine.state
+        now = self._now()
 
         # Get CO2 and tVOC readings from Qingping
         reading = self.qingping.latest_reading
@@ -745,15 +835,15 @@ class Orchestrator:
         # Safety: window/door open = ERV off (overrides everything including manual)
         if self.state_machine.sensors.window_open or self.state_machine.sensors.door_open:
             if self._erv_running:
-                logger.info("ACTION: ERV OFF (window/door open)")
-                ok = self.erv.turn_off()
+                ok = self._apply_erv_speed(
+                    "off",
+                    None,
+                    "safety_interlock",
+                    co2,
+                    bypass_dwell=True,
+                )
                 if ok:
-                    self._erv_running = False
-                    self._erv_speed = "off"
                     self._tvoc_away_ventilation_active = False
-                    self.db.log_climate_action("erv", "off", co2_ppm=co2, reason="safety_interlock")
-                else:
-                    logger.error("ERV OFF failed (safety interlock)")
             return
 
         # Manual override takes priority over automation
@@ -761,24 +851,24 @@ class Orchestrator:
             target_speed = self._manual_erv_speed
             if target_speed == "off":
                 if self._erv_running:
-                    logger.info("ACTION: ERV OFF (manual override)")
-                    ok = self.erv.turn_off()
-                    if ok:
-                        self._erv_running = False
-                        self._erv_speed = "off"
-                    else:
-                        logger.error("ERV OFF failed (manual override)")
+                    self._apply_erv_speed(
+                        "off",
+                        None,
+                        "manual_override",
+                        co2,
+                        bypass_dwell=True,
+                    )
             else:
                 speed_map = {"quiet": FanSpeed.QUIET, "medium": FanSpeed.MEDIUM, "turbo": FanSpeed.TURBO}
                 fan_speed = speed_map.get(target_speed, FanSpeed.QUIET)
                 if not self._erv_running or self._erv_speed != target_speed:
-                    logger.info(f"ACTION: ERV {target_speed.upper()} (manual override)")
-                    ok = self.erv.turn_on(fan_speed)
-                    if ok:
-                        self._erv_running = True
-                        self._erv_speed = target_speed
-                    else:
-                        logger.error(f"ERV {target_speed.upper()} failed (manual override)")
+                    self._apply_erv_speed(
+                        target_speed,
+                        fan_speed,
+                        "manual_override",
+                        co2,
+                        bypass_dwell=True,
+                    )
             return  # Skip automation logic when manual override is active
 
         # CO2 hysteresis: ON at 2000, OFF at 1800 (200ppm dead band)
@@ -799,34 +889,33 @@ class Orchestrator:
             if co2_critical_on:
                 # CO2 >= 2000 - turn on QUIET
                 if not self._erv_running or self._erv_speed != "quiet":
-                    logger.info(f"ACTION: ERV QUIET (CO2 critical: {co2}ppm)")
-                    ok = self.erv.turn_on(FanSpeed.QUIET)
-                    if ok:
-                        self._erv_running = True
-                        self._erv_speed = "quiet"
-                        self.db.log_climate_action("erv", "quiet", co2_ppm=co2, reason=f"present_co2_critical_{co2}ppm")
-                    else:
-                        logger.error("ERV QUIET failed (present CO2 critical)")
+                    self._apply_erv_speed(
+                        "quiet",
+                        FanSpeed.QUIET,
+                        f"present_co2_critical_{co2}ppm",
+                        co2,
+                        bypass_dwell=True,
+                    )
             elif self._erv_running and self._erv_speed == "quiet":
                 # Running QUIET mode, check hysteresis before turning off
                 if co2_critical_off:
-                    logger.info(f"ACTION: ERV OFF (CO2 dropped to {co2}ppm, below {self.config.thresholds.co2_critical_ppm - self.config.thresholds.co2_critical_hysteresis_ppm}ppm)")
-                    ok = self.erv.turn_off()
-                    if ok:
-                        self._erv_running = False
-                        self._erv_speed = "off"
-                    else:
-                        logger.error("ERV OFF failed (present hysteresis)")
+                    self._apply_erv_speed(
+                        "off",
+                        None,
+                        f"present_co2_hysteresis_{co2}ppm",
+                        co2,
+                        bypass_dwell=bypass_dwell,
+                    )
                 # else: stay in hysteresis band (1800-2000), keep running
             elif self._erv_running:
                 # Turn off if running for any other reason
-                logger.info("ACTION: ERV OFF (present, air quality OK)")
-                ok = self.erv.turn_off()
-                if ok:
-                    self._erv_running = False
-                    self._erv_speed = "off"
-                else:
-                    logger.error("ERV OFF failed (present air quality OK)")
+                self._apply_erv_speed(
+                    "off",
+                    None,
+                    "present_air_quality_ok",
+                    co2,
+                    bypass_dwell=bypass_dwell,
+                )
 
         elif state == OccupancyState.AWAY:
             # Settle window: roughly 1 in 3 historical AWAY transitions were
@@ -835,7 +924,7 @@ class Orchestrator:
             # seconds of AWAY so we don't fire TURBO on those.
             settle_seconds = self.config.thresholds.min_away_seconds_before_erv
             if settle_seconds > 0 and self._away_start_time is not None:
-                elapsed = (datetime.now() - self._away_start_time).total_seconds()
+                elapsed = (now - self._away_start_time).total_seconds()
                 if elapsed < settle_seconds:
                     self._schedule_task(self._evaluate_hvac_state, context="erv_hvac_coordination")
                     return
@@ -845,7 +934,7 @@ class Orchestrator:
             # Periodic stale-air flush also runs while continuously closed.
             # Use the most aggressive speed among CO2, tVOC, and stale flush needs.
 
-            stale_flush_active = self._is_away_stale_flush_active(datetime.now())
+            stale_flush_active = self._is_away_stale_flush_active(now)
             stale_adaptive_speed = self._stale_flush_speed() if stale_flush_active else None
 
             # Get adaptive speeds for both CO2 and tVOC
@@ -885,14 +974,13 @@ class Orchestrator:
                     (tvoc_adaptive_speed == "off" or not self._tvoc_away_ventilation_active)):
                 if self._erv_running:
                     reason = "co2_plateau" if self._plateau_detected else "targets_reached"
-                    logger.info(f"ACTION: ERV OFF ({reason}: CO2={co2}ppm, tVOC={tvoc})")
-                    ok = self.erv.turn_off()
-                    if ok:
-                        self._erv_running = False
-                        self._erv_speed = "off"
-                        self.db.log_climate_action("erv", "off", co2_ppm=co2, reason=reason)
-                    else:
-                        logger.error(f"ERV OFF failed (away {reason})")
+                    self._apply_erv_speed(
+                        "off",
+                        None,
+                        reason,
+                        co2,
+                        bypass_dwell=bypass_dwell,
+                    )
             elif co2_priority >= 0 or tvoc_priority >= 0 or stale_priority >= 0:
                 # Pick the more aggressive speed
                 candidates = [
@@ -917,52 +1005,46 @@ class Orchestrator:
                     fan_speed = speed_map[target_speed]
 
                     if not self._erv_running or self._erv_speed != target_speed:
-                        if source == "stale":
-                            logger.info(f"ACTION: ERV {target_speed.upper()} (away, stale-air periodic flush)")
-                        else:
-                            co2_rate = self._calculate_co2_rate_of_change()
-                            tvoc_rate = self._calculate_tvoc_rate_of_change()
-                            rate_str = f"CO2:{co2_rate:.2f}/min" if co2_rate else ""
-                            if tvoc_rate:
-                                rate_str += f" tVOC:{tvoc_rate:.2f}/min" if rate_str else f"tVOC:{tvoc_rate:.2f}/min"
-                            logger.info(f"ACTION: ERV {target_speed.upper()} (away, adaptive: {trigger}, {rate_str})")
-                        ok = self.erv.turn_on(fan_speed)
-                        if ok:
-                            self._erv_running = True
-                            self._erv_speed = target_speed
-                            self.db.log_climate_action("erv", target_speed, co2_ppm=co2, reason=reason)
-                        else:
-                            logger.error(f"ERV {target_speed.upper()} failed (away adaptive)")
+                        initial_away_turbo = (
+                            source == "co2" and
+                            target_speed == "turbo" and
+                            self._initial_away_turbo_active(now)
+                        )
+                        self._apply_erv_speed(
+                            target_speed,
+                            fan_speed,
+                            reason,
+                            co2,
+                            bypass_dwell=bypass_dwell or initial_away_turbo,
+                        )
             elif not co2_needs_refresh and not self._tvoc_away_ventilation_active and stale_priority < 0:
                 # Nothing needs ventilation
                 if self._erv_running:
-                    logger.info(f"ACTION: ERV OFF (air quality OK: CO2={co2}ppm, tVOC={tvoc})")
-                    ok = self.erv.turn_off()
-                    if ok:
-                        self._erv_running = False
-                        self._erv_speed = "off"
-                        self.db.log_climate_action("erv", "off", co2_ppm=co2, reason="air_quality_ok")
-                    else:
-                        logger.error("ERV OFF failed (away air quality OK)")
+                    self._apply_erv_speed(
+                        "off",
+                        None,
+                        "air_quality_ok",
+                        co2,
+                        bypass_dwell=bypass_dwell,
+                    )
             else:
                 # Fall back to TURBO if adaptive not ready yet
                 if not self._erv_running or self._erv_speed != "turbo":
                     trigger = f"CO2={co2}ppm" if co2_needs_refresh else f"tVOC={tvoc}"
-                    logger.info(f"ACTION: ERV TURBO (away mode, {trigger})")
-                    ok = self.erv.turn_on(FanSpeed.TURBO)
-                    if ok:
-                        self._erv_running = True
-                        self._erv_speed = "turbo"
-                        self.db.log_climate_action("erv", "turbo", co2_ppm=co2, reason=f"away_refresh_{trigger}")
-                    else:
-                        logger.error("ERV TURBO failed (away refresh)")
+                    self._apply_erv_speed(
+                        "turbo",
+                        FanSpeed.TURBO,
+                        f"away_refresh_{trigger}",
+                        co2,
+                        bypass_dwell=bypass_dwell or self._initial_away_turbo_active(now),
+                    )
 
         # After ERV state changes, evaluate HVAC coordination
         self._schedule_task(self._evaluate_hvac_state, context="erv_hvac_coordination")
 
     def _is_within_occupancy_hours(self) -> bool:
         """Check if current time is within expected occupancy hours."""
-        now = datetime.now().time()
+        now = self._now().time()
         try:
             start = datetime.strptime(self.config.thresholds.expected_occupancy_start, "%H:%M").time()
             end = datetime.strptime(self.config.thresholds.expected_occupancy_end, "%H:%M").time()
@@ -1324,7 +1406,7 @@ class Orchestrator:
     def _on_state_change(self, old_state: OccupancyState, new_state: OccupancyState):
         """Handle occupancy state changes."""
         logger.info(f"=== STATE CHANGE: {old_state.value} → {new_state.value} ===")
-        now = datetime.now()
+        now = self._now()
 
         # Clear manual overrides - automation takes over on state change
         self._clear_manual_overrides(f"{old_state.value}→{new_state.value}")
@@ -1339,6 +1421,8 @@ class Orchestrator:
             logger.info("Clearing CO2/tVOC history for fresh adaptive calculation")
             self._co2_history.clear()
             self._tvoc_away_history.clear()
+            self._plateau_detected = False
+            self._outdoor_co2_baseline = None
             self._away_start_time = now
             self._away_stale_flush_active_until = None
             self._away_stale_flush_next_due_at = None
@@ -1363,10 +1447,11 @@ class Orchestrator:
                 self._tvoc_plateau_detected = False
 
         # Clear plateau detection state on arrival (start fresh CO2 refresh cycle)
-        if new_state == OccupancyState.PRESENT and self._plateau_detected:
-            logger.info("Clearing plateau state: user returned")
+        if new_state == OccupancyState.PRESENT:
+            if self._plateau_detected:
+                logger.info("Clearing plateau state: user returned")
             self._plateau_detected = False
-            # Keep outdoor baseline for reference
+            self._outdoor_co2_baseline = None
 
         # Log to database
         self.db.log_occupancy_change(
@@ -1376,7 +1461,7 @@ class Orchestrator:
         )
 
         # Evaluate ERV state based on new occupancy
-        self._evaluate_erv_state()
+        self._evaluate_erv_state(bypass_dwell=True)
 
         # Evaluate HVAC coordination
         self._schedule_task(self._evaluate_hvac_state, context="state_change_hvac_eval")
@@ -1519,31 +1604,27 @@ class Orchestrator:
             # Set manual override
             self._manual_erv_override = True
             self._manual_erv_speed = speed
-            self._manual_erv_override_at = datetime.now()
+            self._manual_erv_override_at = self._now()
 
             # Apply the change immediately
             if speed == "off":
-                logger.info("MANUAL: ERV OFF")
-                ok = self.erv.turn_off()
-                if ok:
-                    self._erv_running = False
-                    self._erv_speed = "off"
-                else:
-                    logger.error("Manual ERV OFF failed")
+                ok = self._apply_erv_speed(
+                    "off",
+                    None,
+                    "manual_override",
+                    co2,
+                    bypass_dwell=True,
+                )
             else:
                 speed_map = {"quiet": FanSpeed.QUIET, "medium": FanSpeed.MEDIUM, "turbo": FanSpeed.TURBO}
                 fan_speed = speed_map[speed]
-                logger.info(f"MANUAL: ERV {speed.upper()}")
-                ok = self.erv.turn_on(fan_speed)
-                if ok:
-                    self._erv_running = True
-                    self._erv_speed = speed
-                else:
-                    logger.error(f"Manual ERV {speed.upper()} failed")
-
-            # Log to database only on success
-            if ok:
-                self.db.log_climate_action("erv", speed, co2_ppm=co2, reason="manual_override")
+                ok = self._apply_erv_speed(
+                    speed,
+                    fan_speed,
+                    "manual_override",
+                    co2,
+                    bypass_dwell=True,
+                )
 
             # Broadcast status update
             await self._broadcast_status()
@@ -2914,7 +2995,13 @@ class Orchestrator:
         # Turn off ERV before stopping
         if self._erv_running:
             logger.info("Turning off ERV before shutdown...")
-            ok = self.erv.turn_off()
+            ok = self._apply_erv_speed(
+                "off",
+                None,
+                "shutdown",
+                None,
+                bypass_dwell=True,
+            )
             if not ok:
                 logger.error("ERV OFF failed during shutdown")
 

--- a/tests/test_away_stale_flush.py
+++ b/tests/test_away_stale_flush.py
@@ -179,6 +179,7 @@ def test_stale_flush_repeats_every_8_hours_at_medium():
     assert orchestrator._erv_speed == "medium"
 
     # Flush window ended; next schedule not due yet -> ERV turns off.
+    orchestrator._erv_speed_changed_at = datetime.now() - timedelta(minutes=4)
     orchestrator._away_stale_flush_active_until = datetime.now() - timedelta(seconds=1)
     orchestrator._away_stale_flush_next_due_at = datetime.now() + timedelta(hours=1)
     orchestrator._evaluate_erv_state()
@@ -186,6 +187,7 @@ def test_stale_flush_repeats_every_8_hours_at_medium():
     assert orchestrator._erv_speed == "off"
 
     # Next stale cycle due -> flush starts again.
+    orchestrator._erv_speed_changed_at = datetime.now() - timedelta(minutes=4)
     orchestrator._away_stale_flush_next_due_at = datetime.now() - timedelta(seconds=1)
     orchestrator._evaluate_erv_state()
     assert orchestrator._erv_running is True
@@ -259,6 +261,7 @@ def test_stale_flush_never_overrides_more_aggressive_co2_speed():
         tvoc_away_enabled=False,
         co2_adaptive_speed_enabled=True,
         co2_turbo_duration_minutes=30,
+        min_away_seconds_before_erv=0,
     )
     orchestrator = _build_orchestrator(thresholds)
     orchestrator.state_machine.state = OccupancyState.AWAY

--- a/tests/test_erv_thrash_fix.py
+++ b/tests/test_erv_thrash_fix.py
@@ -1,0 +1,380 @@
+"""Tests for ERV plateau latching and dwell protection."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timedelta
+from types import ModuleType, SimpleNamespace
+import sys
+
+
+def _install_dependency_stubs():
+    if "aiomqtt" not in sys.modules:
+        aiomqtt = ModuleType("aiomqtt")
+        aiomqtt.Message = object
+        aiomqtt.Client = object
+        sys.modules["aiomqtt"] = aiomqtt
+
+    if "tinytuya" not in sys.modules:
+        tinytuya = ModuleType("tinytuya")
+        tinytuya.Device = object
+        tinytuya.Cloud = object
+        sys.modules["tinytuya"] = tinytuya
+
+    if "jwt" not in sys.modules:
+        jwt = ModuleType("jwt")
+        jwt.decode = lambda *args, **kwargs: {}
+        jwt.encode = lambda *args, **kwargs: "token"
+        jwt.ExpiredSignatureError = Exception
+        jwt.InvalidTokenError = Exception
+        sys.modules["jwt"] = jwt
+
+    if "google" not in sys.modules:
+        sys.modules["google"] = ModuleType("google")
+    if "google.oauth2" not in sys.modules:
+        sys.modules["google.oauth2"] = ModuleType("google.oauth2")
+    if "google.oauth2.id_token" not in sys.modules:
+        id_token = ModuleType("google.oauth2.id_token")
+        id_token.verify_oauth2_token = lambda *args, **kwargs: {}
+        sys.modules["google.oauth2.id_token"] = id_token
+    if "google.auth" not in sys.modules:
+        sys.modules["google.auth"] = ModuleType("google.auth")
+    if "google.auth.transport" not in sys.modules:
+        sys.modules["google.auth.transport"] = ModuleType("google.auth.transport")
+    if "google.auth.transport.requests" not in sys.modules:
+        requests_mod = ModuleType("google.auth.transport.requests")
+        requests_mod.Request = object
+        sys.modules["google.auth.transport.requests"] = requests_mod
+
+    if "google_auth_oauthlib" not in sys.modules:
+        sys.modules["google_auth_oauthlib"] = ModuleType("google_auth_oauthlib")
+    if "google_auth_oauthlib.flow" not in sys.modules:
+        flow_mod = ModuleType("google_auth_oauthlib.flow")
+
+        class _Flow:
+            @staticmethod
+            def from_client_config(*args, **kwargs):
+                return _Flow()
+
+        flow_mod.Flow = _Flow
+        sys.modules["google_auth_oauthlib.flow"] = flow_mod
+
+
+_install_dependency_stubs()
+
+from src.config import ThresholdsConfig
+from src.erv_client import FanSpeed
+from src.orchestrator import Orchestrator
+from src.state_machine import OccupancyState
+
+
+class FakeClock:
+    def __init__(self, now: datetime):
+        self.now = now
+
+    def advance(self, **kwargs):
+        self.now += timedelta(**kwargs)
+
+    def set(self, value: datetime):
+        self.now = value
+
+
+class FakeERV:
+    def __init__(self):
+        self.calls: list[tuple[str, str | None]] = []
+
+    def turn_on(self, fan_speed):
+        self.calls.append(("on", fan_speed.value))
+        return True
+
+    def turn_off(self):
+        self.calls.append(("off", None))
+        return True
+
+
+class FakeDB:
+    def __init__(self):
+        self.actions: list[tuple[str, str, str | None]] = []
+        self.occupancy: list[tuple[str, int | None]] = []
+
+    def log_climate_action(self, device, action, co2_ppm=None, reason=None, setpoint=None):
+        self.actions.append((device, action, reason))
+
+    def log_occupancy_change(self, state, trigger=None, co2_ppm=None, details=None):
+        self.occupancy.append((state, co2_ppm))
+
+
+def _reading(co2_ppm: int, tvoc: int = 44):
+    return SimpleNamespace(co2_ppm=co2_ppm, tvoc=tvoc)
+
+
+def _build_orchestrator(
+    thresholds: ThresholdsConfig | None = None,
+    now: datetime | None = None,
+) -> tuple[Orchestrator, FakeClock]:
+    thresholds = thresholds or ThresholdsConfig()
+    clock = FakeClock(now or datetime(2026, 5, 21, 7, 45, 0))
+
+    orchestrator = Orchestrator.__new__(Orchestrator)
+    orchestrator.config = SimpleNamespace(thresholds=thresholds)
+    orchestrator.state_machine = SimpleNamespace(
+        state=OccupancyState.AWAY,
+        sensors=SimpleNamespace(window_open=False, door_open=False),
+    )
+    orchestrator.qingping = SimpleNamespace(latest_reading=_reading(512))
+    orchestrator.erv = FakeERV()
+    orchestrator.db = FakeDB()
+    orchestrator._now = lambda: clock.now
+
+    orchestrator._erv_running = False
+    orchestrator._erv_speed = "off"
+    orchestrator._erv_speed_changed_at = None
+
+    orchestrator._co2_history = deque(maxlen=thresholds.co2_history_size)
+    orchestrator._outdoor_co2_baseline = None
+    orchestrator._plateau_detected = False
+    orchestrator._away_start_time = None
+
+    orchestrator._tvoc_away_history = deque(maxlen=thresholds.tvoc_away_history_size)
+    orchestrator._tvoc_away_ventilation_active = False
+    orchestrator._tvoc_baseline = None
+    orchestrator._tvoc_plateau_detected = False
+
+    orchestrator._manual_erv_override = False
+    orchestrator._manual_erv_speed = None
+    orchestrator._manual_erv_override_at = None
+    orchestrator._manual_hvac_override = False
+    orchestrator._manual_hvac_mode = None
+    orchestrator._manual_hvac_setpoint_f = None
+    orchestrator._manual_hvac_override_at = None
+    orchestrator._manual_override_timeout = 30 * 60
+    orchestrator._main_loop = None
+
+    orchestrator._room_closed_since = clock.now - timedelta(hours=1)
+    orchestrator._room_closed_state_known = True
+    orchestrator._away_stale_flush_active_until = None
+    orchestrator._away_stale_flush_next_due_at = None
+
+    return orchestrator, clock
+
+
+def _append_co2_history(orchestrator: Orchestrator, start: datetime, values: list[int]):
+    for index, value in enumerate(values):
+        orchestrator._co2_history.append((start + timedelta(seconds=index * 30), value))
+
+
+def test_co2_plateau_latches_until_baseline_delta_release():
+    thresholds = ThresholdsConfig(co2_plateau_release_delta_ppm=100)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    start = clock.now - timedelta(minutes=10)
+    _append_co2_history(orchestrator, start, [512, 513, 511, 512] * 6)
+
+    orchestrator._plateau_detected = True
+    orchestrator._outdoor_co2_baseline = 512
+
+    for value in [510, 514, 513, 511, 512]:
+        clock.advance(seconds=30)
+        orchestrator._co2_history.append((clock.now, value))
+        assert orchestrator._detect_co2_plateau() is True
+        assert orchestrator._plateau_detected is True
+
+    clock.advance(seconds=30)
+    orchestrator._co2_history.append((clock.now, 612))
+
+    assert orchestrator._detect_co2_plateau() is False
+    assert orchestrator._plateau_detected is False
+    assert orchestrator._outdoor_co2_baseline is None
+
+
+def test_half_latched_plateau_state_resets_and_recomputes():
+    orchestrator, clock = _build_orchestrator()
+    start = clock.now - timedelta(minutes=10)
+    _append_co2_history(orchestrator, start, [512, 513, 511, 512] * 6)
+    orchestrator._plateau_detected = True
+    orchestrator._outdoor_co2_baseline = None
+
+    assert orchestrator._detect_co2_plateau() is True
+    assert orchestrator._outdoor_co2_baseline == 512
+
+
+def test_apply_erv_speed_suppresses_within_dwell_without_db_row():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator._erv_speed_changed_at = clock.now
+
+    ok = orchestrator._apply_erv_speed(
+        "quiet",
+        FanSpeed.QUIET,
+        "away_adaptive_quiet_CO2=512ppm",
+        512,
+    )
+
+    assert ok is False
+    assert orchestrator.erv.calls == []
+    assert orchestrator.db.actions == []
+
+    clock.advance(seconds=181)
+    ok = orchestrator._apply_erv_speed(
+        "quiet",
+        FanSpeed.QUIET,
+        "away_adaptive_quiet_CO2=512ppm",
+        512,
+    )
+
+    assert ok is True
+    assert orchestrator.erv.calls == [("on", "quiet")]
+    assert orchestrator.db.actions == [
+        ("erv", "quiet", "away_adaptive_quiet_CO2=512ppm")
+    ]
+
+
+def test_apply_erv_speed_bypass_ignores_fresh_dwell_timer():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator._erv_running = True
+    orchestrator._erv_speed = "quiet"
+    orchestrator._erv_speed_changed_at = clock.now
+
+    ok = orchestrator._apply_erv_speed(
+        "off",
+        None,
+        "safety_interlock",
+        512,
+        bypass_dwell=True,
+    )
+
+    assert ok is True
+    assert orchestrator.erv.calls == [("off", None)]
+    assert orchestrator.db.actions == [("erv", "off", "safety_interlock")]
+
+
+def test_safety_interlock_bypasses_dwell_in_evaluate():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator._erv_running = True
+    orchestrator._erv_speed = "quiet"
+    orchestrator._erv_speed_changed_at = clock.now
+    orchestrator.state_machine.sensors.door_open = True
+
+    orchestrator._evaluate_erv_state()
+
+    assert orchestrator.erv.calls == [("off", None)]
+    assert orchestrator.db.actions == [("erv", "off", "safety_interlock")]
+
+
+def test_manual_erv_override_bypasses_dwell_in_evaluate():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator._erv_speed_changed_at = clock.now
+    orchestrator._manual_erv_override = True
+    orchestrator._manual_erv_speed = "turbo"
+    orchestrator._manual_erv_override_at = clock.now
+
+    orchestrator._evaluate_erv_state()
+
+    assert orchestrator.erv.calls == [("on", "turbo")]
+    assert orchestrator.db.actions == [("erv", "turbo", "manual_override")]
+
+
+def test_present_critical_co2_bypasses_dwell_in_evaluate():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator.state_machine.state = OccupancyState.PRESENT
+    orchestrator.qingping.latest_reading = _reading(thresholds.co2_critical_ppm)
+    orchestrator._erv_speed_changed_at = clock.now
+
+    orchestrator._evaluate_erv_state()
+
+    assert orchestrator.erv.calls == [("on", "quiet")]
+    assert orchestrator.db.actions == [
+        ("erv", "quiet", f"present_co2_critical_{thresholds.co2_critical_ppm}ppm")
+    ]
+
+
+def test_presence_transition_bypasses_dwell_for_present_cleanup():
+    thresholds = ThresholdsConfig(erv_min_dwell_seconds=180)
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator.state_machine.state = OccupancyState.PRESENT
+    orchestrator.qingping.latest_reading = _reading(450)
+    orchestrator._erv_running = True
+    orchestrator._erv_speed = "quiet"
+    orchestrator._erv_speed_changed_at = clock.now
+    orchestrator._plateau_detected = True
+    orchestrator._outdoor_co2_baseline = 512
+
+    orchestrator._on_state_change(OccupancyState.AWAY, OccupancyState.PRESENT)
+
+    assert orchestrator.erv.calls == [("off", None)]
+    assert orchestrator.db.actions == [("erv", "off", "present_co2_hysteresis_450ppm")]
+    assert orchestrator._plateau_detected is False
+    assert orchestrator._outdoor_co2_baseline is None
+
+
+def test_presence_transition_bypasses_dwell_for_away_turbo():
+    thresholds = ThresholdsConfig(
+        erv_min_dwell_seconds=180,
+        min_away_seconds_before_erv=0,
+    )
+    orchestrator, clock = _build_orchestrator(thresholds)
+    orchestrator.state_machine.state = OccupancyState.AWAY
+    orchestrator.qingping.latest_reading = _reading(700)
+    orchestrator._erv_speed_changed_at = clock.now
+
+    orchestrator._on_state_change(OccupancyState.PRESENT, OccupancyState.AWAY)
+
+    assert orchestrator.erv.calls == [("on", "turbo")]
+    assert orchestrator.db.actions == [("erv", "turbo", "away_adaptive_turbo_CO2=700ppm")]
+
+
+def test_may_21_sensor_replay_emits_at_most_one_transition_after_plateau():
+    thresholds = ThresholdsConfig(
+        co2_turbo_duration_minutes=30,
+        min_away_seconds_before_erv=0,
+        tvoc_away_enabled=False,
+        away_stale_flush_enabled=False,
+        erv_min_dwell_seconds=180,
+    )
+    start = datetime(2026, 5, 21, 7, 45, 20)
+    orchestrator, clock = _build_orchestrator(thresholds, now=start)
+    orchestrator.state_machine.state = OccupancyState.AWAY
+    orchestrator._away_start_time = start - timedelta(minutes=31)
+    orchestrator._erv_running = True
+    orchestrator._erv_speed = "quiet"
+    orchestrator._erv_speed_changed_at = start - timedelta(minutes=10)
+    _append_co2_history(
+        orchestrator,
+        start - timedelta(minutes=10),
+        [517, 516, 517, 518, 519, 518, 518, 517, 517, 518,
+         519, 519, 516, 518, 516, 517, 515, 516, 515, 516],
+    )
+
+    samples = [
+        (0, 517), (4, 516), (31, 517), (34, 518), (61, 519), (64, 518),
+        (93, 518), (94, 517), (124, 517), (124, 518), (154, 519),
+        (156, 519), (184, 516), (185, 518), (214, 516), (217, 517),
+        (244, 515), (248, 516), (274, 515), (278, 516), (304, 513),
+        (309, 514), (334, 514), (341, 513), (364, 513), (371, 513),
+        (394, 513), (402, 512), (424, 512), (434, 512), (454, 512),
+        (464, 511), (484, 513), (495, 513), (514, 514), (526, 514),
+        (544, 513), (559, 513), (574, 513), (588, 512), (604, 514),
+        (619, 514), (634, 514), (650, 513), (664, 513), (681, 513),
+        (694, 512), (712, 511), (724, 512), (743, 512), (754, 510),
+        (775, 511), (784, 510), (805, 511), (814, 511), (836, 512),
+        (844, 512), (867, 512), (874, 512), (899, 512), (904, 512),
+        (929, 512), (934, 511), (960, 511), (964, 510), (991, 510),
+        (994, 511), (1022, 510), (1024, 510), (1053, 509), (1054, 506),
+        (1084, 505), (1084, 506), (1114, 506), (1115, 505), (1144, 508),
+        (1146, 506), (1174, 508), (1177, 508), (1204, 509), (1208, 508),
+        (1234, 509), (1239, 508), (1264, 510), (1270, 510), (1294, 508),
+        (1301, 509), (1324, 507), (1332, 508), (1354, 507),
+    ]
+
+    for offset_seconds, co2 in samples:
+        clock.set(start + timedelta(seconds=offset_seconds))
+        orchestrator.qingping.latest_reading = _reading(co2)
+        orchestrator._co2_history.append((clock.now, co2))
+        orchestrator._evaluate_erv_state()
+
+    assert orchestrator.erv.calls == [("off", None)]
+    assert orchestrator.db.actions == [("erv", "off", "co2_plateau")]
+    assert orchestrator._plateau_detected is True


### PR DESCRIPTION
## Summary
- latch CO2 plateau state until CO2 climbs above the learned outdoor baseline by the configured release delta
- route all ERV speed changes through a dwell-aware helper with safety, manual, critical CO2, shutdown, and presence-transition bypasses
- add regression coverage for the May 21 CO2 replay, dwell suppression, bypass paths, and stale-flush assumptions
- update the Tuya local-key runbook to document command-burst key drift alongside firmware OTA

Fixes #59

## Tests
- python3 -m pytest
