### PR TITLE
Port state machine and climate policy parity

### DIFF
--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
     pub qingping: QingpingConfig,
@@ -50,28 +50,90 @@ impl Default for QingpingConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ThresholdsConfig {
+    pub motion_timeout_seconds: u64,
+    pub departure_verification_seconds: u64,
+    pub door_open_threshold_minutes: u64,
+    pub door_open_away_timeout_minutes: u64,
     pub co2_critical_ppm: i64,
+    pub co2_critical_hysteresis_ppm: i64,
     pub co2_refresh_target_ppm: i64,
+    pub co2_plateau_enabled: bool,
+    pub co2_plateau_rate_threshold: f64,
+    pub co2_plateau_window_minutes: u64,
+    pub co2_plateau_min_co2: i64,
+    pub co2_plateau_release_delta_ppm: i64,
+    pub co2_history_size: usize,
+    pub co2_adaptive_speed_enabled: bool,
+    pub co2_rate_turbo_threshold: f64,
+    pub co2_rate_medium_threshold: f64,
+    pub co2_rate_quiet_threshold: f64,
+    pub co2_turbo_duration_minutes: u64,
+    pub min_away_seconds_before_erv: u64,
+    pub erv_min_dwell_seconds: u64,
+    pub tvoc_away_enabled: bool,
+    pub tvoc_away_threshold: i64,
+    pub tvoc_away_target: i64,
+    pub tvoc_away_history_size: usize,
+    pub tvoc_plateau_rate_threshold: f64,
+    pub tvoc_rate_turbo_threshold: f64,
+    pub tvoc_rate_medium_threshold: f64,
+    pub tvoc_rate_quiet_threshold: f64,
+    pub hvac_min_temp_f: i64,
+    pub hvac_critical_temp_f: i64,
     pub hvac_heat_on_temp_f: i64,
     pub hvac_heat_off_temp_f: i64,
     pub hvac_cool_off_temp_f: i64,
     pub hvac_cool_on_temp_f: i64,
     pub away_stale_flush_enabled: bool,
+    pub away_stale_flush_interval_hours: u64,
+    pub away_stale_flush_duration_minutes: u64,
+    pub away_stale_flush_speed: String,
 }
 
 impl Default for ThresholdsConfig {
     fn default() -> Self {
         Self {
+            motion_timeout_seconds: 60,
+            departure_verification_seconds: 10,
+            door_open_threshold_minutes: 5,
+            door_open_away_timeout_minutes: 5,
             co2_critical_ppm: 2000,
+            co2_critical_hysteresis_ppm: 200,
             co2_refresh_target_ppm: 500,
+            co2_plateau_enabled: true,
+            co2_plateau_rate_threshold: 0.5,
+            co2_plateau_window_minutes: 10,
+            co2_plateau_min_co2: 600,
+            co2_plateau_release_delta_ppm: 100,
+            co2_history_size: 40,
+            co2_adaptive_speed_enabled: true,
+            co2_rate_turbo_threshold: 8.0,
+            co2_rate_medium_threshold: 2.0,
+            co2_rate_quiet_threshold: 0.5,
+            co2_turbo_duration_minutes: 30,
+            min_away_seconds_before_erv: 60,
+            erv_min_dwell_seconds: 180,
+            tvoc_away_enabled: true,
+            tvoc_away_threshold: 200,
+            tvoc_away_target: 40,
+            tvoc_away_history_size: 40,
+            tvoc_plateau_rate_threshold: 0.3,
+            tvoc_rate_turbo_threshold: 5.0,
+            tvoc_rate_medium_threshold: 1.5,
+            tvoc_rate_quiet_threshold: 0.3,
+            hvac_min_temp_f: 68,
+            hvac_critical_temp_f: 55,
             hvac_heat_on_temp_f: 71,
             hvac_heat_off_temp_f: 75,
             hvac_cool_off_temp_f: 78,
             hvac_cool_on_temp_f: 81,
             away_stale_flush_enabled: true,
+            away_stale_flush_interval_hours: 8,
+            away_stale_flush_duration_minutes: 30,
+            away_stale_flush_speed: "medium".to_string(),
         }
     }
 }

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -2,6 +2,8 @@ pub mod cli;
 pub mod config;
 pub mod db;
 pub mod http;
+pub mod policy;
+pub mod state;
 pub mod status;
 
 pub use cli::run_cli;

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -326,6 +326,7 @@ impl ErvPolicyState {
                 let mut co2_speed = None;
                 let mut co2_fallback_turbo = false;
                 let mut tvoc_speed = None;
+                let latest_tvoc = input.tvoc.or_else(|| self.latest_tvoc());
 
                 if co2_needs_refresh {
                     co2_speed =
@@ -340,12 +341,8 @@ impl ErvPolicyState {
                     if tvoc_at_target && self.tvoc_away_ventilation_active {
                         self.tvoc_away_ventilation_active = false;
                         self.tvoc_plateau_detected = false;
-                    } else {
-                        tvoc_speed = self.adaptive_tvoc_speed(
-                            thresholds,
-                            input.tvoc.expect("tVOC required while clearing"),
-                            now,
-                        );
+                    } else if let Some(tvoc) = latest_tvoc {
+                        tvoc_speed = self.adaptive_tvoc_speed(thresholds, tvoc, now);
                         if !self.tvoc_away_ventilation_active && tvoc_needs_clearing {
                             self.tvoc_away_ventilation_active = true;
                         }
@@ -391,7 +388,7 @@ impl ErvPolicyState {
                             }
                         }
                         AwaySource::Tvoc => {
-                            let tvoc = input.tvoc.expect("tVOC source selected");
+                            let tvoc = latest_tvoc.expect("tVOC source selected");
                             format!("away_adaptive_{}_tVOC={tvoc}", target_speed.as_str())
                         }
                         AwaySource::Stale => {
@@ -448,6 +445,10 @@ impl ErvPolicyState {
 
     fn tvoc_rate_of_change(&self) -> Option<f64> {
         rate_of_change(&self.tvoc_history)
+    }
+
+    fn latest_tvoc(&self) -> Option<i64> {
+        self.tvoc_history.back().map(|sample| sample.value)
     }
 
     fn detect_co2_plateau(&mut self, thresholds: &ThresholdsConfig) -> bool {
@@ -1025,6 +1026,51 @@ mod tests {
                 bypass_dwell: false,
             }
         );
+        assert!(policy.tvoc_away_ventilation_active);
+    }
+
+    #[test]
+    fn active_tvoc_ventilation_tolerates_missing_tvoc_reading() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(0.0);
+        policy.record_reading(
+            &thresholds,
+            1_900.0,
+            AirQualityReading {
+                co2_ppm: Some(450),
+                tvoc: Some(250),
+                temp_c: None,
+            },
+        );
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(450), Some(250)), 1_900.0);
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "away_refresh_tVOC=250".to_string(),
+                bypass_dwell: false,
+            }
+        );
+        assert!(policy.tvoc_away_ventilation_active);
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Turbo,
+                tvoc: None,
+                ..away_input(Some(450), None)
+            },
+            1_930.0,
+        );
+
+        assert_eq!(decision, ErvDecision::NoChange);
         assert!(policy.tvoc_away_ventilation_active);
     }
 

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -1,0 +1,1163 @@
+use std::collections::VecDeque;
+
+use crate::{config::ThresholdsConfig, state::OccupancyState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VentilationSpeed {
+    Off,
+    Quiet,
+    Medium,
+    Turbo,
+}
+
+impl VentilationSpeed {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Quiet => "quiet",
+            Self::Medium => "medium",
+            Self::Turbo => "turbo",
+        }
+    }
+
+    fn priority(self) -> i8 {
+        match self {
+            Self::Off => 0,
+            Self::Quiet => 1,
+            Self::Medium => 2,
+            Self::Turbo => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvacBandAction {
+    PauseHeat,
+    ResumeHeat,
+    StartCool,
+    StopCool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvacMode {
+    Off,
+    Heat,
+    Cool,
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ErvPolicyInput {
+    pub occupancy: OccupancyState,
+    pub door_open: bool,
+    pub window_open: bool,
+    pub co2_ppm: Option<i64>,
+    pub tvoc: Option<i64>,
+    pub current_running: bool,
+    pub current_speed: VentilationSpeed,
+    pub manual_override: Option<VentilationSpeed>,
+    pub last_speed_changed_at: Option<f64>,
+    pub bypass_dwell: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErvDecision {
+    NoChange,
+    SuppressedByDwell {
+        target_speed: VentilationSpeed,
+        reason: String,
+    },
+    SetSpeed {
+        target_speed: VentilationSpeed,
+        reason: String,
+        bypass_dwell: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AirQualityReading {
+    pub co2_ppm: Option<i64>,
+    pub tvoc: Option<i64>,
+    pub temp_c: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Sample {
+    at: f64,
+    value: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ErvPolicyState {
+    co2_history: VecDeque<Sample>,
+    tvoc_history: VecDeque<Sample>,
+    pub plateau_detected: bool,
+    pub outdoor_co2_baseline: Option<i64>,
+    pub tvoc_away_ventilation_active: bool,
+    pub tvoc_baseline: Option<i64>,
+    pub tvoc_plateau_detected: bool,
+    pub away_start_at: Option<f64>,
+    pub room_closed_since: Option<f64>,
+    pub room_closed_state_known: bool,
+    pub away_stale_flush_active_until: Option<f64>,
+    pub away_stale_flush_next_due_at: Option<f64>,
+}
+
+impl ErvPolicyState {
+    pub fn new(thresholds: &ThresholdsConfig) -> Self {
+        Self {
+            co2_history: VecDeque::with_capacity(thresholds.co2_history_size),
+            tvoc_history: VecDeque::with_capacity(thresholds.tvoc_away_history_size),
+            plateau_detected: false,
+            outdoor_co2_baseline: None,
+            tvoc_away_ventilation_active: false,
+            tvoc_baseline: None,
+            tvoc_plateau_detected: false,
+            away_start_at: None,
+            room_closed_since: None,
+            room_closed_state_known: false,
+            away_stale_flush_active_until: None,
+            away_stale_flush_next_due_at: None,
+        }
+    }
+
+    pub fn record_reading(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        now: f64,
+        reading: AirQualityReading,
+    ) {
+        if let Some(co2_ppm) = reading.co2_ppm {
+            push_bounded(
+                &mut self.co2_history,
+                thresholds.co2_history_size,
+                Sample {
+                    at: now,
+                    value: co2_ppm,
+                },
+            );
+        }
+
+        if let Some(tvoc) = reading.tvoc {
+            push_bounded(
+                &mut self.tvoc_history,
+                thresholds.tvoc_away_history_size,
+                Sample {
+                    at: now,
+                    value: tvoc,
+                },
+            );
+        }
+    }
+
+    pub fn on_occupancy_transition(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        old_state: OccupancyState,
+        new_state: OccupancyState,
+        now: f64,
+        door_open: bool,
+        window_open: bool,
+    ) {
+        if old_state == new_state {
+            return;
+        }
+
+        if new_state == OccupancyState::Away {
+            self.co2_history.clear();
+            self.tvoc_history.clear();
+            self.plateau_detected = false;
+            self.outdoor_co2_baseline = None;
+            self.away_start_at = Some(now);
+            self.away_stale_flush_active_until = None;
+            self.away_stale_flush_next_due_at = None;
+            self.update_room_closed_tracking(now, door_open, window_open, false);
+            if thresholds.away_stale_flush_enabled && self.room_closed_since.is_some() {
+                let interval = (thresholds.away_stale_flush_interval_hours.max(1) * 3600) as f64;
+                let first_due = self.room_closed_since.expect("room closed since set") + interval;
+                self.away_stale_flush_next_due_at =
+                    Some(if now >= first_due { now } else { first_due });
+            }
+        }
+
+        if new_state == OccupancyState::Present {
+            self.away_start_at = None;
+            self.away_stale_flush_active_until = None;
+            self.away_stale_flush_next_due_at = None;
+            self.tvoc_away_ventilation_active = false;
+            self.tvoc_plateau_detected = false;
+            self.plateau_detected = false;
+            self.outdoor_co2_baseline = None;
+        }
+    }
+
+    pub fn update_room_closed_tracking(
+        &mut self,
+        now: f64,
+        door_open: bool,
+        window_open: bool,
+        mark_state_known: bool,
+    ) {
+        if mark_state_known {
+            self.room_closed_state_known = true;
+        }
+
+        if !self.room_closed_state_known {
+            return;
+        }
+
+        if !door_open && !window_open {
+            if self.room_closed_since.is_none() {
+                self.room_closed_since = Some(now);
+            }
+            return;
+        }
+
+        self.room_closed_since = None;
+        self.away_stale_flush_active_until = None;
+        self.away_stale_flush_next_due_at = None;
+    }
+
+    pub fn decide_erv(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        input: ErvPolicyInput,
+        now: f64,
+    ) -> ErvDecision {
+        if input.window_open || input.door_open {
+            self.tvoc_away_ventilation_active = false;
+            if input.current_running {
+                return target_decision(
+                    thresholds,
+                    &input,
+                    now,
+                    VentilationSpeed::Off,
+                    "safety_interlock".to_string(),
+                    true,
+                );
+            }
+            return ErvDecision::NoChange;
+        }
+
+        if let Some(target_speed) = input.manual_override {
+            return target_decision(
+                thresholds,
+                &input,
+                now,
+                target_speed,
+                "manual_override".to_string(),
+                true,
+            );
+        }
+
+        let co2_critical_on = input
+            .co2_ppm
+            .is_some_and(|co2| co2 >= thresholds.co2_critical_ppm);
+        let co2_critical_off = input.co2_ppm.is_some_and(|co2| {
+            co2 < thresholds.co2_critical_ppm - thresholds.co2_critical_hysteresis_ppm
+        });
+        let co2_needs_refresh = input
+            .co2_ppm
+            .is_some_and(|co2| co2 > thresholds.co2_refresh_target_ppm);
+        let tvoc_needs_clearing = input
+            .tvoc
+            .is_some_and(|tvoc| tvoc > thresholds.tvoc_away_threshold);
+        let tvoc_at_target = input
+            .tvoc
+            .is_some_and(|tvoc| tvoc <= thresholds.tvoc_away_target);
+
+        match input.occupancy {
+            OccupancyState::Present => {
+                if co2_critical_on {
+                    return target_decision(
+                        thresholds,
+                        &input,
+                        now,
+                        VentilationSpeed::Quiet,
+                        format!(
+                            "present_co2_critical_{}ppm",
+                            input.co2_ppm.expect("co2 critical checked")
+                        ),
+                        true,
+                    );
+                }
+
+                if input.current_running && input.current_speed == VentilationSpeed::Quiet {
+                    if co2_critical_off {
+                        return target_decision(
+                            thresholds,
+                            &input,
+                            now,
+                            VentilationSpeed::Off,
+                            format!(
+                                "present_co2_hysteresis_{}ppm",
+                                input.co2_ppm.expect("co2 off checked")
+                            ),
+                            input.bypass_dwell,
+                        );
+                    }
+                    return ErvDecision::NoChange;
+                }
+
+                if input.current_running {
+                    return target_decision(
+                        thresholds,
+                        &input,
+                        now,
+                        VentilationSpeed::Off,
+                        "present_air_quality_ok".to_string(),
+                        input.bypass_dwell,
+                    );
+                }
+
+                ErvDecision::NoChange
+            }
+            OccupancyState::Away => {
+                if self.initial_away_settle_active(thresholds, now) {
+                    return ErvDecision::NoChange;
+                }
+
+                let stale_speed = self.away_stale_flush_speed_if_active(
+                    thresholds,
+                    now,
+                    input.door_open,
+                    input.window_open,
+                );
+                let mut co2_speed = None;
+                let mut co2_fallback_turbo = false;
+                let mut tvoc_speed = None;
+
+                if co2_needs_refresh {
+                    co2_speed =
+                        self.adaptive_co2_speed(thresholds, input.co2_ppm.expect("co2"), now);
+                    if co2_speed.is_none() {
+                        co2_speed = Some(VentilationSpeed::Turbo);
+                        co2_fallback_turbo = true;
+                    }
+                }
+
+                if tvoc_needs_clearing || self.tvoc_away_ventilation_active {
+                    if tvoc_at_target && self.tvoc_away_ventilation_active {
+                        self.tvoc_away_ventilation_active = false;
+                        self.tvoc_plateau_detected = false;
+                    } else {
+                        tvoc_speed = self.adaptive_tvoc_speed(
+                            thresholds,
+                            input.tvoc.expect("tVOC required while clearing"),
+                            now,
+                        );
+                        if !self.tvoc_away_ventilation_active && tvoc_needs_clearing {
+                            self.tvoc_away_ventilation_active = true;
+                        }
+                    }
+                }
+
+                if stale_speed.is_none()
+                    && co2_speed == Some(VentilationSpeed::Off)
+                    && (tvoc_speed == Some(VentilationSpeed::Off)
+                        || !self.tvoc_away_ventilation_active)
+                {
+                    if input.current_running {
+                        let reason = if self.plateau_detected {
+                            "co2_plateau"
+                        } else {
+                            "targets_reached"
+                        };
+                        return target_decision(
+                            thresholds,
+                            &input,
+                            now,
+                            VentilationSpeed::Off,
+                            reason.to_string(),
+                            input.bypass_dwell,
+                        );
+                    }
+                    return ErvDecision::NoChange;
+                }
+
+                let selected = select_away_candidate(co2_speed, tvoc_speed, stale_speed);
+                if let Some((source, target_speed)) = selected {
+                    if target_speed == VentilationSpeed::Off {
+                        return ErvDecision::NoChange;
+                    }
+
+                    let reason = match source {
+                        AwaySource::Co2 => {
+                            let co2 = input.co2_ppm.expect("co2 source selected");
+                            if co2_fallback_turbo {
+                                format!("away_refresh_CO2={co2}ppm")
+                            } else {
+                                format!("away_adaptive_{}_CO2={co2}ppm", target_speed.as_str())
+                            }
+                        }
+                        AwaySource::Tvoc => {
+                            let tvoc = input.tvoc.expect("tVOC source selected");
+                            format!("away_adaptive_{}_tVOC={tvoc}", target_speed.as_str())
+                        }
+                        AwaySource::Stale => {
+                            format!("away_stale_flush_{}", target_speed.as_str())
+                        }
+                    };
+                    let bypass = input.bypass_dwell
+                        || (source == AwaySource::Co2
+                            && target_speed == VentilationSpeed::Turbo
+                            && self.initial_away_turbo_active(thresholds, now));
+
+                    return target_decision(thresholds, &input, now, target_speed, reason, bypass);
+                }
+
+                if !co2_needs_refresh
+                    && !self.tvoc_away_ventilation_active
+                    && stale_speed.is_none()
+                    && input.current_running
+                {
+                    return target_decision(
+                        thresholds,
+                        &input,
+                        now,
+                        VentilationSpeed::Off,
+                        "air_quality_ok".to_string(),
+                        input.bypass_dwell,
+                    );
+                }
+
+                if co2_needs_refresh || tvoc_needs_clearing {
+                    let trigger = if co2_needs_refresh {
+                        format!("CO2={}ppm", input.co2_ppm.expect("co2 trigger"))
+                    } else {
+                        format!("tVOC={}", input.tvoc.expect("tVOC trigger"))
+                    };
+                    return target_decision(
+                        thresholds,
+                        &input,
+                        now,
+                        VentilationSpeed::Turbo,
+                        format!("away_refresh_{trigger}"),
+                        input.bypass_dwell || self.initial_away_turbo_active(thresholds, now),
+                    );
+                }
+
+                ErvDecision::NoChange
+            }
+        }
+    }
+
+    fn co2_rate_of_change(&self) -> Option<f64> {
+        rate_of_change(&self.co2_history)
+    }
+
+    fn tvoc_rate_of_change(&self) -> Option<f64> {
+        rate_of_change(&self.tvoc_history)
+    }
+
+    fn detect_co2_plateau(&mut self, thresholds: &ThresholdsConfig) -> bool {
+        if !thresholds.co2_plateau_enabled {
+            return false;
+        }
+
+        let current_co2 = self.co2_history.back().map(|sample| sample.value);
+        if self.plateau_detected && self.outdoor_co2_baseline.is_none() {
+            self.plateau_detected = false;
+        }
+
+        if self.plateau_detected {
+            if let (Some(current), Some(baseline)) = (current_co2, self.outdoor_co2_baseline) {
+                if current < baseline + thresholds.co2_plateau_release_delta_ppm {
+                    return true;
+                }
+                self.plateau_detected = false;
+                self.outdoor_co2_baseline = None;
+            } else {
+                return true;
+            }
+        }
+
+        let min_readings = 20.max((thresholds.co2_plateau_window_minutes * 2) as usize);
+        if self.co2_history.len() < min_readings {
+            return false;
+        }
+
+        let current_co2 = current_co2.expect("history has readings");
+        if current_co2 > thresholds.co2_plateau_min_co2 {
+            return false;
+        }
+
+        let Some(rate) = self.co2_rate_of_change() else {
+            return false;
+        };
+
+        if rate.abs() < thresholds.co2_plateau_rate_threshold {
+            self.outdoor_co2_baseline = Some(current_co2);
+            self.plateau_detected = true;
+            return true;
+        }
+
+        false
+    }
+
+    fn adaptive_co2_speed(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        _co2: i64,
+        now: f64,
+    ) -> Option<VentilationSpeed> {
+        if !thresholds.co2_adaptive_speed_enabled {
+            return None;
+        }
+
+        if self.detect_co2_plateau(thresholds) {
+            return Some(VentilationSpeed::Off);
+        }
+
+        if self.initial_away_turbo_active(thresholds, now) {
+            return Some(VentilationSpeed::Turbo);
+        }
+
+        let rate = self.co2_rate_of_change()?;
+        let abs_rate = rate.abs();
+        if abs_rate > thresholds.co2_rate_turbo_threshold {
+            Some(VentilationSpeed::Turbo)
+        } else if abs_rate > thresholds.co2_rate_medium_threshold {
+            Some(VentilationSpeed::Medium)
+        } else if abs_rate > thresholds.co2_rate_quiet_threshold {
+            Some(VentilationSpeed::Quiet)
+        } else {
+            Some(VentilationSpeed::Quiet)
+        }
+    }
+
+    fn detect_tvoc_plateau(&mut self, thresholds: &ThresholdsConfig) -> bool {
+        if !thresholds.tvoc_away_enabled || self.tvoc_history.len() < 20 {
+            return false;
+        }
+
+        let current_tvoc = self
+            .tvoc_history
+            .back()
+            .expect("history has readings")
+            .value;
+        if current_tvoc > thresholds.tvoc_away_target + 20 {
+            return false;
+        }
+
+        let Some(rate) = self.tvoc_rate_of_change() else {
+            return false;
+        };
+        if rate.abs() < thresholds.tvoc_plateau_rate_threshold {
+            self.tvoc_baseline = Some(current_tvoc);
+            return true;
+        }
+
+        false
+    }
+
+    fn adaptive_tvoc_speed(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        _tvoc: i64,
+        now: f64,
+    ) -> Option<VentilationSpeed> {
+        if !thresholds.tvoc_away_enabled {
+            return None;
+        }
+
+        if self.initial_away_turbo_active(thresholds, now) {
+            return Some(VentilationSpeed::Turbo);
+        }
+
+        if self.detect_tvoc_plateau(thresholds) {
+            self.tvoc_plateau_detected = true;
+            return Some(VentilationSpeed::Off);
+        }
+
+        let rate = self.tvoc_rate_of_change()?;
+        let abs_rate = rate.abs();
+        if abs_rate > thresholds.tvoc_rate_turbo_threshold {
+            Some(VentilationSpeed::Turbo)
+        } else if abs_rate > thresholds.tvoc_rate_medium_threshold {
+            Some(VentilationSpeed::Medium)
+        } else if abs_rate > thresholds.tvoc_rate_quiet_threshold {
+            Some(VentilationSpeed::Quiet)
+        } else {
+            Some(VentilationSpeed::Quiet)
+        }
+    }
+
+    fn away_stale_flush_speed_if_active(
+        &mut self,
+        thresholds: &ThresholdsConfig,
+        now: f64,
+        door_open: bool,
+        window_open: bool,
+    ) -> Option<VentilationSpeed> {
+        if !thresholds.away_stale_flush_enabled {
+            self.away_stale_flush_active_until = None;
+            self.away_stale_flush_next_due_at = None;
+            return None;
+        }
+
+        self.update_room_closed_tracking(now, door_open, window_open, false);
+        self.room_closed_since?;
+
+        let interval = (thresholds.away_stale_flush_interval_hours.max(1) * 3600) as f64;
+        let duration = (thresholds.away_stale_flush_duration_minutes.max(1) * 60) as f64;
+
+        if self.away_stale_flush_next_due_at.is_none() {
+            let first_due = self.room_closed_since.expect("room closed") + interval;
+            self.away_stale_flush_next_due_at =
+                Some(if now >= first_due { now } else { first_due });
+        }
+
+        if self
+            .away_stale_flush_active_until
+            .is_some_and(|active_until| now >= active_until)
+        {
+            self.away_stale_flush_active_until = None;
+        }
+
+        if self.away_stale_flush_active_until.is_none()
+            && self
+                .away_stale_flush_next_due_at
+                .is_some_and(|next_due| now >= next_due)
+        {
+            self.away_stale_flush_active_until = Some(now + duration);
+            self.away_stale_flush_next_due_at = Some(now + interval);
+        }
+
+        if self
+            .away_stale_flush_active_until
+            .is_some_and(|active_until| now < active_until)
+        {
+            return Some(stale_flush_speed(thresholds));
+        }
+
+        None
+    }
+
+    fn initial_away_settle_active(&self, thresholds: &ThresholdsConfig, now: f64) -> bool {
+        thresholds.min_away_seconds_before_erv > 0
+            && self.away_start_at.is_some_and(|started_at| {
+                now - started_at < thresholds.min_away_seconds_before_erv as f64
+            })
+    }
+
+    fn initial_away_turbo_active(&self, thresholds: &ThresholdsConfig, now: f64) -> bool {
+        self.away_start_at.is_some_and(|started_at| {
+            (now - started_at) / 60.0 < thresholds.co2_turbo_duration_minutes as f64
+        })
+    }
+}
+
+pub fn get_hvac_band_action(
+    temp_f: Option<f64>,
+    hvac_mode: HvacMode,
+    temp_band_mode: Option<HvacMode>,
+    state: OccupancyState,
+    erv_running: bool,
+    min_temp_f: f64,
+    within_occupancy_hours: bool,
+    heat_off_temp_f: f64,
+    heat_on_temp_f: f64,
+    cool_on_temp_f: f64,
+    cool_off_temp_f: f64,
+) -> Option<HvacBandAction> {
+    let temp_f = temp_f?;
+
+    if hvac_mode == HvacMode::Heat && temp_f >= heat_off_temp_f {
+        return Some(HvacBandAction::PauseHeat);
+    }
+
+    if hvac_mode == HvacMode::Cool && temp_f <= cool_off_temp_f {
+        return Some(HvacBandAction::StopCool);
+    }
+
+    if hvac_mode != HvacMode::Off {
+        return None;
+    }
+
+    if temp_band_mode == Some(HvacMode::Heat) && temp_f <= heat_on_temp_f {
+        if state == OccupancyState::Away {
+            if erv_running && temp_f > min_temp_f {
+                return None;
+            }
+            if !within_occupancy_hours {
+                return None;
+            }
+        }
+
+        return Some(HvacBandAction::ResumeHeat);
+    }
+
+    if state == OccupancyState::Present && temp_f > cool_on_temp_f {
+        return Some(HvacBandAction::StartCool);
+    }
+
+    None
+}
+
+fn target_decision(
+    thresholds: &ThresholdsConfig,
+    input: &ErvPolicyInput,
+    now: f64,
+    target_speed: VentilationSpeed,
+    reason: String,
+    bypass_dwell: bool,
+) -> ErvDecision {
+    if target_speed == VentilationSpeed::Off && !input.current_running {
+        return ErvDecision::NoChange;
+    }
+    if target_speed != VentilationSpeed::Off
+        && input.current_running
+        && input.current_speed == target_speed
+    {
+        return ErvDecision::NoChange;
+    }
+
+    if !bypass_dwell
+        && thresholds.erv_min_dwell_seconds > 0
+        && input
+            .last_speed_changed_at
+            .is_some_and(|changed_at| now - changed_at < thresholds.erv_min_dwell_seconds as f64)
+    {
+        return ErvDecision::SuppressedByDwell {
+            target_speed,
+            reason,
+        };
+    }
+
+    ErvDecision::SetSpeed {
+        target_speed,
+        reason,
+        bypass_dwell,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AwaySource {
+    Co2,
+    Tvoc,
+    Stale,
+}
+
+fn select_away_candidate(
+    co2_speed: Option<VentilationSpeed>,
+    tvoc_speed: Option<VentilationSpeed>,
+    stale_speed: Option<VentilationSpeed>,
+) -> Option<(AwaySource, VentilationSpeed)> {
+    [
+        (AwaySource::Co2, co2_speed, 3_i8),
+        (AwaySource::Tvoc, tvoc_speed, 2_i8),
+        (AwaySource::Stale, stale_speed, 1_i8),
+    ]
+    .into_iter()
+    .filter_map(|(source, speed, source_priority)| {
+        speed.map(|speed| (source, speed, speed.priority(), source_priority))
+    })
+    .max_by_key(|(_, _, speed_priority, source_priority)| (*speed_priority, *source_priority))
+    .map(|(source, speed, _, _)| (source, speed))
+}
+
+fn push_bounded(queue: &mut VecDeque<Sample>, max_len: usize, sample: Sample) {
+    let max_len = max_len.max(1);
+    if queue.len() >= max_len {
+        queue.pop_front();
+    }
+    queue.push_back(sample);
+}
+
+fn rate_of_change(queue: &VecDeque<Sample>) -> Option<f64> {
+    let oldest = queue.front()?;
+    let newest = queue.back()?;
+    let minutes = (newest.at - oldest.at) / 60.0;
+    if minutes == 0.0 {
+        return None;
+    }
+    Some((newest.value - oldest.value) as f64 / minutes)
+}
+
+fn stale_flush_speed(thresholds: &ThresholdsConfig) -> VentilationSpeed {
+    match thresholds
+        .away_stale_flush_speed
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "quiet" => VentilationSpeed::Quiet,
+        "turbo" => VentilationSpeed::Turbo,
+        _ => VentilationSpeed::Medium,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn away_input(co2_ppm: Option<i64>, tvoc: Option<i64>) -> ErvPolicyInput {
+        ErvPolicyInput {
+            occupancy: OccupancyState::Away,
+            door_open: false,
+            window_open: false,
+            co2_ppm,
+            tvoc,
+            current_running: false,
+            current_speed: VentilationSpeed::Off,
+            manual_override: None,
+            last_speed_changed_at: None,
+            bypass_dwell: false,
+        }
+    }
+
+    #[test]
+    fn safety_interlock_turns_running_erv_off_with_dwell_bypass() {
+        let thresholds = ThresholdsConfig::default();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                door_open: true,
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                last_speed_changed_at: Some(1_000.0),
+                ..away_input(Some(700), None)
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Off,
+                reason: "safety_interlock".to_string(),
+                bypass_dwell: true,
+            }
+        );
+    }
+
+    #[test]
+    fn manual_override_returns_target_without_device_write() {
+        let thresholds = ThresholdsConfig::default();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                manual_override: Some(VentilationSpeed::Turbo),
+                last_speed_changed_at: Some(1_000.0),
+                ..away_input(Some(450), None)
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "manual_override".to_string(),
+                bypass_dwell: true,
+            }
+        );
+    }
+
+    #[test]
+    fn present_mode_uses_co2_hysteresis_and_ignores_tvoc() {
+        let thresholds = ThresholdsConfig::default();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(2_000),
+                tvoc: Some(500),
+                current_running: false,
+                current_speed: VentilationSpeed::Off,
+                manual_override: None,
+                door_open: false,
+                window_open: false,
+                last_speed_changed_at: Some(1_000.0),
+                bypass_dwell: false,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "present_co2_critical_2000ppm".to_string(),
+                bypass_dwell: true,
+            }
+        );
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(1_799),
+                tvoc: Some(500),
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                manual_override: None,
+                door_open: false,
+                window_open: false,
+                last_speed_changed_at: Some(1_000.0),
+                bypass_dwell: true,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Off,
+                reason: "present_co2_hysteresis_1799ppm".to_string(),
+                bypass_dwell: true,
+            }
+        );
+    }
+
+    #[test]
+    fn away_settle_window_holds_prior_erv_state() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 60,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(1_000.0);
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(900), None), 1_030.0);
+
+        assert_eq!(decision, ErvDecision::NoChange);
+    }
+
+    #[test]
+    fn away_high_co2_falls_back_to_turbo_until_adaptive_history_exists() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(0.0);
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(700), None), 1_901.0);
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "away_refresh_CO2=700ppm".to_string(),
+                bypass_dwell: false,
+            }
+        );
+    }
+
+    #[test]
+    fn co2_plateau_latches_until_baseline_delta_release() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 0,
+            co2_plateau_release_delta_ppm: 100,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(0.0);
+        for index in 0..24 {
+            let value = [512, 513, 511, 512][index % 4];
+            policy.record_reading(
+                &thresholds,
+                index as f64 * 30.0,
+                AirQualityReading {
+                    co2_ppm: Some(value),
+                    tvoc: None,
+                    temp_c: None,
+                },
+            );
+        }
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                ..away_input(Some(512), None)
+            },
+            720.0,
+        );
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Off,
+                reason: "co2_plateau".to_string(),
+                bypass_dwell: false,
+            }
+        );
+        assert!(policy.plateau_detected);
+        assert_eq!(policy.outdoor_co2_baseline, Some(512));
+
+        policy.record_reading(
+            &thresholds,
+            750.0,
+            AirQualityReading {
+                co2_ppm: Some(612),
+                tvoc: None,
+                temp_c: None,
+            },
+        );
+        assert!(!policy.detect_co2_plateau(&thresholds));
+        assert!(!policy.plateau_detected);
+    }
+
+    #[test]
+    fn away_tvoc_high_falls_back_to_turbo_when_adaptive_history_is_missing() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(0.0);
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(450), Some(250)), 1_900.0);
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "away_refresh_tVOC=250".to_string(),
+                bypass_dwell: false,
+            }
+        );
+        assert!(policy.tvoc_away_ventilation_active);
+    }
+
+    #[test]
+    fn stale_flush_runs_at_configured_speed_but_loses_to_co2_turbo() {
+        let thresholds = ThresholdsConfig {
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: true,
+            away_stale_flush_interval_hours: 8,
+            away_stale_flush_duration_minutes: 30,
+            away_stale_flush_speed: "medium".to_string(),
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.room_closed_state_known = true;
+        policy.room_closed_since = Some(0.0);
+        policy.away_stale_flush_next_due_at = Some(100.0);
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(450), Some(20)), 101.0);
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Medium,
+                reason: "away_stale_flush_medium".to_string(),
+                bypass_dwell: false,
+            }
+        );
+
+        let decision = policy.decide_erv(&thresholds, away_input(Some(700), Some(20)), 102.0);
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "away_refresh_CO2=700ppm".to_string(),
+                bypass_dwell: false,
+            }
+        );
+    }
+
+    #[test]
+    fn dwell_suppresses_non_bypassed_speed_change_without_side_effects() {
+        let thresholds = ThresholdsConfig {
+            erv_min_dwell_seconds: 180,
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                last_speed_changed_at: Some(1_000.0),
+                ..away_input(Some(450), None)
+            },
+            1_010.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SuppressedByDwell {
+                target_speed: VentilationSpeed::Off,
+                reason: "air_quality_ok".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn hvac_band_action_matches_python_helper() {
+        assert_eq!(
+            get_hvac_band_action(
+                Some(75.2),
+                HvacMode::Heat,
+                None,
+                OccupancyState::Present,
+                false,
+                68.0,
+                true,
+                75.0,
+                71.0,
+                81.0,
+                78.0,
+            ),
+            Some(HvacBandAction::PauseHeat)
+        );
+        assert_eq!(
+            get_hvac_band_action(
+                Some(70.0),
+                HvacMode::Off,
+                Some(HvacMode::Heat),
+                OccupancyState::Away,
+                true,
+                68.0,
+                true,
+                75.0,
+                71.0,
+                81.0,
+                78.0,
+            ),
+            None
+        );
+        assert_eq!(
+            get_hvac_band_action(
+                Some(81.1),
+                HvacMode::Off,
+                None,
+                OccupancyState::Present,
+                false,
+                68.0,
+                true,
+                75.0,
+                71.0,
+                81.0,
+                78.0,
+            ),
+            Some(HvacBandAction::StartCool)
+        );
+        assert_eq!(
+            get_hvac_band_action(
+                Some(78.0),
+                HvacMode::Cool,
+                None,
+                OccupancyState::Present,
+                false,
+                68.0,
+                true,
+                75.0,
+                71.0,
+                81.0,
+                78.0,
+            ),
+            Some(HvacBandAction::StopCool)
+        );
+    }
+}

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -1,0 +1,580 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::ThresholdsConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OccupancyState {
+    Present,
+    Away,
+}
+
+impl OccupancyState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Away => "away",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StateConfig {
+    pub motion_timeout_seconds: f64,
+    pub departure_verification_seconds: f64,
+    pub door_open_threshold_minutes: f64,
+    pub door_open_away_timeout_minutes: f64,
+    pub co2_critical_ppm: i64,
+    pub co2_refresh_target_ppm: i64,
+}
+
+impl StateConfig {
+    pub fn from_thresholds(thresholds: &ThresholdsConfig) -> Self {
+        Self {
+            motion_timeout_seconds: thresholds.motion_timeout_seconds as f64,
+            departure_verification_seconds: thresholds.departure_verification_seconds as f64,
+            door_open_threshold_minutes: thresholds.door_open_threshold_minutes as f64,
+            door_open_away_timeout_minutes: thresholds.door_open_away_timeout_minutes as f64,
+            co2_critical_ppm: thresholds.co2_critical_ppm,
+            co2_refresh_target_ppm: thresholds.co2_refresh_target_ppm,
+        }
+    }
+}
+
+impl Default for StateConfig {
+    fn default() -> Self {
+        Self {
+            motion_timeout_seconds: 60.0,
+            departure_verification_seconds: 10.0,
+            door_open_threshold_minutes: 5.0,
+            door_open_away_timeout_minutes: 5.0,
+            co2_critical_ppm: 2000,
+            co2_refresh_target_ppm: 500,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SensorState {
+    pub mac_last_active: f64,
+    pub external_monitor: bool,
+    pub motion_detected: bool,
+    pub motion_last_seen: f64,
+    pub door_open: bool,
+    pub door_last_changed: f64,
+    pub window_open: bool,
+    pub co2_ppm: i64,
+    pub last_updated: f64,
+}
+
+impl Default for SensorState {
+    fn default() -> Self {
+        Self {
+            mac_last_active: 0.0,
+            external_monitor: false,
+            motion_detected: false,
+            motion_last_seen: 0.0,
+            door_open: false,
+            door_last_changed: 0.0,
+            window_open: false,
+            co2_ppm: 400,
+            last_updated: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateTransition {
+    pub old_state: OccupancyState,
+    pub new_state: OccupancyState,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StateStatus {
+    pub state: String,
+    pub is_present: bool,
+    pub presence_signal_active: bool,
+    pub safety_interlock: bool,
+    pub erv_should_run: bool,
+    pub verifying_departure: bool,
+    pub in_door_open_mode: bool,
+    pub sensors: StateStatusSensors,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct StateStatusSensors {
+    pub mac_last_active: f64,
+    pub external_monitor: bool,
+    pub motion_detected: bool,
+    pub door_open: bool,
+    pub window_open: bool,
+    pub co2_ppm: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateMachine {
+    pub config: StateConfig,
+    pub state: OccupancyState,
+    pub sensors: SensorState,
+    last_door_state: Option<bool>,
+    departure_verification_deadline: Option<f64>,
+    door_open_away_deadline: Option<f64>,
+    suppress_next_door_close_departure: bool,
+    last_activity_time: f64,
+}
+
+impl StateMachine {
+    pub fn new(config: StateConfig, now: f64) -> Self {
+        Self {
+            config,
+            state: OccupancyState::Away,
+            sensors: SensorState {
+                last_updated: now,
+                ..SensorState::default()
+            },
+            last_door_state: None,
+            departure_verification_deadline: None,
+            door_open_away_deadline: None,
+            suppress_next_door_close_departure: false,
+            last_activity_time: now,
+        }
+    }
+
+    pub fn from_thresholds(thresholds: &ThresholdsConfig, now: f64) -> Self {
+        Self::new(StateConfig::from_thresholds(thresholds), now)
+    }
+
+    pub fn in_door_open_mode_at(&self, now: f64) -> bool {
+        self.sensors.door_open
+            && (now - self.sensors.door_last_changed) / 60.0
+                >= self.config.door_open_threshold_minutes
+    }
+
+    pub fn presence_signal_active_at(&self, now: f64) -> bool {
+        if self.in_door_open_mode_at(now) {
+            let motion_age = now - self.sensors.motion_last_seen;
+            let motion_recent =
+                self.sensors.motion_detected || motion_age < self.config.motion_timeout_seconds;
+            let mac_recent = self.sensors.external_monitor && self.sensors.mac_last_active > 0.0;
+            return mac_recent || motion_recent;
+        }
+
+        let mac_presence = self.sensors.external_monitor
+            && self.sensors.mac_last_active > self.sensors.door_last_changed;
+        let motion_age = now - self.sensors.motion_last_seen;
+        let motion_recent =
+            self.sensors.motion_detected || motion_age < self.config.motion_timeout_seconds;
+        let motion_inside = motion_recent
+            && !self.sensors.door_open
+            && self.sensors.motion_last_seen > self.sensors.door_last_changed;
+
+        mac_presence || motion_inside
+    }
+
+    pub fn safety_interlock_active(&self) -> bool {
+        self.sensors.window_open || self.sensors.door_open
+    }
+
+    pub fn erv_should_run(&self) -> bool {
+        if self.safety_interlock_active() {
+            return false;
+        }
+
+        match self.state {
+            OccupancyState::Present => self.sensors.co2_ppm > self.config.co2_critical_ppm,
+            OccupancyState::Away => self.sensors.co2_ppm > self.config.co2_refresh_target_ppm,
+        }
+    }
+
+    pub fn verifying_departure(&self) -> bool {
+        self.departure_verification_deadline.is_some()
+    }
+
+    pub fn advance_timers(&mut self, now: f64) -> Option<StateTransition> {
+        if self
+            .departure_verification_deadline
+            .is_some_and(|deadline| now >= deadline)
+        {
+            self.departure_verification_deadline = None;
+            if self.state == OccupancyState::Present {
+                let transition = self.transition_to(OccupancyState::Away);
+                self.sensors.motion_last_seen = 0.0;
+                self.sensors.motion_detected = false;
+                if transition.is_some() {
+                    return transition;
+                }
+            }
+        }
+
+        if self
+            .door_open_away_deadline
+            .is_some_and(|deadline| now >= deadline)
+        {
+            self.door_open_away_deadline = None;
+            if self.state == OccupancyState::Present && self.in_door_open_mode_at(now) {
+                return self.transition_to(OccupancyState::Away);
+            }
+        }
+
+        None
+    }
+
+    pub fn evaluate_at(&mut self, now: f64) -> Option<StateTransition> {
+        if let Some(transition) = self.advance_timers(now) {
+            return Some(transition);
+        }
+
+        let transition = if self.in_door_open_mode_at(now) {
+            if self.state == OccupancyState::Away && self.presence_signal_active_at(now) {
+                let transition = self.transition_to(OccupancyState::Present);
+                self.start_door_open_away_timer(now);
+                transition
+            } else {
+                if self.state == OccupancyState::Present && self.presence_signal_active_at(now) {
+                    self.start_door_open_away_timer(now);
+                }
+                None
+            }
+        } else if self.state == OccupancyState::Away && self.presence_signal_active_at(now) {
+            self.transition_to(OccupancyState::Present)
+        } else {
+            None
+        };
+
+        self.last_door_state = Some(self.sensors.door_open);
+        transition
+    }
+
+    pub fn update_mac_occupancy(
+        &mut self,
+        last_active_timestamp: f64,
+        external_monitor: bool,
+        now: f64,
+    ) -> Option<StateTransition> {
+        let timer_transition = self.advance_timers(now);
+
+        self.sensors.external_monitor = external_monitor;
+        self.sensors.mac_last_active = last_active_timestamp;
+        self.sensors.last_updated = now;
+
+        if last_active_timestamp > self.sensors.door_last_changed && self.verifying_departure() {
+            self.cancel_departure_verification();
+        }
+
+        self.evaluate_at(now).or(timer_transition)
+    }
+
+    pub fn update_motion(&mut self, detected: bool, now: f64) -> Option<StateTransition> {
+        let timer_transition = self.advance_timers(now);
+
+        self.sensors.motion_detected = detected;
+        if detected {
+            self.sensors.motion_last_seen = now;
+            self.last_activity_time = now;
+            if self.verifying_departure() {
+                self.cancel_departure_verification();
+            }
+        }
+        self.sensors.last_updated = now;
+
+        self.evaluate_at(now).or(timer_transition)
+    }
+
+    pub fn update_door(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        let timer_transition = self.advance_timers(now);
+        let was_open = self.last_door_state;
+
+        self.sensors.door_open = is_open;
+        self.sensors.door_last_changed = now;
+        self.sensors.last_updated = now;
+
+        if !is_open && self.suppress_next_door_close_departure {
+            self.cancel_door_open_away_timer();
+            self.suppress_next_door_close_departure = false;
+        } else if was_open == Some(true) && !is_open {
+            self.cancel_door_open_away_timer();
+            self.start_departure_verification(now);
+        }
+
+        timer_transition.or_else(|| self.evaluate_at(now))
+    }
+
+    pub fn update_window(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        let timer_transition = self.advance_timers(now);
+
+        self.sensors.window_open = is_open;
+        self.sensors.last_updated = now;
+        self.evaluate_at(now).or(timer_transition)
+    }
+
+    pub fn set_manual_presence(&mut self, present: bool, now: f64) -> Option<StateTransition> {
+        self.advance_timers(now);
+        let old_state = self.state;
+
+        if present {
+            self.sensors.motion_detected = true;
+            self.sensors.motion_last_seen = now;
+            self.last_activity_time = now;
+            if self.verifying_departure() {
+                self.cancel_departure_verification();
+            }
+            if self.sensors.door_open {
+                self.suppress_next_door_close_departure = true;
+            }
+            self.sensors.last_updated = now;
+            self.state = OccupancyState::Present;
+            self.last_door_state = Some(self.sensors.door_open);
+            if self.sensors.door_open {
+                self.start_door_open_away_timer(now);
+            }
+            return (old_state != self.state).then_some(StateTransition {
+                old_state,
+                new_state: self.state,
+            });
+        }
+
+        self.cancel_departure_verification();
+        self.cancel_door_open_away_timer();
+        self.suppress_next_door_close_departure = false;
+        self.sensors.motion_detected = false;
+        self.sensors.motion_last_seen = 0.0;
+        self.sensors.door_last_changed = now;
+        self.sensors.last_updated = now;
+        self.state = OccupancyState::Away;
+        self.last_door_state = Some(self.sensors.door_open);
+
+        (old_state != self.state).then_some(StateTransition {
+            old_state,
+            new_state: self.state,
+        })
+    }
+
+    pub fn update_co2(&mut self, ppm: i64, now: f64) {
+        self.sensors.co2_ppm = ppm;
+        self.sensors.last_updated = now;
+    }
+
+    pub fn status_at(&self, now: f64) -> StateStatus {
+        StateStatus {
+            state: self.state.as_str().to_string(),
+            is_present: self.state == OccupancyState::Present,
+            presence_signal_active: self.presence_signal_active_at(now),
+            safety_interlock: self.safety_interlock_active(),
+            erv_should_run: self.erv_should_run(),
+            verifying_departure: self.verifying_departure(),
+            in_door_open_mode: self.in_door_open_mode_at(now),
+            sensors: StateStatusSensors {
+                mac_last_active: self.sensors.mac_last_active,
+                external_monitor: self.sensors.external_monitor,
+                motion_detected: self.sensors.motion_detected,
+                door_open: self.sensors.door_open,
+                window_open: self.sensors.window_open,
+                co2_ppm: self.sensors.co2_ppm,
+            },
+        }
+    }
+
+    fn transition_to(&mut self, new_state: OccupancyState) -> Option<StateTransition> {
+        let old_state = self.state;
+        if old_state == new_state {
+            return None;
+        }
+        self.state = new_state;
+        Some(StateTransition {
+            old_state,
+            new_state,
+        })
+    }
+
+    fn start_departure_verification(&mut self, now: f64) {
+        if self.state == OccupancyState::Present {
+            self.departure_verification_deadline =
+                Some(now + self.config.departure_verification_seconds);
+        }
+    }
+
+    fn cancel_departure_verification(&mut self) {
+        self.departure_verification_deadline = None;
+    }
+
+    fn start_door_open_away_timer(&mut self, now: f64) {
+        if self.state == OccupancyState::Present {
+            self.door_open_away_deadline =
+                Some(now + self.config.door_open_away_timeout_minutes * 60.0);
+        }
+    }
+
+    fn cancel_door_open_away_timer(&mut self) {
+        self.door_open_away_deadline = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mac_activity_after_door_event_transitions_to_present() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.sensors.door_last_changed = 1_010.0;
+
+        assert_eq!(machine.update_mac_occupancy(1_005.0, true, 1_020.0), None);
+        assert_eq!(machine.state, OccupancyState::Away);
+
+        let transition = machine.update_mac_occupancy(1_021.0, true, 1_021.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+    }
+
+    #[test]
+    fn motion_only_counts_after_door_event_and_when_door_closed() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.sensors.door_last_changed = 1_050.0;
+        machine.sensors.motion_last_seen = 1_040.0;
+
+        assert_eq!(machine.evaluate_at(1_060.0), None);
+        assert_eq!(machine.state, OccupancyState::Away);
+
+        assert!(machine.update_motion(true, 1_061.0).is_some());
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        machine.state = OccupancyState::Away;
+        machine.sensors.door_open = true;
+        assert_eq!(machine.update_motion(true, 1_070.0), None);
+        assert_eq!(machine.state, OccupancyState::Away);
+    }
+
+    #[test]
+    fn departure_verification_expires_to_away_and_resets_motion() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        assert_eq!(machine.advance_timers(1_029.0), None);
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        let transition = machine.advance_timers(1_030.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert!(!machine.sensors.motion_detected);
+        assert_eq!(machine.sensors.motion_last_seen, 0.0);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn mac_activity_cancels_departure_verification() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_door(false, 1_020.0);
+
+        machine.update_mac_occupancy(1_021.0, true, 1_022.0);
+
+        assert!(!machine.verifying_departure());
+        assert_eq!(machine.advance_timers(1_040.0), None);
+        assert_eq!(machine.state, OccupancyState::Present);
+    }
+
+    #[test]
+    fn fresh_mac_update_after_departure_timer_restores_present() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_door(false, 1_020.0);
+
+        machine.update_mac_occupancy(1_031.0, true, 1_031.0);
+
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn door_open_mode_uses_activity_and_timer() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.update_door(true, 1_000.0);
+
+        assert!(machine.in_door_open_mode_at(1_301.0));
+        let transition = machine.update_motion(true, 1_301.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+
+        let transition = machine.advance_timers(1_601.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+    }
+
+    #[test]
+    fn manual_present_while_door_open_suppresses_next_door_close_departure() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.update_door(true, 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+
+        machine.update_door(false, 1_002.0);
+
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn manual_away_resets_stale_activity_boundary() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.state = OccupancyState::Present;
+        machine.sensors.external_monitor = true;
+        machine.sensors.mac_last_active = 1_100.0;
+        machine.sensors.door_last_changed = 1_040.0;
+        machine.sensors.motion_detected = true;
+        machine.sensors.motion_last_seen = 1_100.0;
+
+        machine.set_manual_presence(false, 1_101.0);
+
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.sensors.motion_detected);
+        assert_eq!(machine.sensors.motion_last_seen, 0.0);
+        assert_eq!(machine.sensors.door_last_changed, 1_101.0);
+        assert!(!machine.presence_signal_active_at(1_102.0));
+    }
+
+    #[test]
+    fn safety_interlock_blocks_erv_status_decision() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.update_co2(900, 1_001.0);
+        assert!(machine.erv_should_run());
+
+        machine.update_door(true, 1_002.0);
+        assert!(machine.safety_interlock_active());
+        assert!(!machine.erv_should_run());
+    }
+
+    #[test]
+    fn present_erv_status_uses_python_greater_than_threshold() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.state = OccupancyState::Present;
+        machine.update_co2(2_000, 1_001.0);
+        assert!(!machine.erv_should_run());
+
+        machine.update_co2(2_001, 1_002.0);
+        assert!(machine.erv_should_run());
+    }
+}


### PR DESCRIPTION
## Summary
- Port the PRESENT/AWAY state machine into deterministic Rust state logic with explicit timer deadlines for departure verification and door-open mode.
- Add pure ERV/HVAC policy decision helpers for safety interlocks, manual override, CO2/tVOC adaptive ventilation, stale-air flush, dwell suppression, and HVAC temperature bands.
- Extend Rust threshold config defaults needed by the state/policy layer without adding device clients or write paths.

## Spec Reference
- #62
- docs/working/62_primary_host_modern_stack.md

## Test Plan
- [x] cargo fmt --all --check
- [x] cargo check --workspace
- [x] cargo test --workspace
- [x] venv/bin/python -m pytest tests/ -v

Fixes #65