### PR TITLE
Port HTTP WebSocket auth and artifact contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -70,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,12 +95,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -104,14 +120,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -138,10 +157,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -164,6 +204,25 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -212,6 +271,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,7 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,6 +411,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,9 +440,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -307,7 +492,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -385,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +605,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -422,13 +630,127 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -436,6 +758,27 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -450,6 +793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +809,33 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
 
 [[package]]
 name = "lazy_static"
@@ -497,10 +873,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -530,6 +918,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,7 +935,24 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -546,7 +961,41 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -555,17 +1004,27 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
+ "chrono",
  "clap",
+ "futures-util",
+ "ipnet",
+ "jsonwebtoken",
+ "rand 0.8.6",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]
@@ -579,6 +1038,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -597,6 +1066,30 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -618,6 +1111,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,9 +1176,74 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "regex-automata"
@@ -650,6 +1263,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +1329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,8 +1344,49 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -768,6 +1480,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +1527,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,14 +1557,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -836,6 +1600,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -844,10 +1622,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -860,18 +1658,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -883,6 +1738,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -909,12 +1799,24 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -992,6 +1894,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1944,36 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1034,6 +2000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +2030,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1092,10 +2122,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1105,6 +2235,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1201,6 +2460,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +2502,66 @@ name = "zerocopy-derive"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -6,17 +6,27 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"
-axum = "0.8"
+axum = { version = "0.8", features = ["multipart", "ws"] }
+base64 = "0.22"
+chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
+futures-util = "0.3"
+ipnet = "2"
+jsonwebtoken = "9"
+rand = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+sha2 = "0.10"
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "time"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+urlencoding = "2"
 
 [dev-dependencies]
 tempfile = "3"
+tokio-tungstenite = "0.29"
 tower = { version = "0.5", features = ["util"] }

--- a/rust/office-automate-server/src/artifacts.rs
+++ b/rust/office-automate-server/src/artifacts.rs
@@ -1,0 +1,406 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::{Context, Result, anyhow};
+use axum::{
+    Json,
+    body::Body,
+    extract::Multipart,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use chrono::Local;
+use rand::{RngCore, rngs::OsRng};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tokio::{
+    fs,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+pub const ARTIFACT_MAX_SIZE_BYTES: u64 = 100 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct ArtifactStore {
+    inner: Arc<ArtifactStoreInner>,
+}
+
+#[derive(Debug)]
+struct ArtifactStoreInner {
+    artifacts_root: PathBuf,
+    legacy_apk_path: PathBuf,
+    max_size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactMetadata {
+    pub artifact_hash: String,
+    pub uploaded_at: String,
+    pub size_bytes: u64,
+    pub uploaded_by: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_code: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_name: Option<String>,
+}
+
+impl ArtifactStore {
+    pub fn new(artifacts_root: PathBuf, legacy_apk_path: PathBuf) -> Self {
+        Self::with_max_size(artifacts_root, legacy_apk_path, ARTIFACT_MAX_SIZE_BYTES)
+    }
+
+    pub fn with_max_size(
+        artifacts_root: PathBuf,
+        legacy_apk_path: PathBuf,
+        max_size_bytes: u64,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ArtifactStoreInner {
+                artifacts_root,
+                legacy_apk_path,
+                max_size_bytes,
+            }),
+        }
+    }
+
+    fn app_dir(&self, app: &str) -> PathBuf {
+        self.inner.artifacts_root.join(app)
+    }
+
+    fn latest_path(&self, app: &str) -> PathBuf {
+        self.app_dir(app).join("latest.apk")
+    }
+
+    fn hashed_path(&self, app: &str, artifact_hash: &str) -> PathBuf {
+        self.app_dir(app).join(format!("{artifact_hash}.apk"))
+    }
+
+    fn meta_path(&self, app: &str) -> PathBuf {
+        self.app_dir(app).join("meta.json")
+    }
+
+    pub async fn read_metadata(&self, app: &str) -> Result<Option<ArtifactMetadata>> {
+        if !is_valid_app_name(app) {
+            return Ok(None);
+        }
+
+        let meta_path = self.meta_path(app);
+        if !meta_path.exists() {
+            return Ok(None);
+        }
+
+        let contents = fs::read_to_string(&meta_path)
+            .await
+            .with_context(|| format!("failed to read {}", meta_path.display()))?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", meta_path.display()))
+            .map(Some)
+    }
+
+    async fn write_metadata(&self, app: &str, metadata: &ArtifactMetadata) -> Result<()> {
+        let meta_path = self.meta_path(app);
+        let temp_path = unique_temp_path(&self.app_dir(app), ".tmp-meta-", ".json");
+        let contents = serde_json::to_vec(metadata).context("failed to serialize metadata")?;
+        fs::write(&temp_path, contents)
+            .await
+            .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        fs::rename(&temp_path, &meta_path)
+            .await
+            .with_context(|| format!("failed to replace {}", meta_path.display()))?;
+        Ok(())
+    }
+
+    pub async fn serve_legacy_apk(&self) -> Result<Option<Response>> {
+        if !self.inner.legacy_apk_path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&self.inner.legacy_apk_path)
+            .await
+            .with_context(|| format!("failed to read {}", self.inner.legacy_apk_path.display()))?;
+        Ok(Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    header::CONTENT_DISPOSITION,
+                    "attachment; filename=office-climate.apk",
+                )
+                .body(Body::from(bytes))
+                .expect("valid APK response"),
+        ))
+    }
+
+    pub async fn serve_hashed_artifact(
+        &self,
+        app: &str,
+        artifact_hash: &str,
+    ) -> Result<Option<Response>> {
+        if !is_valid_app_name(app) || !is_valid_artifact_hash(artifact_hash) {
+            return Ok(None);
+        }
+
+        let artifact_path = self.hashed_path(app, artifact_hash);
+        if !artifact_path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&artifact_path)
+            .await
+            .with_context(|| format!("failed to read {}", artifact_path.display()))?;
+        Ok(Some(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+                .header(
+                    header::CONTENT_DISPOSITION,
+                    format!("attachment; filename={app}.apk"),
+                )
+                .body(Body::from(bytes))
+                .expect("valid artifact response"),
+        ))
+    }
+
+    pub async fn store_upload(
+        &self,
+        app: &str,
+        mut multipart: Multipart,
+        user_email: &str,
+    ) -> Result<UploadOutcome, ArtifactError> {
+        if !is_valid_app_name(app) {
+            return Err(ArtifactError::BadRequest("Invalid app name".to_string()));
+        }
+
+        let app_dir = self.app_dir(app);
+        fs::create_dir_all(&app_dir)
+            .await
+            .map_err(|error| ArtifactError::Internal(anyhow!(error).context("create app dir")))?;
+
+        let temp_path = unique_temp_path(&app_dir, ".tmp-artifact-", ".apk");
+        let mut temp_file = fs::File::create(&temp_path)
+            .await
+            .map_err(|error| ArtifactError::Internal(anyhow!(error).context("create temp")))?;
+        let mut size_bytes = 0_u64;
+        let mut sha256 = Sha256::new();
+        let mut file_uploaded = false;
+        let mut version_code = None;
+        let mut version_name = None;
+
+        while let Some(mut field) = multipart
+            .next_field()
+            .await
+            .map_err(|_| ArtifactError::BadRequest("Expected multipart form upload".to_string()))?
+        {
+            let Some(name) = field.name().map(str::to_string) else {
+                continue;
+            };
+
+            match name.as_str() {
+                "file" => {
+                    file_uploaded = true;
+                    while let Some(chunk) = field.chunk().await.map_err(|_| {
+                        ArtifactError::BadRequest("Expected multipart form upload".to_string())
+                    })? {
+                        size_bytes += chunk.len() as u64;
+                        if size_bytes > self.inner.max_size_bytes {
+                            remove_file_if_exists(&temp_path).await;
+                            return Err(ArtifactError::PayloadTooLarge);
+                        }
+                        sha256.update(&chunk);
+                        temp_file.write_all(&chunk).await.map_err(|error| {
+                            ArtifactError::Internal(anyhow!(error).context("write artifact chunk"))
+                        })?;
+                    }
+                }
+                "version_code" => {
+                    let raw = field.text().await.map_err(|_| {
+                        ArtifactError::BadRequest("Expected multipart form upload".to_string())
+                    })?;
+                    let trimmed = raw.trim();
+                    if !trimmed.is_empty() {
+                        version_code = Some(trimmed.parse::<i64>().map_err(|_| {
+                            ArtifactError::BadRequest("version_code must be an integer".to_string())
+                        })?);
+                    }
+                }
+                "version_name" => {
+                    let raw = field.text().await.map_err(|_| {
+                        ArtifactError::BadRequest("Expected multipart form upload".to_string())
+                    })?;
+                    let trimmed = raw.trim();
+                    if !trimmed.is_empty() {
+                        version_name = Some(trimmed.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        temp_file
+            .flush()
+            .await
+            .map_err(|error| ArtifactError::Internal(anyhow!(error).context("flush artifact")))?;
+        drop(temp_file);
+
+        if !file_uploaded {
+            remove_file_if_exists(&temp_path).await;
+            return Err(ArtifactError::BadRequest(
+                "Missing multipart field 'file'".to_string(),
+            ));
+        }
+
+        let latest_path = self.latest_path(app);
+        fs::rename(&temp_path, &latest_path)
+            .await
+            .map_err(|error| {
+                ArtifactError::Internal(anyhow!(error).context("replace latest artifact"))
+            })?;
+
+        let artifact_hash = format!("{:x}", sha256.finalize())[..8].to_string();
+        let hashed_path = self.hashed_path(app, &artifact_hash);
+        if !hashed_path.exists() {
+            copy_file_atomically(&latest_path, &hashed_path).await?;
+        }
+
+        let metadata = ArtifactMetadata {
+            artifact_hash,
+            uploaded_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+            size_bytes,
+            uploaded_by: user_email.to_string(),
+            version_code,
+            version_name,
+        };
+        self.write_metadata(app, &metadata)
+            .await
+            .map_err(ArtifactError::Internal)?;
+
+        Ok(UploadOutcome {
+            app: app.to_string(),
+            size_bytes,
+            download_url: format!("/apps/{app}/latest.apk"),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UploadOutcome {
+    pub app: String,
+    pub size_bytes: u64,
+    pub download_url: String,
+}
+
+#[derive(Debug)]
+pub enum ArtifactError {
+    BadRequest(String),
+    PayloadTooLarge,
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for ArtifactError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::BadRequest(message) => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": message})),
+            )
+                .into_response(),
+            Self::PayloadTooLarge => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(json!({"ok": false, "error": "Artifact exceeds 100 MB limit"})),
+            )
+                .into_response(),
+            Self::Internal(error) => {
+                tracing::error!("artifact error: {error:#}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"ok": false, "error": "Failed to store artifact"})),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+pub fn is_valid_app_name(app: &str) -> bool {
+    let mut chars = app.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_lowercase() || first.is_ascii_digit())
+        && chars.all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+}
+
+pub fn is_valid_artifact_hash(artifact_hash: &str) -> bool {
+    artifact_hash.len() == 8
+        && artifact_hash
+            .chars()
+            .all(|character| character.is_ascii_hexdigit() && !character.is_ascii_uppercase())
+}
+
+async fn copy_file_atomically(
+    source_path: &PathBuf,
+    destination_path: &PathBuf,
+) -> Result<(), ArtifactError> {
+    let temp_path = unique_temp_path(
+        destination_path
+            .parent()
+            .ok_or_else(|| ArtifactError::Internal(anyhow!("destination has no parent")))?,
+        ".tmp-artifact-copy-",
+        ".apk",
+    );
+    let mut source = fs::File::open(source_path)
+        .await
+        .map_err(|error| ArtifactError::Internal(anyhow!(error).context("open source artifact")))?;
+    let mut destination = fs::File::create(&temp_path).await.map_err(|error| {
+        ArtifactError::Internal(anyhow!(error).context("create hashed artifact temp"))
+    })?;
+    let mut bytes = Vec::new();
+    source
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|error| ArtifactError::Internal(anyhow!(error).context("read source artifact")))?;
+    destination.write_all(&bytes).await.map_err(|error| {
+        ArtifactError::Internal(anyhow!(error).context("write hashed artifact"))
+    })?;
+    destination.flush().await.map_err(|error| {
+        ArtifactError::Internal(anyhow!(error).context("flush hashed artifact"))
+    })?;
+    drop(destination);
+    fs::rename(&temp_path, destination_path)
+        .await
+        .map_err(|error| {
+            ArtifactError::Internal(anyhow!(error).context("replace hashed artifact"))
+        })?;
+    Ok(())
+}
+
+fn unique_temp_path(dir: impl Into<PathBuf>, prefix: &str, suffix: &str) -> PathBuf {
+    let mut bytes = [0_u8; 8];
+    OsRng.fill_bytes(&mut bytes);
+    let token = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    dir.into().join(format!("{prefix}{token}{suffix}"))
+}
+
+async fn remove_file_if_exists(path: &PathBuf) {
+    let _ = fs::remove_file(path).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_app_names_and_hashes() {
+        assert!(is_valid_app_name("office-climate"));
+        assert!(is_valid_app_name("a1"));
+        assert!(!is_valid_app_name("-bad"));
+        assert!(!is_valid_app_name("Office"));
+        assert!(is_valid_artifact_hash("1a2b3c4d"));
+        assert!(!is_valid_artifact_hash("1A2B3C4D"));
+        assert!(!is_valid_artifact_hash("abcd"));
+    }
+}

--- a/rust/office-automate-server/src/artifacts.rs
+++ b/rust/office-automate-server/src/artifacts.rs
@@ -248,18 +248,18 @@ impl ArtifactStore {
             ));
         }
 
+        let artifact_hash = format!("{:x}", sha256.finalize())[..8].to_string();
+        let hashed_path = self.hashed_path(app, &artifact_hash);
+        if !hashed_path.exists() {
+            copy_file_atomically(&temp_path, &hashed_path).await?;
+        }
+
         let latest_path = self.latest_path(app);
         fs::rename(&temp_path, &latest_path)
             .await
             .map_err(|error| {
                 ArtifactError::Internal(anyhow!(error).context("replace latest artifact"))
             })?;
-
-        let artifact_hash = format!("{:x}", sha256.finalize())[..8].to_string();
-        let hashed_path = self.hashed_path(app, &artifact_hash);
-        if !hashed_path.exists() {
-            copy_file_atomically(&latest_path, &hashed_path).await?;
-        }
 
         let metadata = ArtifactMetadata {
             artifact_hash,

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -24,6 +24,8 @@ const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 const GOOGLE_DEVICE_CODE_URL: &str = "https://oauth2.googleapis.com/device/code";
 const GOOGLE_TOKENINFO_URL: &str = "https://oauth2.googleapis.com/tokeninfo";
 const OAUTH_SCOPE: &str = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+const BASIC_WS_COOKIE: &str = "office_basic_ws";
+const BASIC_WS_COOKIE_MAX_AGE_SECONDS: i64 = 600;
 
 #[derive(Clone)]
 pub struct AuthManager {
@@ -36,6 +38,7 @@ struct AuthInner {
     pending_oauth: RwLock<HashMap<String, PendingOAuthState>>,
     device_flows: RwLock<HashMap<String, DeviceFlowState>>,
     invalidated_tokens: RwLock<HashSet<String>>,
+    basic_ws_tokens: RwLock<HashMap<String, chrono::DateTime<Utc>>>,
     client: Client,
 }
 
@@ -80,7 +83,9 @@ pub enum HttpAuthMode {
 pub enum WebSocketAuth {
     TrustedNetwork,
     UpgradeBearer,
+    UpgradeBasic,
     FirstMessage,
+    Reject,
     Open,
 }
 
@@ -144,6 +149,7 @@ impl AuthManager {
                 pending_oauth: RwLock::new(HashMap::new()),
                 device_flows: RwLock::new(HashMap::new()),
                 invalidated_tokens: RwLock::new(HashSet::new()),
+                basic_ws_tokens: RwLock::new(HashMap::new()),
                 client: Client::builder()
                     .timeout(Duration::from_secs(10))
                     .build()
@@ -218,6 +224,45 @@ impl AuthManager {
         username == credentials.username && password == credentials.password
     }
 
+    pub fn issue_basic_websocket_cookie(&self) -> Option<String> {
+        self.inner.basic.as_ref()?;
+        let token = random_url_token(32);
+        let expires_at = Utc::now() + TimeDelta::seconds(BASIC_WS_COOKIE_MAX_AGE_SECONDS);
+        let mut tokens = self
+            .inner
+            .basic_ws_tokens
+            .write()
+            .expect("basic websocket token lock");
+        prune_expired_tokens(&mut tokens);
+        tokens.insert(token.clone(), expires_at);
+        Some(format!(
+            "{BASIC_WS_COOKIE}={token}; Max-Age={BASIC_WS_COOKIE_MAX_AGE_SECONDS}; Path=/ws; HttpOnly; SameSite=Lax"
+        ))
+    }
+
+    pub fn verify_basic_websocket_auth(&self, headers: &HeaderMap) -> bool {
+        self.verify_basic_header(headers) || self.verify_basic_websocket_cookie(headers)
+    }
+
+    fn verify_basic_websocket_cookie(&self, headers: &HeaderMap) -> bool {
+        if self.inner.basic.is_none() {
+            return false;
+        }
+        let Some(token) = cookie_value(headers, BASIC_WS_COOKIE) else {
+            return false;
+        };
+        let now = Utc::now();
+        let mut tokens = self
+            .inner
+            .basic_ws_tokens
+            .write()
+            .expect("basic websocket token lock");
+        prune_expired_tokens_at(&mut tokens, now);
+        tokens
+            .get(token)
+            .is_some_and(|expires_at| *expires_at > now)
+    }
+
     pub fn verify_jwt(&self, token: &str) -> Option<String> {
         if self
             .inner
@@ -273,6 +318,12 @@ impl AuthManager {
                 return WebSocketAuth::UpgradeBearer;
             }
             WebSocketAuth::FirstMessage
+        } else if self.basic_enabled() {
+            if self.verify_basic_websocket_auth(headers) {
+                WebSocketAuth::UpgradeBasic
+            } else {
+                WebSocketAuth::Reject
+            }
         } else {
             WebSocketAuth::Open
         }
@@ -599,6 +650,26 @@ fn header_to_str(value: &HeaderValue) -> Option<&str> {
     value.to_str().ok()
 }
 
+fn cookie_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(header::COOKIE)
+        .and_then(header_to_str)?
+        .split(';')
+        .filter_map(|cookie| cookie.trim().split_once('='))
+        .find_map(|(cookie_name, value)| (cookie_name == name).then_some(value))
+}
+
+fn prune_expired_tokens(tokens: &mut HashMap<String, chrono::DateTime<Utc>>) {
+    prune_expired_tokens_at(tokens, Utc::now());
+}
+
+fn prune_expired_tokens_at(
+    tokens: &mut HashMap<String, chrono::DateTime<Utc>>,
+    now: chrono::DateTime<Utc>,
+) {
+    tokens.retain(|_, expires_at| *expires_at > now);
+}
+
 fn generate_pkce_pair() -> (String, String) {
     let code_verifier = random_url_token(32);
     let challenge = Sha256::digest(code_verifier.as_bytes());
@@ -713,5 +784,27 @@ mod tests {
         );
 
         assert!(manager.verify_basic_header(&headers));
+    }
+
+    #[test]
+    fn basic_websocket_cookie_is_issued_and_verified() {
+        let manager = AuthManager::new(&OrchestratorConfig {
+            auth_username: Some("admin".to_string()),
+            auth_password: Some("secret".to_string()),
+            ..OrchestratorConfig::default()
+        })
+        .expect("auth");
+
+        let cookie = manager
+            .issue_basic_websocket_cookie()
+            .expect("basic websocket cookie");
+        let cookie_pair = cookie.split(';').next().expect("cookie pair");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(cookie_pair).expect("cookie"),
+        );
+
+        assert!(manager.verify_basic_websocket_auth(&headers));
     }
 }

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -1,0 +1,717 @@
+use std::{
+    collections::{HashMap, HashSet},
+    net::IpAddr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use base64::{Engine, engine::general_purpose};
+use chrono::{TimeDelta, Utc};
+use ipnet::IpNet;
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use rand::{RngCore, rngs::OsRng};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::config::{GoogleOAuthConfig, OrchestratorConfig};
+
+const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/auth";
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GOOGLE_DEVICE_CODE_URL: &str = "https://oauth2.googleapis.com/device/code";
+const GOOGLE_TOKENINFO_URL: &str = "https://oauth2.googleapis.com/tokeninfo";
+const OAUTH_SCOPE: &str = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+
+#[derive(Clone)]
+pub struct AuthManager {
+    inner: Arc<AuthInner>,
+}
+
+struct AuthInner {
+    oauth: Option<OAuthRuntime>,
+    basic: Option<BasicCredentials>,
+    pending_oauth: RwLock<HashMap<String, PendingOAuthState>>,
+    device_flows: RwLock<HashMap<String, DeviceFlowState>>,
+    invalidated_tokens: RwLock<HashSet<String>>,
+    client: Client,
+}
+
+#[derive(Clone)]
+struct OAuthRuntime {
+    client_id: String,
+    client_secret: String,
+    allowed_emails: HashSet<String>,
+    token_expiry_days: i64,
+    device_flow_enabled: bool,
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+    trusted_networks: Vec<IpNet>,
+}
+
+#[derive(Debug, Clone)]
+struct BasicCredentials {
+    username: String,
+    password: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingOAuthState {
+    pub code_verifier: String,
+    pub redirect_uri: String,
+    pub platform: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DeviceFlowState {
+    expires_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpAuthMode {
+    Open,
+    OAuth,
+    Basic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebSocketAuth {
+    TrustedNetwork,
+    UpgradeBearer,
+    FirstMessage,
+    Open,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedUser {
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Claims {
+    email: String,
+    exp: usize,
+    iat: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GoogleTokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GoogleTokenInfo {
+    email: Option<String>,
+    aud: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeviceFlowStartResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_url: String,
+    pub expires_in: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<i64>,
+}
+
+impl AuthManager {
+    pub fn new(config: &OrchestratorConfig) -> Result<Self> {
+        let oauth = config
+            .google_oauth
+            .as_ref()
+            .map(OAuthRuntime::from_config)
+            .transpose()?;
+
+        let basic = match (&config.auth_username, &config.auth_password) {
+            (Some(username), Some(password)) if !username.is_empty() && !password.is_empty() => {
+                Some(BasicCredentials {
+                    username: username.clone(),
+                    password: password.clone(),
+                })
+            }
+            _ => None,
+        };
+
+        Ok(Self {
+            inner: Arc::new(AuthInner {
+                oauth,
+                basic,
+                pending_oauth: RwLock::new(HashMap::new()),
+                device_flows: RwLock::new(HashMap::new()),
+                invalidated_tokens: RwLock::new(HashSet::new()),
+                client: Client::builder()
+                    .timeout(Duration::from_secs(10))
+                    .build()
+                    .context("failed to build OAuth HTTP client")?,
+            }),
+        })
+    }
+
+    pub fn mode(&self) -> HttpAuthMode {
+        if self.inner.oauth.is_some() {
+            HttpAuthMode::OAuth
+        } else if self.inner.basic.is_some() {
+            HttpAuthMode::Basic
+        } else {
+            HttpAuthMode::Open
+        }
+    }
+
+    pub fn oauth_enabled(&self) -> bool {
+        self.inner.oauth.is_some()
+    }
+
+    pub fn basic_enabled(&self) -> bool {
+        self.inner.basic.is_some()
+    }
+
+    pub fn is_trusted_request(&self, headers: &HeaderMap) -> bool {
+        let Some(oauth) = &self.inner.oauth else {
+            return false;
+        };
+
+        let Some(client_ip) = forwarded_client_ip(headers) else {
+            return false;
+        };
+
+        let Ok(address) = client_ip.parse::<IpAddr>() else {
+            return false;
+        };
+
+        oauth
+            .trusted_networks
+            .iter()
+            .any(|network| network.contains(&address))
+    }
+
+    pub fn verify_bearer_header(&self, headers: &HeaderMap) -> Option<AuthenticatedUser> {
+        let token = bearer_token(headers)?;
+        self.verify_jwt(token)
+            .map(|email| AuthenticatedUser { email })
+    }
+
+    pub fn verify_basic_header(&self, headers: &HeaderMap) -> bool {
+        let Some(credentials) = &self.inner.basic else {
+            return false;
+        };
+        let Some(header_value) = headers.get(header::AUTHORIZATION).and_then(header_to_str) else {
+            return false;
+        };
+        let Some(encoded) = header_value.strip_prefix("Basic ") else {
+            return false;
+        };
+        let Ok(decoded) = general_purpose::STANDARD.decode(encoded) else {
+            return false;
+        };
+        let Ok(decoded) = String::from_utf8(decoded) else {
+            return false;
+        };
+        let Some((username, password)) = decoded.split_once(':') else {
+            return false;
+        };
+
+        username == credentials.username && password == credentials.password
+    }
+
+    pub fn verify_jwt(&self, token: &str) -> Option<String> {
+        if self
+            .inner
+            .invalidated_tokens
+            .read()
+            .expect("invalidated token lock")
+            .contains(token)
+        {
+            return None;
+        }
+
+        let oauth = self.inner.oauth.as_ref()?;
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_aud = false;
+        let claims = decode::<Claims>(token, &oauth.decoding_key, &validation)
+            .ok()?
+            .claims;
+        let email = claims.email.to_ascii_lowercase();
+        oauth.allowed_emails.contains(&email).then_some(email)
+    }
+
+    pub fn generate_jwt(&self, email: &str) -> Result<String> {
+        let oauth = self
+            .inner
+            .oauth
+            .as_ref()
+            .ok_or_else(|| anyhow!("OAuth not configured"))?;
+        let now = Utc::now();
+        let expiry = now + TimeDelta::days(oauth.token_expiry_days);
+        let claims = Claims {
+            email: email.to_ascii_lowercase(),
+            iat: now.timestamp() as usize,
+            exp: expiry.timestamp() as usize,
+        };
+        encode(&Header::new(Algorithm::HS256), &claims, &oauth.encoding_key)
+            .context("failed to generate JWT")
+    }
+
+    pub fn invalidate_token(&self, token: &str) {
+        self.inner
+            .invalidated_tokens
+            .write()
+            .expect("invalidated token lock")
+            .insert(token.to_string());
+    }
+
+    pub fn websocket_auth(&self, headers: &HeaderMap) -> WebSocketAuth {
+        if self.oauth_enabled() {
+            if self.is_trusted_request(headers) {
+                return WebSocketAuth::TrustedNetwork;
+            }
+            if self.verify_bearer_header(headers).is_some() {
+                return WebSocketAuth::UpgradeBearer;
+            }
+            WebSocketAuth::FirstMessage
+        } else {
+            WebSocketAuth::Open
+        }
+    }
+
+    pub fn begin_login(
+        &self,
+        host: &str,
+        forwarded_proto: Option<&str>,
+        platform: Option<String>,
+    ) -> Result<Value> {
+        let oauth = self
+            .inner
+            .oauth
+            .as_ref()
+            .ok_or_else(|| anyhow!("OAuth not configured"))?;
+        let redirect_uri = format!(
+            "{}://{host}/auth/callback",
+            resolve_redirect_scheme(host, forwarded_proto)
+        );
+        let (code_verifier, code_challenge) = generate_pkce_pair();
+        let state = random_url_token(32);
+
+        self.inner
+            .pending_oauth
+            .write()
+            .expect("pending OAuth lock")
+            .insert(
+                state.clone(),
+                PendingOAuthState {
+                    code_verifier,
+                    redirect_uri: redirect_uri.clone(),
+                    platform,
+                },
+            );
+
+        let authorization_url = format!(
+            "{GOOGLE_AUTH_URL}?response_type=code&client_id={}&redirect_uri={}&scope={}&access_type=offline&include_granted_scopes=true&state={}&code_challenge={}&code_challenge_method=S256&prompt=consent",
+            urlencoding::encode(&oauth.client_id),
+            urlencoding::encode(&redirect_uri),
+            urlencoding::encode(OAUTH_SCOPE),
+            urlencoding::encode(&state),
+            urlencoding::encode(&code_challenge),
+        );
+
+        Ok(json!({
+            "authorization_url": authorization_url,
+            "state": state,
+        }))
+    }
+
+    pub fn pending_state(&self, state: &str) -> Option<PendingOAuthState> {
+        self.inner
+            .pending_oauth
+            .read()
+            .expect("pending OAuth lock")
+            .get(state)
+            .cloned()
+    }
+
+    pub async fn finish_callback(
+        &self,
+        code: &str,
+        state: &str,
+    ) -> Result<Option<FinishedOAuthLogin>> {
+        let oauth = self
+            .inner
+            .oauth
+            .as_ref()
+            .ok_or_else(|| anyhow!("OAuth not configured"))?;
+        let pending = self
+            .inner
+            .pending_oauth
+            .write()
+            .expect("pending OAuth lock")
+            .remove(state)
+            .ok_or_else(|| anyhow!("Invalid state"))?;
+
+        let token_response: GoogleTokenResponse = self
+            .inner
+            .client
+            .post(GOOGLE_TOKEN_URL)
+            .form(&[
+                ("client_id", oauth.client_id.as_str()),
+                ("client_secret", oauth.client_secret.as_str()),
+                ("code", code),
+                ("code_verifier", pending.code_verifier.as_str()),
+                ("redirect_uri", pending.redirect_uri.as_str()),
+                ("grant_type", "authorization_code"),
+            ])
+            .send()
+            .await
+            .context("OAuth token exchange failed")?
+            .error_for_status()
+            .context("OAuth token exchange returned an error")?
+            .json()
+            .await
+            .context("OAuth token response was not JSON")?;
+
+        let Some(id_token) = token_response.id_token.as_deref() else {
+            return Ok(None);
+        };
+        let Some(email) = self.verify_google_id_token(oauth, id_token).await? else {
+            return Ok(None);
+        };
+        let jwt = self.generate_jwt(&email)?;
+
+        Ok(Some(FinishedOAuthLogin {
+            email,
+            jwt,
+            platform: pending.platform,
+            refresh_token: token_response.refresh_token,
+            access_token: token_response.access_token,
+        }))
+    }
+
+    pub async fn start_device_flow(&self) -> Result<DeviceFlowStartResponse> {
+        let oauth = self
+            .inner
+            .oauth
+            .as_ref()
+            .ok_or_else(|| anyhow!("OAuth not configured"))?;
+        if !oauth.device_flow_enabled {
+            return Err(anyhow!("Device flow not enabled"));
+        }
+
+        let response: DeviceFlowStartResponse = self
+            .inner
+            .client
+            .post(GOOGLE_DEVICE_CODE_URL)
+            .form(&[
+                ("client_id", oauth.client_id.as_str()),
+                ("scope", "openid email profile"),
+            ])
+            .send()
+            .await
+            .context("device flow initiation failed")?
+            .error_for_status()
+            .context("device flow initiation returned an error")?
+            .json()
+            .await
+            .context("device flow response was not JSON")?;
+
+        self.inner
+            .device_flows
+            .write()
+            .expect("device flow lock")
+            .insert(
+                response.device_code.clone(),
+                DeviceFlowState {
+                    expires_at: Utc::now() + TimeDelta::seconds(response.expires_in),
+                },
+            );
+
+        Ok(response)
+    }
+
+    pub async fn poll_device_flow(&self, device_code: &str) -> Result<Value> {
+        let oauth = self
+            .inner
+            .oauth
+            .as_ref()
+            .ok_or_else(|| anyhow!("OAuth not configured"))?;
+        if !oauth.device_flow_enabled {
+            return Ok(json!({"status": "error", "message": "Device flow not enabled"}));
+        }
+
+        {
+            let mut device_flows = self.inner.device_flows.write().expect("device flow lock");
+            let Some(state) = device_flows.get(device_code) else {
+                return Ok(json!({"status": "invalid", "message": "Unknown device code"}));
+            };
+            if Utc::now() >= state.expires_at {
+                device_flows.remove(device_code);
+                return Ok(json!({"status": "expired", "message": "Device code expired"}));
+            }
+        }
+
+        let response = self
+            .inner
+            .client
+            .post(GOOGLE_TOKEN_URL)
+            .form(&[
+                ("client_id", oauth.client_id.as_str()),
+                ("client_secret", oauth.client_secret.as_str()),
+                ("device_code", device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await
+            .context("device flow polling failed")?;
+        let status = response.status();
+        let body: Value = response.json().await.unwrap_or_else(|_| json!({}));
+
+        if status == StatusCode::OK {
+            let Some(id_token) = body.get("id_token").and_then(Value::as_str) else {
+                return Ok(json!({"status": "error", "message": "Missing id_token"}));
+            };
+            let Some(email) = self.verify_google_id_token(oauth, id_token).await? else {
+                return Ok(json!({"status": "forbidden", "message": "Email not allowed"}));
+            };
+            let jwt = self.generate_jwt(&email)?;
+            self.inner
+                .device_flows
+                .write()
+                .expect("device flow lock")
+                .remove(device_code);
+            return Ok(json!({
+                "status": "success",
+                "email": email,
+                "access_token": jwt,
+                "refresh_token": body.get("refresh_token").cloned().unwrap_or(Value::Null),
+                "expires_in": oauth.token_expiry_days * 24 * 60 * 60,
+            }));
+        }
+
+        if status == StatusCode::PRECONDITION_REQUIRED {
+            return Ok(json!({"status": "pending", "message": "User has not authorized yet"}));
+        }
+
+        if status == StatusCode::BAD_REQUEST {
+            let error = body.get("error").and_then(Value::as_str).unwrap_or("error");
+            return Ok(match error {
+                "authorization_pending" => {
+                    json!({"status": "pending", "message": "Waiting for user authorization"})
+                }
+                "slow_down" => json!({"status": "slow_down", "message": "Polling too fast"}),
+                _ => json!({"status": "error", "message": error}),
+            });
+        }
+
+        Ok(json!({"status": "error", "message": format!("HTTP {}", status.as_u16())}))
+    }
+
+    async fn verify_google_id_token(
+        &self,
+        oauth: &OAuthRuntime,
+        id_token: &str,
+    ) -> Result<Option<String>> {
+        let info: GoogleTokenInfo = self
+            .inner
+            .client
+            .get(GOOGLE_TOKENINFO_URL)
+            .query(&[("id_token", id_token)])
+            .send()
+            .await
+            .context("Google id_token verification failed")?
+            .error_for_status()
+            .context("Google rejected id_token")?
+            .json()
+            .await
+            .context("Google tokeninfo response was not JSON")?;
+
+        if info.aud.as_deref() != Some(oauth.client_id.as_str()) {
+            return Ok(None);
+        }
+
+        let Some(email) = info.email.map(|email| email.to_ascii_lowercase()) else {
+            return Ok(None);
+        };
+
+        Ok(oauth.allowed_emails.contains(&email).then_some(email))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinishedOAuthLogin {
+    pub email: String,
+    pub jwt: String,
+    pub platform: Option<String>,
+    pub access_token: Option<String>,
+    pub refresh_token: Option<String>,
+}
+
+impl OAuthRuntime {
+    fn from_config(config: &GoogleOAuthConfig) -> Result<Self> {
+        let jwt_secret = config
+            .jwt_secret
+            .clone()
+            .unwrap_or_else(|| random_url_token(32));
+        let trusted_networks = config
+            .trusted_networks
+            .iter()
+            .map(|network| {
+                network
+                    .parse()
+                    .with_context(|| format!("invalid trusted network {network:?}"))
+            })
+            .collect::<Result<Vec<IpNet>>>()?;
+
+        Ok(Self {
+            client_id: config.client_id.clone(),
+            client_secret: config.client_secret.clone(),
+            allowed_emails: config
+                .allowed_emails
+                .iter()
+                .map(|email| email.to_ascii_lowercase())
+                .collect(),
+            token_expiry_days: config.token_expiry_days,
+            device_flow_enabled: config.device_flow_enabled,
+            encoding_key: EncodingKey::from_secret(jwt_secret.as_bytes()),
+            decoding_key: DecodingKey::from_secret(jwt_secret.as_bytes()),
+            trusted_networks,
+        })
+    }
+}
+
+pub fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(header_to_str)?
+        .strip_prefix("Bearer ")
+}
+
+fn forwarded_client_ip(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(header_to_str)
+        .and_then(|value| value.split(',').next().map(str::trim))
+        .filter(|value| !value.is_empty())
+}
+
+fn header_to_str(value: &HeaderValue) -> Option<&str> {
+    value.to_str().ok()
+}
+
+fn generate_pkce_pair() -> (String, String) {
+    let code_verifier = random_url_token(32);
+    let challenge = Sha256::digest(code_verifier.as_bytes());
+    let code_challenge = general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+    (code_verifier, code_challenge)
+}
+
+fn random_url_token(byte_len: usize) -> String {
+    let mut bytes = vec![0_u8; byte_len];
+    OsRng.fill_bytes(&mut bytes);
+    general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub fn resolve_redirect_scheme(host: &str, forwarded_proto: Option<&str>) -> &'static str {
+    if let Some(proto) = forwarded_proto.and_then(|value| value.split(',').next()) {
+        let proto = proto.trim();
+        if proto.eq_ignore_ascii_case("http") {
+            return "http";
+        }
+        if proto.eq_ignore_ascii_case("https") {
+            return "https";
+        }
+    }
+
+    let host_without_port = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    if host_without_port == "localhost"
+        || host_without_port == "127.0.0.1"
+        || host_without_port.ends_with(".local")
+    {
+        "http"
+    } else {
+        "https"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderValue;
+
+    use super::*;
+
+    fn oauth_config() -> OrchestratorConfig {
+        OrchestratorConfig {
+            google_oauth: Some(GoogleOAuthConfig {
+                client_id: "client".to_string(),
+                client_secret: "secret".to_string(),
+                allowed_emails: vec!["Engineer@RajesHGo.li".to_string()],
+                jwt_secret: Some("test-secret".to_string()),
+                trusted_networks: vec!["192.168.0.0/16".to_string()],
+                ..GoogleOAuthConfig::default()
+            }),
+            ..OrchestratorConfig::default()
+        }
+    }
+
+    #[test]
+    fn jwt_generation_and_validation_honors_allowlist() {
+        let manager = AuthManager::new(&oauth_config()).expect("auth");
+        let token = manager.generate_jwt("engineer@rajeshgo.li").expect("token");
+
+        assert_eq!(
+            manager.verify_jwt(&token),
+            Some("engineer@rajeshgo.li".to_string())
+        );
+
+        manager.invalidate_token(&token);
+        assert_eq!(manager.verify_jwt(&token), None);
+    }
+
+    #[test]
+    fn trusted_network_uses_forwarded_for() {
+        let manager = AuthManager::new(&oauth_config()).expect("auth");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("192.168.1.20"));
+
+        assert!(manager.is_trusted_request(&headers));
+    }
+
+    #[test]
+    fn login_uses_forwarded_proto_and_host() {
+        let manager = AuthManager::new(&oauth_config()).expect("auth");
+        let payload = manager
+            .begin_login(
+                "office.example.com",
+                Some("https"),
+                Some("android".to_string()),
+            )
+            .expect("login");
+        let url = payload["authorization_url"].as_str().expect("url");
+        let state = payload["state"].as_str().expect("state");
+
+        assert!(url.contains("redirect_uri=https%3A%2F%2Foffice.example.com%2Fauth%2Fcallback"));
+        assert_eq!(
+            manager.pending_state(state).expect("stored").platform,
+            Some("android".to_string())
+        );
+    }
+
+    #[test]
+    fn basic_auth_validates_credentials() {
+        let manager = AuthManager::new(&OrchestratorConfig {
+            auth_username: Some("admin".to_string()),
+            auth_password: Some("secret".to_string()),
+            ..OrchestratorConfig::default()
+        })
+        .expect("auth");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Basic YWRtaW46c2VjcmV0"),
+        );
+
+        assert!(manager.verify_basic_header(&headers));
+    }
+}

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -19,6 +19,9 @@ pub struct AppConfig {
 pub struct OrchestratorConfig {
     pub host: String,
     pub port: u16,
+    pub auth_username: Option<String>,
+    pub auth_password: Option<String>,
+    pub google_oauth: Option<GoogleOAuthConfig>,
 }
 
 impl Default for OrchestratorConfig {
@@ -26,6 +29,35 @@ impl Default for OrchestratorConfig {
         Self {
             host: "0.0.0.0".to_string(),
             port: 8080,
+            auth_username: None,
+            auth_password: None,
+            google_oauth: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct GoogleOAuthConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub allowed_emails: Vec<String>,
+    pub token_expiry_days: i64,
+    pub device_flow_enabled: bool,
+    pub jwt_secret: Option<String>,
+    pub trusted_networks: Vec<String>,
+}
+
+impl Default for GoogleOAuthConfig {
+    fn default() -> Self {
+        Self {
+            client_id: String::new(),
+            client_secret: String::new(),
+            allowed_emails: Vec::new(),
+            token_expiry_days: 7,
+            device_flow_enabled: true,
+            jwt_secret: None,
+            trusted_networks: Vec::new(),
         }
     }
 }
@@ -144,6 +176,9 @@ pub struct RuntimeConfig {
     pub config_path: PathBuf,
     pub data_dir: PathBuf,
     pub database_path: PathBuf,
+    pub frontend_dist: PathBuf,
+    pub artifacts_dir: PathBuf,
+    pub legacy_apk_path: PathBuf,
     pub base_url: Option<String>,
     pub public_url: Option<String>,
     pub mqtt_host: String,
@@ -200,9 +235,12 @@ impl AppConfig {
         }
 
         let runtime = RuntimeConfig {
+            frontend_dist: root.join("frontend").join("dist"),
             root,
             config_path: config_path.to_path_buf(),
             database_path: data_dir.join("office_climate.db"),
+            artifacts_dir: data_dir.join("apps"),
+            legacy_apk_path: data_dir.join("app-debug.apk"),
             data_dir,
             base_url: env_lookup("OFFICE_AUTOMATE_BASE_URL"),
             public_url: env_lookup("OFFICE_AUTOMATE_PUBLIC_URL"),
@@ -267,6 +305,18 @@ thresholds:
         assert_eq!(
             config.runtime.database_path,
             temp_dir.path().join("db").join("office_climate.db")
+        );
+        assert_eq!(
+            config.runtime.frontend_dist,
+            temp_dir.path().join("root").join("frontend").join("dist")
+        );
+        assert_eq!(
+            config.runtime.artifacts_dir,
+            temp_dir.path().join("db").join("apps")
+        );
+        assert_eq!(
+            config.runtime.legacy_apk_path,
+            temp_dir.path().join("db").join("app-debug.apk")
         );
         assert_eq!(
             config.runtime.public_url.as_deref(),

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1,9 +1,14 @@
-use std::{fs, path::Path};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fs,
+    path::Path,
+};
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, Timelike};
 use rusqlite::{Connection, OptionalExtension, params, types::ValueRef};
 use serde::{Serialize, de::DeserializeOwned};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::config::AppConfig;
 
@@ -278,6 +283,610 @@ pub fn read_history(database_path: &Path, hours: i64, limit: i64) -> Result<Hist
     })
 }
 
+pub fn read_office_sessions(database_path: &Path, days: i64) -> Result<Value> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let cutoff = format_timestamp(now - Duration::days(days));
+    let rows = query_text_pairs(
+        &connection,
+        "SELECT timestamp, state FROM occupancy_log WHERE timestamp > ? ORDER BY timestamp ASC",
+        &cutoff,
+    )?;
+
+    let mut by_date: BTreeMap<String, Vec<(NaiveDateTime, String)>> = BTreeMap::new();
+    for (timestamp, state) in rows {
+        if let Some(parsed) = parse_timestamp(&timestamp) {
+            by_date
+                .entry(parsed.date().to_string())
+                .or_default()
+                .push((parsed, state));
+        }
+    }
+
+    let mut sessions = Vec::new();
+    let mut arrival_minutes = Vec::new();
+    let mut departure_minutes = Vec::new();
+
+    for (date, transitions) in by_date {
+        let Some(arrival) = transitions.iter().find_map(|(timestamp, state)| {
+            (state == "present" && timestamp.hour() >= 5).then_some(*timestamp)
+        }) else {
+            continue;
+        };
+
+        let (mut departure, departure_state) = transitions
+            .last()
+            .map(|(timestamp, state)| (*timestamp, state.as_str()))
+            .expect("non-empty transitions");
+        if departure_state == "present" && arrival.date() == now.date() {
+            departure = now;
+        }
+
+        let mut duration_hours = (departure - arrival).num_seconds() as f64 / 3600.0;
+        let mut gaps = Vec::new();
+        let mut gap_start = None;
+        for (timestamp, state) in &transitions {
+            if *timestamp <= arrival || *timestamp > departure {
+                continue;
+            }
+            if state == "away" && gap_start.is_none() {
+                gap_start = Some(*timestamp);
+            } else if state == "present" {
+                if let Some(start) = gap_start.take() {
+                    let duration_min = (timestamp.signed_duration_since(start).num_seconds() as f64
+                        / 60.0)
+                        .round() as i64;
+                    if duration_min >= 2 {
+                        gaps.push(json!({
+                            "left": start.format("%H:%M:%S").to_string(),
+                            "returned": timestamp.format("%H:%M:%S").to_string(),
+                            "duration_min": duration_min,
+                        }));
+                        duration_hours -= duration_min as f64 / 60.0;
+                    }
+                }
+            }
+        }
+
+        arrival_minutes.push((arrival.hour() * 60 + arrival.minute()) as f64);
+        departure_minutes.push((departure.hour() * 60 + departure.minute()) as f64);
+        sessions.push(json!({
+            "date": date,
+            "arrival": arrival.format("%H:%M:%S").to_string(),
+            "departure": departure.format("%H:%M:%S").to_string(),
+            "duration_hours": round1(duration_hours),
+            "gaps": gaps,
+        }));
+    }
+
+    let summary = if sessions.is_empty() {
+        json!({
+            "avg_arrival": "00:00:00",
+            "avg_departure": "00:00:00",
+            "avg_duration_hours": 0,
+            "std_arrival_min": 0,
+            "std_departure_min": 0,
+            "total_hours_week": 0,
+        })
+    } else {
+        let avg_arrival = average(&arrival_minutes);
+        let avg_departure = average(&departure_minutes);
+        let durations = sessions
+            .iter()
+            .filter_map(|session| session.get("duration_hours").and_then(Value::as_f64))
+            .collect::<Vec<_>>();
+        let total_hours = durations.iter().sum::<f64>();
+        json!({
+            "avg_arrival": minutes_to_time(avg_arrival),
+            "avg_departure": minutes_to_time(avg_departure),
+            "avg_duration_hours": round1(total_hours / durations.len() as f64),
+            "std_arrival_min": stddev(&arrival_minutes, avg_arrival).round() as i64,
+            "std_departure_min": stddev(&departure_minutes, avg_departure).round() as i64,
+            "total_hours_week": round1(total_hours),
+        })
+    };
+
+    Ok(json!({"sessions": sessions, "summary": summary}))
+}
+
+pub fn read_co2_ohlc(database_path: &Path, hours: i64, bucket_minutes: i64) -> Result<Value> {
+    let rows = query_sensor_points(database_path, "co2_ppm", hours)?;
+    let mut buckets: BTreeMap<NaiveDateTime, Vec<i64>> = BTreeMap::new();
+    for (timestamp, value) in rows {
+        if let (Some(timestamp), Some(value)) = (parse_timestamp(&timestamp), value.as_i64()) {
+            buckets
+                .entry(bucket_start(timestamp, bucket_minutes))
+                .or_default()
+                .push(value);
+        }
+    }
+
+    let candles = buckets
+        .into_iter()
+        .map(|(bucket, values)| {
+            let sum: i64 = values.iter().sum();
+            json!({
+                "timestamp": format_timestamp(bucket),
+                "open": values[0],
+                "high": values.iter().max().copied().unwrap_or_default(),
+                "low": values.iter().min().copied().unwrap_or_default(),
+                "close": values[values.len() - 1],
+                "avg": (sum as f64 / values.len() as f64).round() as i64,
+                "readings": values.len(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({"bucket_minutes": bucket_minutes, "candles": candles}))
+}
+
+pub fn read_temperature_history(
+    database_path: &Path,
+    hours: i64,
+    bucket_minutes: i64,
+) -> Result<Value> {
+    let rows = query_sensor_points(database_path, "temp_c", hours)?;
+    let mut buckets: BTreeMap<NaiveDateTime, Vec<f64>> = BTreeMap::new();
+    for (timestamp, value) in rows {
+        if let (Some(timestamp), Some(value)) = (parse_timestamp(&timestamp), value.as_f64()) {
+            buckets
+                .entry(bucket_start(timestamp, bucket_minutes))
+                .or_default()
+                .push(value);
+        }
+    }
+
+    let points = buckets
+        .into_iter()
+        .map(|(bucket, values)| {
+            let avg_c = values.iter().sum::<f64>() / values.len() as f64;
+            let min_c = values.iter().copied().fold(f64::INFINITY, f64::min);
+            let max_c = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            json!({
+                "timestamp": format_timestamp(bucket),
+                "avg_f": round1(c_to_f(avg_c)),
+                "min_f": round1(c_to_f(min_c)),
+                "max_f": round1(c_to_f(max_c)),
+                "readings": values.len(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({"bucket_minutes": bucket_minutes, "points": points}))
+}
+
+pub fn read_daily_stats(database_path: &Path, days: i64) -> Result<Vec<Value>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let start = day_start(now.date() - Duration::days(days - 1));
+    let cutoff = format_timestamp(start);
+    let labels = day_labels(now.date(), days);
+
+    let mut door_counts = HashMap::new();
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type = 'door' GROUP BY date(timestamp)",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (date, count) = row?;
+        door_counts.insert(date, count);
+    }
+
+    let presence = durations_from_state_table(
+        &connection,
+        "occupancy_log",
+        "state",
+        "present",
+        &cutoff,
+        start,
+        now,
+        3600.0,
+        None,
+    )?;
+    let erv = durations_from_state_table(
+        &connection,
+        "climate_actions",
+        "action",
+        "off",
+        &cutoff,
+        start,
+        now,
+        60.0,
+        Some("erv"),
+    )?;
+    let hvac = durations_from_state_table(
+        &connection,
+        "climate_actions",
+        "action",
+        "off",
+        &cutoff,
+        start,
+        now,
+        60.0,
+        Some("hvac"),
+    )?;
+
+    Ok(labels
+        .into_iter()
+        .map(|date| {
+            json!({
+                "date": date,
+                "door_events": door_counts.get(&date).copied().unwrap_or_default(),
+                "erv_runtime_min": erv.get(&date).copied().unwrap_or_default().round() as i64,
+                "hvac_runtime_min": hvac.get(&date).copied().unwrap_or_default().round() as i64,
+                "presence_hours": round1(presence.get(&date).copied().unwrap_or_default()),
+            })
+        })
+        .collect())
+}
+
+pub fn read_orchestration_activity(database_path: &Path, days: i64) -> Result<Vec<Value>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let labels = day_labels(now.date(), days);
+    let cutoff = format_timestamp(day_start(now.date() - Duration::days(days - 1)));
+    let mut grouped = labels
+        .iter()
+        .map(|date| {
+            (
+                date.clone(),
+                json!({
+                    "date": date,
+                    "messages": 0,
+                    "sessions": 0,
+                    "first_prompt": Value::Null,
+                    "last_prompt": Value::Null,
+                    "by_tool": {"claude": 0, "codex": 0},
+                    "timestamps": [],
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut sessions: HashMap<String, HashSet<String>> = HashMap::new();
+
+    let mut statement = connection.prepare(
+        "SELECT timestamp, tool, session_id FROM orchestration_activity WHERE timestamp >= ? ORDER BY timestamp ASC",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (timestamp, tool, session_id) = row?;
+        let Some(parsed) = parse_timestamp(&timestamp) else {
+            continue;
+        };
+        let date = parsed.date().to_string();
+        let Some(item) = grouped.get_mut(&date) else {
+            continue;
+        };
+        let time = parsed.format("%H:%M").to_string();
+        item["messages"] = json!(item["messages"].as_i64().unwrap_or_default() + 1);
+        item["by_tool"][&tool] = json!(item["by_tool"][&tool].as_i64().unwrap_or_default() + 1);
+        item["timestamps"]
+            .as_array_mut()
+            .expect("timestamps")
+            .push(json!({"time": time, "tool": tool}));
+        if item["first_prompt"].is_null() {
+            item["first_prompt"] = json!(time);
+        }
+        item["last_prompt"] = json!(time);
+        sessions.entry(date).or_default().insert(session_id);
+    }
+
+    for (date, session_ids) in sessions {
+        if let Some(item) = grouped.get_mut(&date) {
+            item["sessions"] = json!(session_ids.len());
+        }
+    }
+
+    Ok(labels
+        .into_iter()
+        .filter_map(|date| grouped.remove(&date))
+        .collect())
+}
+
+pub fn read_project_focus(database_path: &Path, days: i64) -> Result<Vec<Value>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let labels = day_labels(now.date(), days);
+    let cutoff = format_timestamp(day_start(now.date() - Duration::days(days - 1)));
+    let mut grouped: BTreeMap<String, HashMap<String, ProjectFocusItem>> = BTreeMap::new();
+
+    let mut statement = connection.prepare(
+        "SELECT timestamp, project FROM orchestration_activity WHERE timestamp >= ? ORDER BY timestamp ASC",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (timestamp, project) = row?;
+        let Some(parsed) = parse_timestamp(&timestamp) else {
+            continue;
+        };
+        let date = parsed.date().to_string();
+        if !labels.contains(&date) {
+            continue;
+        }
+        let name = normalize_project_name(&project);
+        let time = parsed.format("%H:%M").to_string();
+        let item = grouped
+            .entry(date)
+            .or_default()
+            .entry(name.clone())
+            .or_insert(ProjectFocusItem {
+                name,
+                messages: 0,
+                first_prompt: time.clone(),
+                last_prompt: time.clone(),
+            });
+        item.messages += 1;
+        if time < item.first_prompt {
+            item.first_prompt = time.clone();
+        }
+        if time > item.last_prompt {
+            item.last_prompt = time;
+        }
+    }
+
+    Ok(labels
+        .into_iter()
+        .map(|date| {
+            let mut projects = grouped
+                .remove(&date)
+                .unwrap_or_default()
+                .into_values()
+                .collect::<Vec<_>>();
+            projects.sort_by(|a, b| b.messages.cmp(&a.messages).then_with(|| a.name.cmp(&b.name)));
+            let total: i64 = projects.iter().map(|project| project.messages).sum();
+            json!({
+                "date": date,
+                "total": total,
+                "projects": projects.into_iter().map(ProjectFocusItem::into_value).collect::<Vec<_>>(),
+            })
+        })
+        .collect())
+}
+
+pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let start = day_start(now.date() - Duration::days(days - 1));
+    let cutoff = format_timestamp(start);
+    let labels = day_labels(now.date(), days);
+    let mut grouped = labels
+        .iter()
+        .map(|date| {
+            (
+                date.clone(),
+                json!({"date": date, "door": [], "window": []}),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for device_type in ["door", "window"] {
+        let last_before: Option<String> = connection
+            .query_row(
+                "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? ORDER BY timestamp DESC LIMIT 1",
+                params![cutoff, device_type],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let mut open_start = (last_before.as_deref() == Some("open")).then_some(start);
+
+        let mut statement = connection.prepare(
+            "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? ORDER BY timestamp ASC",
+        )?;
+        let rows = statement.query_map(params![cutoff, device_type], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (timestamp, event) = row?;
+            let Some(parsed) = parse_timestamp(&timestamp) else {
+                continue;
+            };
+            if event == "open" && open_start.is_none() {
+                open_start = Some(parsed);
+            } else if event == "closed" {
+                if let Some(started) = open_start.take() {
+                    push_open_intervals(&mut grouped, device_type, started, parsed);
+                }
+            }
+        }
+        if let Some(started) = open_start {
+            push_open_intervals(&mut grouped, device_type, started, now);
+        }
+    }
+
+    Ok(labels
+        .into_iter()
+        .filter_map(|date| grouped.remove(&date))
+        .collect())
+}
+
+pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let labels = day_labels(now.date(), days);
+    let cutoff = format_timestamp(day_start(now.date() - Duration::days(days - 1)));
+    let mut grouped = labels
+        .iter()
+        .map(|date| (date.clone(), LeverageDay::new(date)))
+        .collect::<BTreeMap<_, _>>();
+
+    for (date, prompts, sessions) in query_count_rows(
+        &connection,
+        "date(timestamp)",
+        "orchestration_activity",
+        "timestamp >= ?",
+        &cutoff,
+        Some("COUNT(*)"),
+        Some("COUNT(DISTINCT session_id)"),
+    )? {
+        if let Some(day) = grouped.get_mut(&date) {
+            day.prompts = prompts;
+            day.sessions = sessions;
+        }
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT date(created_at) AS date, COUNT(*) AS count FROM github_prs WHERE created_at >= ? GROUP BY date(created_at)",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (date, count) = row?;
+        if let Some(day) = grouped.get_mut(&date) {
+            day.prs_opened = count;
+        }
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT date(merged_at) AS date, COUNT(*) AS count, SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS hours FROM github_prs WHERE merged_at IS NOT NULL AND merged_at >= ? GROUP BY date(merged_at)",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, Option<f64>>(2)?.unwrap_or_default(),
+        ))
+    })?;
+    for row in rows {
+        let (date, count, hours) = row?;
+        if let Some(day) = grouped.get_mut(&date) {
+            day.prs_merged = count;
+            day.pr_cycle_hours_total = hours;
+        }
+    }
+
+    let mut week = LeverageWeek::default();
+    let days_payload = labels
+        .into_iter()
+        .filter_map(|date| grouped.remove(&date))
+        .map(|day| {
+            week.add(&day);
+            day.into_value()
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({"days": days_payload, "week": week.into_value()}))
+}
+
+pub fn read_project_leverage(database_path: &Path, days: i64) -> Result<Value> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = Local::now().naive_local();
+    let labels = day_labels(now.date(), days);
+    let since = (now.date() - Duration::days(days - 1)).to_string();
+    let mut by_project: HashMap<String, HashMap<String, HashMap<String, f64>>> = HashMap::new();
+    let mut persona_projects = HashSet::new();
+
+    let mut statement = connection.prepare(
+        "SELECT date, project, metric, value FROM project_leverage WHERE date >= ? ORDER BY date ASC, project ASC, metric ASC",
+    )?;
+    let rows = statement.query_map(params![since], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, f64>(3)?,
+        ))
+    })?;
+    for row in rows {
+        let (date, project, metric, value) = row?;
+        if project == "agent-os" && metric.starts_with("persona_project::") {
+            persona_projects.insert(metric.trim_start_matches("persona_project::").to_string());
+        }
+        by_project
+            .entry(project)
+            .or_default()
+            .entry(date)
+            .or_default()
+            .insert(metric, value);
+    }
+
+    let session_metrics = [
+        "sm_dispatches",
+        "sm_sends",
+        "sm_reminds",
+        "sm_active_sessions",
+        "sm_telegram_in",
+        "sm_telegram_out",
+    ];
+    let engram_metrics = [
+        "engram_last_fold_age_hours",
+        "engram_folds_7d",
+        "engram_active_concepts",
+    ];
+    let agent_metrics = ["persona_reads", "persona_projects"];
+    let office_metrics = ["automation_events", "state_transitions"];
+
+    let session_days =
+        project_leverage_days(by_project.get("session-manager"), &session_metrics, &labels);
+    let session_week = sum_project_days(&session_days, &session_metrics);
+    let engram_days = project_leverage_days(by_project.get("engram"), &engram_metrics, &labels);
+    let latest_engram = by_project.get("engram").and_then(|days| {
+        days.iter()
+            .max_by_key(|(date, _)| *date)
+            .map(|(_, metrics)| metrics)
+    });
+    let engram_current = json!({
+        "last_fold_age_hours": metric_value(latest_engram.and_then(|metrics| metrics.get("engram_last_fold_age_hours")).copied()),
+        "folds_7d": metric_value(Some(latest_engram.and_then(|metrics| metrics.get("engram_folds_7d")).copied().unwrap_or_default())),
+        "active_concepts": metric_value(Some(latest_engram.and_then(|metrics| metrics.get("engram_active_concepts")).copied().unwrap_or_default())),
+    });
+    let agent_days = project_leverage_days(by_project.get("agent-os"), &agent_metrics, &labels);
+    let persona_project_count = if persona_projects.is_empty() {
+        sum_metric(&agent_days, "persona_projects")
+    } else {
+        persona_projects.len() as f64
+    };
+    let agent_week = json!({
+        "persona_reads": metric_value(Some(sum_metric(&agent_days, "persona_reads"))),
+        "persona_projects": metric_value(Some(persona_project_count)),
+    });
+    let office_days =
+        project_leverage_days(by_project.get("office-automate"), &office_metrics, &labels);
+    let office_week = sum_project_days(&office_days, &office_metrics);
+
+    Ok(json!({
+        "projects": {
+            "session-manager": {
+                "summary": summarize_session_manager(&session_week, days),
+                "days": session_days,
+                "week": session_week,
+            },
+            "engram": {
+                "summary": summarize_engram(&engram_current),
+                "days": engram_days,
+                "current": engram_current,
+            },
+            "agent-os": {
+                "summary": summarize_agent_os(&agent_week, days),
+                "days": agent_days,
+                "week": agent_week,
+            },
+            "office-automate": {
+                "summary": summarize_office_automate(&office_week, days),
+                "days": office_days,
+                "week": office_week,
+            },
+        }
+    }))
+}
+
 fn recent_rows(
     connection: &Connection,
     table_name: &'static str,
@@ -316,6 +925,531 @@ fn sqlite_value_to_json(value: ValueRef<'_>) -> Value {
         ValueRef::Text(value) => Value::from(String::from_utf8_lossy(value).to_string()),
         ValueRef::Blob(value) => Value::from(String::from_utf8_lossy(value).to_string()),
     }
+}
+
+fn parse_timestamp(value: &str) -> Option<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .or_else(|| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S").ok())
+        .or_else(|| {
+            DateTime::parse_from_rfc3339(value)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&Local).naive_local())
+        })
+}
+
+fn format_timestamp(value: NaiveDateTime) -> String {
+    value.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn day_start(date: NaiveDate) -> NaiveDateTime {
+    date.and_hms_opt(0, 0, 0).expect("valid start of day")
+}
+
+fn day_labels(today: NaiveDate, days: i64) -> Vec<String> {
+    (0..days)
+        .rev()
+        .map(|offset| (today - Duration::days(offset)).to_string())
+        .collect()
+}
+
+fn bucket_start(timestamp: NaiveDateTime, bucket_minutes: i64) -> NaiveDateTime {
+    let bucket_minutes = bucket_minutes.max(1) as u32;
+    let minutes = timestamp.hour() * 60 + timestamp.minute();
+    let bucket = (minutes / bucket_minutes) * bucket_minutes;
+    timestamp
+        .date()
+        .and_hms_opt(bucket / 60, bucket % 60, 0)
+        .expect("valid bucket")
+}
+
+fn round1(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}
+
+fn round2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn c_to_f(value: f64) -> f64 {
+    value * 9.0 / 5.0 + 32.0
+}
+
+fn average(values: &[f64]) -> f64 {
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+fn stddev(values: &[f64], average: f64) -> f64 {
+    if values.len() <= 1 {
+        return 0.0;
+    }
+    (values
+        .iter()
+        .map(|value| (value - average).powi(2))
+        .sum::<f64>()
+        / values.len() as f64)
+        .sqrt()
+}
+
+fn minutes_to_time(minutes: f64) -> String {
+    let minutes = minutes as i64;
+    format!("{:02}:{:02}:00", minutes / 60, minutes % 60)
+}
+
+fn query_text_pairs(
+    connection: &Connection,
+    sql: &str,
+    parameter: &str,
+) -> Result<Vec<(String, String)>> {
+    let mut statement = connection.prepare(sql)?;
+    let rows = statement.query_map(params![parameter], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read text-pair rows")
+}
+
+fn query_sensor_points(
+    database_path: &Path,
+    column: &'static str,
+    hours: i64,
+) -> Result<Vec<(String, Value)>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let cutoff = format_timestamp(Local::now().naive_local() - Duration::hours(hours));
+    let mut statement = connection.prepare(&format!(
+        "SELECT timestamp, {column} FROM sensor_readings WHERE timestamp > ? AND {column} IS NOT NULL ORDER BY timestamp ASC"
+    ))?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            sqlite_value_to_json(row.get_ref(1)?),
+        ))
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read sensor points")
+}
+
+fn query_count_rows(
+    connection: &Connection,
+    date_expr: &'static str,
+    table: &'static str,
+    where_clause: &'static str,
+    parameter: &str,
+    first_count: Option<&'static str>,
+    second_count: Option<&'static str>,
+) -> Result<Vec<(String, i64, i64)>> {
+    let first_count = first_count.unwrap_or("COUNT(*)");
+    let second_count = second_count.unwrap_or("0");
+    let mut statement = connection.prepare(&format!(
+        "SELECT {date_expr} AS date, {first_count} AS first_count, {second_count} AS second_count FROM {table} WHERE {where_clause} GROUP BY {date_expr}"
+    ))?;
+    let rows = statement.query_map(params![parameter], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read count rows")
+}
+
+fn durations_from_state_table(
+    connection: &Connection,
+    table: &'static str,
+    state_column: &'static str,
+    active_value: &'static str,
+    cutoff: &str,
+    start: NaiveDateTime,
+    now: NaiveDateTime,
+    seconds_per_unit: f64,
+    system: Option<&'static str>,
+) -> Result<HashMap<String, f64>> {
+    let last_state: Option<String> = if let Some(system) = system {
+        connection
+            .query_row(
+                &format!(
+                    "SELECT {state_column} FROM {table} WHERE timestamp <= ? AND system = ? ORDER BY timestamp DESC LIMIT 1"
+                ),
+                params![cutoff, system],
+                |row| row.get(0),
+            )
+            .optional()?
+    } else {
+        connection
+            .query_row(
+                &format!(
+                    "SELECT {state_column} FROM {table} WHERE timestamp <= ? ORDER BY timestamp DESC LIMIT 1"
+                ),
+                params![cutoff],
+                |row| row.get(0),
+            )
+            .optional()?
+    };
+
+    let mut statement = if system.is_some() {
+        connection.prepare(&format!(
+            "SELECT timestamp, {state_column} FROM {table} WHERE timestamp > ? AND system = ? ORDER BY timestamp ASC"
+        ))?
+    } else {
+        connection.prepare(&format!(
+            "SELECT timestamp, {state_column} FROM {table} WHERE timestamp > ? ORDER BY timestamp ASC"
+        ))?
+    };
+    let rows = if let Some(system) = system {
+        statement
+            .query_map(params![cutoff, system], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        statement
+            .query_map(params![cutoff], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    let mut totals = HashMap::new();
+    let mut previous_timestamp = last_state.as_ref().map(|_| start);
+    let mut previous_active = last_state.as_deref().is_some_and(|state| {
+        if system.is_some() {
+            state != active_value
+        } else {
+            state == active_value
+        }
+    });
+
+    for (timestamp, state) in rows {
+        let Some(parsed) = parse_timestamp(&timestamp) else {
+            continue;
+        };
+        if previous_active {
+            if let Some(started) = previous_timestamp {
+                accumulate_duration(&mut totals, started, parsed, seconds_per_unit);
+            }
+        }
+        previous_timestamp = Some(parsed);
+        previous_active = if system.is_some() {
+            state != active_value
+        } else {
+            state == active_value
+        };
+    }
+
+    if previous_active {
+        if let Some(started) = previous_timestamp {
+            accumulate_duration(&mut totals, started, now, seconds_per_unit);
+        }
+    }
+
+    Ok(totals)
+}
+
+fn accumulate_duration(
+    totals: &mut HashMap<String, f64>,
+    mut start: NaiveDateTime,
+    end: NaiveDateTime,
+    seconds_per_unit: f64,
+) {
+    while start < end {
+        let next_midnight = day_start(start.date() + Duration::days(1));
+        let segment_end = end.min(next_midnight);
+        let amount = (segment_end - start).num_seconds() as f64 / seconds_per_unit;
+        *totals.entry(start.date().to_string()).or_default() += amount;
+        start = segment_end;
+    }
+}
+
+fn push_open_intervals(
+    grouped: &mut BTreeMap<String, Value>,
+    device_type: &str,
+    mut start: NaiveDateTime,
+    end: NaiveDateTime,
+) {
+    while start < end {
+        let next_midnight = day_start(start.date() + Duration::days(1));
+        let segment_end = end.min(next_midnight);
+        if let Some(day) = grouped.get_mut(&start.date().to_string()) {
+            day[device_type]
+                .as_array_mut()
+                .expect("opening array")
+                .push(json!({
+                    "open": start.format("%H:%M:%S").to_string(),
+                    "close": segment_end.format("%H:%M:%S").to_string(),
+                }));
+        }
+        start = segment_end;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProjectFocusItem {
+    name: String,
+    messages: i64,
+    first_prompt: String,
+    last_prompt: String,
+}
+
+impl ProjectFocusItem {
+    fn into_value(self) -> Value {
+        json!({
+            "name": self.name,
+            "messages": self.messages,
+            "first_prompt": self.first_prompt,
+            "last_prompt": self.last_prompt,
+        })
+    }
+}
+
+fn normalize_project_name(project: &str) -> String {
+    let basename = project
+        .trim()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or(project)
+        .to_ascii_lowercase();
+    match basename.as_str() {
+        "" => "unknown".to_string(),
+        "office-automation" | "claude-automate" => "office-automate".to_string(),
+        "financial-analysis" | "market generator" | "fms-branch" => "fractal".to_string(),
+        "claude-session-manager" => "session-manager".to_string(),
+        value if value == "fractal" || value.starts_with("fractal-") => "fractal".to_string(),
+        value => value.to_string(),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LeverageDay {
+    date: String,
+    prompts: i64,
+    sessions: i64,
+    lines_added: i64,
+    lines_removed: i64,
+    files_modified: i64,
+    commits: i64,
+    prs_merged: i64,
+    prs_opened: i64,
+    duration_minutes: i64,
+    pr_cycle_hours_total: f64,
+}
+
+impl LeverageDay {
+    fn new(date: &str) -> Self {
+        Self {
+            date: date.to_string(),
+            prompts: 0,
+            sessions: 0,
+            lines_added: 0,
+            lines_removed: 0,
+            files_modified: 0,
+            commits: 0,
+            prs_merged: 0,
+            prs_opened: 0,
+            duration_minutes: 0,
+            pr_cycle_hours_total: 0.0,
+        }
+    }
+
+    fn lines_changed(&self) -> i64 {
+        self.lines_added + self.lines_removed
+    }
+
+    fn into_value(self) -> Value {
+        json!({
+            "date": self.date,
+            "prompts": self.prompts,
+            "sessions": self.sessions,
+            "lines_added": self.lines_added,
+            "lines_removed": self.lines_removed,
+            "lines_changed": self.lines_changed(),
+            "files_modified": self.files_modified,
+            "commits": self.commits,
+            "prs_merged": self.prs_merged,
+            "prs_opened": self.prs_opened,
+            "avg_pr_cycle_hours": safe_ratio(self.pr_cycle_hours_total, self.prs_merged),
+            "lines_per_prompt": safe_ratio(self.lines_changed() as f64, self.prompts),
+            "commits_per_prompt": safe_ratio(self.commits as f64, self.prompts),
+            "lines_per_session_minute": safe_ratio(self.lines_changed() as f64, self.duration_minutes),
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct LeverageWeek {
+    prompts: i64,
+    sessions: i64,
+    lines_added: i64,
+    lines_removed: i64,
+    files_modified: i64,
+    commits: i64,
+    prs_merged: i64,
+    prs_opened: i64,
+    active_days: i64,
+    duration_minutes: i64,
+    pr_cycle_hours_total: f64,
+}
+
+impl LeverageWeek {
+    fn add(&mut self, day: &LeverageDay) {
+        self.prompts += day.prompts;
+        self.sessions += day.sessions;
+        self.lines_added += day.lines_added;
+        self.lines_removed += day.lines_removed;
+        self.files_modified += day.files_modified;
+        self.commits += day.commits;
+        self.prs_merged += day.prs_merged;
+        self.prs_opened += day.prs_opened;
+        self.duration_minutes += day.duration_minutes;
+        self.pr_cycle_hours_total += day.pr_cycle_hours_total;
+        if day.prompts > 0 {
+            self.active_days += 1;
+        }
+    }
+
+    fn lines_changed(&self) -> i64 {
+        self.lines_added + self.lines_removed
+    }
+
+    fn into_value(self) -> Value {
+        json!({
+            "prompts": self.prompts,
+            "sessions": self.sessions,
+            "lines_added": self.lines_added,
+            "lines_removed": self.lines_removed,
+            "lines_changed": self.lines_changed(),
+            "files_modified": self.files_modified,
+            "commits": self.commits,
+            "prs_merged": self.prs_merged,
+            "prs_opened": self.prs_opened,
+            "avg_pr_cycle_hours": safe_ratio(self.pr_cycle_hours_total, self.prs_merged),
+            "lines_per_prompt": safe_ratio(self.lines_changed() as f64, self.prompts),
+            "commits_per_prompt": safe_ratio(self.commits as f64, self.prompts),
+            "lines_per_session_minute": safe_ratio(self.lines_changed() as f64, self.duration_minutes),
+            "active_days": self.active_days,
+        })
+    }
+}
+
+fn safe_ratio(numerator: f64, denominator: i64) -> Value {
+    if denominator == 0 {
+        Value::Null
+    } else {
+        json!(round2(numerator / denominator as f64))
+    }
+}
+
+fn metric_value(value: Option<f64>) -> Value {
+    match value {
+        None => Value::Null,
+        Some(value) if value.fract() == 0.0 => json!(value as i64),
+        Some(value) => json!(round2(value)),
+    }
+}
+
+fn project_leverage_days(
+    rows: Option<&HashMap<String, HashMap<String, f64>>>,
+    metrics: &[&str],
+    labels: &[String],
+) -> Vec<Value> {
+    labels
+        .iter()
+        .map(|date| {
+            let mut day = serde_json::Map::new();
+            day.insert("date".to_string(), json!(date));
+            for metric in metrics {
+                day.insert(
+                    (*metric).to_string(),
+                    metric_value(Some(
+                        rows.and_then(|rows| rows.get(date))
+                            .and_then(|row| row.get(*metric))
+                            .copied()
+                            .unwrap_or_default(),
+                    )),
+                );
+            }
+            Value::Object(day)
+        })
+        .collect()
+}
+
+fn sum_metric(days: &[Value], metric: &str) -> f64 {
+    days.iter()
+        .filter_map(|day| {
+            day.get(metric).and_then(Value::as_f64).or_else(|| {
+                day.get(metric)
+                    .and_then(Value::as_i64)
+                    .map(|value| value as f64)
+            })
+        })
+        .sum()
+}
+
+fn sum_project_days(days: &[Value], metrics: &[&str]) -> Value {
+    let mut object = serde_json::Map::new();
+    for metric in metrics {
+        object.insert(
+            (*metric).to_string(),
+            metric_value(Some(sum_metric(days, metric))),
+        );
+    }
+    Value::Object(object)
+}
+
+fn window_phrase(days: i64) -> String {
+    match days {
+        1 => "today".to_string(),
+        7 => "this week".to_string(),
+        value => format!("in the last {value} days"),
+    }
+}
+
+fn summarize_session_manager(week: &Value, days: i64) -> String {
+    let dispatches = week["sm_dispatches"].as_i64().unwrap_or_default();
+    let sends = week["sm_sends"].as_i64().unwrap_or_default();
+    let telegram = week["sm_telegram_in"].as_i64().unwrap_or_default()
+        + week["sm_telegram_out"].as_i64().unwrap_or_default();
+    if telegram > 0 {
+        format!(
+            "{dispatches} dispatches, {telegram} Telegram messages {}",
+            window_phrase(days)
+        )
+    } else {
+        format!(
+            "{dispatches} dispatches, {sends} sends {}",
+            window_phrase(days)
+        )
+    }
+}
+
+fn summarize_engram(current: &Value) -> String {
+    let active = current["active_concepts"].as_i64().unwrap_or_default();
+    if let Some(age) = current["last_fold_age_hours"].as_f64() {
+        format!("Last fold {age:.1}h ago, {active} active concepts")
+    } else {
+        format!("{active} active concepts, no committed fold data yet")
+    }
+}
+
+fn summarize_agent_os(week: &Value, days: i64) -> String {
+    format!(
+        "{} persona reads across {} projects {}",
+        week["persona_reads"].as_i64().unwrap_or_default(),
+        week["persona_projects"].as_i64().unwrap_or_default(),
+        window_phrase(days)
+    )
+}
+
+fn summarize_office_automate(week: &Value, days: i64) -> String {
+    format!(
+        "{} automation events, {} state transitions {}",
+        week["automation_events"].as_i64().unwrap_or_default(),
+        week["state_transitions"].as_i64().unwrap_or_default(),
+        window_phrase(days)
+    )
 }
 
 fn ensure_column(

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1,7 +1,8 @@
 use std::{fs, path::Path};
 
 use anyhow::{Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::config::AppConfig;
 
@@ -133,6 +134,60 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn get_setting<T>(database_path: &Path, key: &str) -> Result<Option<T>>
+where
+    T: DeserializeOwned,
+{
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let value: Option<String> = connection
+        .query_row(
+            "SELECT value FROM app_settings WHERE key = ?",
+            params![key],
+            |row| row.get(0),
+        )
+        .optional()
+        .with_context(|| format!("failed to read app setting {key}"))?;
+
+    value
+        .map(|value| {
+            serde_json::from_str(&value)
+                .with_context(|| format!("invalid JSON in app setting {key}"))
+        })
+        .transpose()
+}
+
+pub fn set_setting<T>(database_path: &Path, key: &str, value: &T) -> Result<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let encoded = serde_json::to_string(value)
+        .with_context(|| format!("failed to encode app setting {key}"))?;
+    let updated_at = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+    connection
+        .execute(
+            r#"
+            INSERT INTO app_settings (key, value, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = excluded.updated_at
+            "#,
+            params![key, encoded, updated_at],
+        )
+        .with_context(|| format!("failed to write app setting {key}"))?;
+
+    Ok(())
+}
+
 fn ensure_column(
     connection: &Connection,
     table_name: &str,
@@ -227,5 +282,25 @@ mod tests {
                 (450, 21.0, 45.0, 1, 2, 3, 36, "qingping"),
             )
             .expect("insert sensor reading with noise_db");
+    }
+
+    #[test]
+    fn app_settings_round_trip_json_values() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let value = serde_json::json!({
+            "heat_on_temp_f": 70,
+            "heat_off_temp_f": 74,
+            "cool_off_temp_f": 78,
+            "cool_on_temp_f": 82,
+        });
+        set_setting(&db_path, "hvac_temperature_bands", &value).expect("write setting");
+
+        let stored: serde_json::Value = get_setting(&db_path, "hvac_temperature_bands")
+            .expect("read setting")
+            .expect("value");
+        assert_eq!(stored, value);
     }
 }

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1,8 +1,9 @@
 use std::{fs, path::Path};
 
 use anyhow::{Context, Result};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, types::ValueRef};
 use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
 
 use crate::config::AppConfig;
 
@@ -188,6 +189,135 @@ where
     Ok(())
 }
 
+pub fn log_occupancy_change(
+    database_path: &Path,
+    state: &str,
+    trigger: Option<&str>,
+    co2_ppm: Option<i64>,
+    details: Option<&Value>,
+) -> Result<()> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let details = details
+        .map(serde_json::to_string)
+        .transpose()
+        .context("failed to encode occupancy details")?;
+
+    connection
+        .execute(
+            r#"
+            INSERT INTO occupancy_log (timestamp, state, trigger, co2_ppm, details)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+            params![timestamp, state, trigger, co2_ppm, details],
+        )
+        .context("failed to insert occupancy log")?;
+
+    Ok(())
+}
+
+pub fn log_device_event(
+    database_path: &Path,
+    device_type: &str,
+    event: &str,
+    device_name: Option<&str>,
+    details: Option<&Value>,
+) -> Result<()> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let details = details
+        .map(serde_json::to_string)
+        .transpose()
+        .context("failed to encode device event details")?;
+
+    connection
+        .execute(
+            r#"
+            INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+            params![timestamp, device_type, device_name, event, details],
+        )
+        .context("failed to insert device event")?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HistoryRows {
+    pub sensor_readings: Vec<Value>,
+    pub occupancy_history: Vec<Value>,
+    pub device_events: Vec<Value>,
+    pub climate_actions: Vec<Value>,
+}
+
+pub fn read_history(database_path: &Path, hours: i64, limit: i64) -> Result<HistoryRows> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let since = (chrono::Local::now() - chrono::Duration::hours(hours))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+
+    Ok(HistoryRows {
+        sensor_readings: recent_rows(&connection, "sensor_readings", &since, limit)?,
+        occupancy_history: recent_rows(&connection, "occupancy_log", &since, limit)?,
+        device_events: recent_rows(&connection, "device_events", &since, limit)?,
+        climate_actions: recent_rows(&connection, "climate_actions", &since, limit)?,
+    })
+}
+
+fn recent_rows(
+    connection: &Connection,
+    table_name: &'static str,
+    since: &str,
+    limit: i64,
+) -> Result<Vec<Value>> {
+    let mut statement = connection
+        .prepare(&format!(
+            "SELECT * FROM {table_name} WHERE timestamp > ? ORDER BY timestamp DESC LIMIT ?"
+        ))
+        .with_context(|| format!("failed to prepare history query for {table_name}"))?;
+    let columns = statement
+        .column_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let rows = statement
+        .query_map(params![since, limit], |row| {
+            let mut object = serde_json::Map::new();
+            for (index, column) in columns.iter().enumerate() {
+                object.insert(column.clone(), sqlite_value_to_json(row.get_ref(index)?));
+            }
+            Ok(Value::Object(object))
+        })
+        .with_context(|| format!("failed to query history rows for {table_name}"))?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .with_context(|| format!("failed to read history rows for {table_name}"))
+}
+
+fn sqlite_value_to_json(value: ValueRef<'_>) -> Value {
+    match value {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(value) => Value::from(value),
+        ValueRef::Real(value) => Value::from(value),
+        ValueRef::Text(value) => Value::from(String::from_utf8_lossy(value).to_string()),
+        ValueRef::Blob(value) => Value::from(String::from_utf8_lossy(value).to_string()),
+    }
+}
+
 fn ensure_column(
     connection: &Connection,
     table_name: &str,
@@ -302,5 +432,33 @@ mod tests {
             .expect("read setting")
             .expect("value");
         assert_eq!(stored, value);
+    }
+
+    #[test]
+    fn logs_presence_and_reads_history_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        log_device_event(
+            &db_path,
+            "presence",
+            "manual_present",
+            Some("Dashboard"),
+            Some(&serde_json::json!({"state": "present"})),
+        )
+        .expect("log device");
+        log_occupancy_change(&db_path, "present", Some("manual"), Some(500), None)
+            .expect("log occupancy");
+
+        let history = read_history(&db_path, 1, 100).expect("history");
+
+        assert_eq!(history.device_events.len(), 1);
+        assert_eq!(history.device_events[0]["device_type"], "presence");
+        assert_eq!(history.device_events[0]["event"], "manual_present");
+        assert_eq!(history.occupancy_history.len(), 1);
+        assert_eq!(history.occupancy_history[0]["state"], "present");
+        assert_eq!(history.occupancy_history[0]["trigger"], "manual");
+        assert_eq!(history.occupancy_history[0]["co2_ppm"], 500);
     }
 }

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result};
@@ -11,6 +11,29 @@ use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
 use crate::config::AppConfig;
+
+const SESSION_OUTPUT_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS session_output (
+    session_id TEXT PRIMARY KEY,
+    project TEXT NOT NULL DEFAULT 'unknown',
+    start_time DATETIME NOT NULL,
+    duration_minutes INTEGER NOT NULL DEFAULT 0,
+    lines_added INTEGER NOT NULL DEFAULT 0,
+    lines_removed INTEGER NOT NULL DEFAULT 0,
+    files_modified INTEGER NOT NULL DEFAULT 0,
+    git_commits INTEGER NOT NULL DEFAULT 0,
+    git_pushes INTEGER NOT NULL DEFAULT 0,
+    user_message_count INTEGER NOT NULL DEFAULT 0,
+    assistant_message_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    tool_counts TEXT,
+    languages TEXT,
+    is_human_session INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_session_output_start ON session_output(start_time);
+CREATE INDEX IF NOT EXISTS idx_session_output_project ON session_output(project);
+"#;
 
 pub fn migrate(config: &AppConfig) -> Result<()> {
     migrate_database(&config.runtime.database_path)
@@ -720,29 +743,50 @@ pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
     let now = Local::now().naive_local();
     let labels = day_labels(now.date(), days);
     let cutoff = format_timestamp(day_start(now.date() - Duration::days(days - 1)));
+    let orchestration_datetime = sqlite_local_datetime_expr("timestamp");
+    let orchestration_date = format!("date({orchestration_datetime})");
+    let pr_created_datetime = sqlite_local_datetime_expr("created_at");
+    let pr_created_date = format!("date({pr_created_datetime})");
+    let pr_merged_datetime = sqlite_local_datetime_expr("merged_at");
+    let pr_merged_date = format!("date({pr_merged_datetime})");
     let mut grouped = labels
         .iter()
         .map(|date| (date.clone(), LeverageDay::new(date)))
         .collect::<BTreeMap<_, _>>();
 
-    for (date, prompts, sessions) in query_count_rows(
-        &connection,
-        "date(timestamp)",
-        "orchestration_activity",
-        "timestamp >= ?",
-        &cutoff,
-        Some("COUNT(*)"),
-        Some("COUNT(DISTINCT session_id)"),
-    )? {
+    let mut statement = connection.prepare(&format!(
+        "SELECT {orchestration_date} AS date, COUNT(*) AS prompts, COUNT(DISTINCT session_id) AS sessions \
+         FROM orchestration_activity WHERE {orchestration_datetime} >= ? GROUP BY {orchestration_date}"
+    ))?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (date, prompts, sessions) = row?;
         if let Some(day) = grouped.get_mut(&date) {
             day.prompts = prompts;
             day.sessions = sessions;
         }
     }
 
-    let mut statement = connection.prepare(
-        "SELECT date(created_at) AS date, COUNT(*) AS count FROM github_prs WHERE created_at >= ? GROUP BY date(created_at)",
-    )?;
+    for row in read_leverage_session_rows(&connection, database_path, &cutoff)? {
+        if let Some(day) = grouped.get_mut(&row.date) {
+            day.lines_added = row.lines_added;
+            day.lines_removed = row.lines_removed;
+            day.files_modified = row.files_modified;
+            day.commits = row.commits;
+            day.duration_minutes = row.duration_minutes;
+        }
+    }
+
+    let mut statement = connection.prepare(&format!(
+        "SELECT {pr_created_date} AS date, COUNT(*) AS count \
+         FROM github_prs WHERE {pr_created_datetime} >= ? GROUP BY {pr_created_date}"
+    ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
     })?;
@@ -753,9 +797,10 @@ pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
         }
     }
 
-    let mut statement = connection.prepare(
-        "SELECT date(merged_at) AS date, COUNT(*) AS count, SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS hours FROM github_prs WHERE merged_at IS NOT NULL AND merged_at >= ? GROUP BY date(merged_at)",
-    )?;
+    let mut statement = connection.prepare(&format!(
+        "SELECT {pr_merged_date} AS date, COUNT(*) AS count, SUM((julianday(merged_at) - julianday(created_at)) * 24.0) AS hours \
+         FROM github_prs WHERE merged_at IS NOT NULL AND {pr_merged_datetime} >= ? GROUP BY {pr_merged_date}"
+    ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((
             row.get::<_, String>(0)?,
@@ -782,6 +827,99 @@ pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
         .collect::<Vec<_>>();
 
     Ok(json!({"days": days_payload, "week": week.into_value()}))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LeverageSessionRow {
+    date: String,
+    lines_added: i64,
+    lines_removed: i64,
+    files_modified: i64,
+    commits: i64,
+    duration_minutes: i64,
+}
+
+fn read_leverage_session_rows(
+    connection: &Connection,
+    database_path: &Path,
+    cutoff: &str,
+) -> Result<Vec<LeverageSessionRow>> {
+    let telemetry_path = telemetry_database_path(database_path);
+    ensure_telemetry_database(&telemetry_path)?;
+    let telemetry_path = telemetry_path.to_string_lossy().to_string();
+    connection
+        .execute("ATTACH DATABASE ? AS telemetry", params![telemetry_path])
+        .context("failed to attach telemetry database")?;
+
+    let result = query_attached_leverage_session_rows(connection, cutoff);
+    let detach_result = connection
+        .execute_batch("DETACH DATABASE telemetry")
+        .context("failed to detach telemetry database");
+
+    match (result, detach_result) {
+        (Ok(rows), Ok(())) => Ok(rows),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+fn query_attached_leverage_session_rows(
+    connection: &Connection,
+    cutoff: &str,
+) -> Result<Vec<LeverageSessionRow>> {
+    let session_datetime = sqlite_local_datetime_expr("start_time");
+    let session_date = format!("date({session_datetime})");
+    let mut statement = connection.prepare(&format!(
+        "SELECT {session_date} AS date, \
+                SUM(lines_added) AS lines_added, \
+                SUM(lines_removed) AS lines_removed, \
+                SUM(files_modified) AS files_modified, \
+                SUM(git_commits) AS commits, \
+                SUM(duration_minutes) AS duration_minutes \
+         FROM telemetry.session_output \
+         WHERE {session_datetime} >= ? \
+         GROUP BY {session_date}"
+    ))?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok(LeverageSessionRow {
+            date: row.get(0)?,
+            lines_added: row.get::<_, Option<i64>>(1)?.unwrap_or_default(),
+            lines_removed: row.get::<_, Option<i64>>(2)?.unwrap_or_default(),
+            files_modified: row.get::<_, Option<i64>>(3)?.unwrap_or_default(),
+            commits: row.get::<_, Option<i64>>(4)?.unwrap_or_default(),
+            duration_minutes: row.get::<_, Option<i64>>(5)?.unwrap_or_default(),
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read leverage session rows")
+}
+
+fn telemetry_database_path(database_path: &Path) -> PathBuf {
+    database_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("telemetry.db")
+}
+
+fn ensure_telemetry_database(database_path: &Path) -> Result<()> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create telemetry data directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let connection = Connection::open(database_path).with_context(|| {
+        format!(
+            "failed to open telemetry SQLite database {}",
+            database_path.display()
+        )
+    })?;
+    connection
+        .execute_batch(SESSION_OUTPUT_SCHEMA)
+        .context("failed to apply telemetry SQLite schema")
 }
 
 pub fn read_project_leverage(database_path: &Path, days: i64) -> Result<Value> {
@@ -938,6 +1076,14 @@ fn parse_timestamp(value: &str) -> Option<NaiveDateTime> {
         })
 }
 
+fn sqlite_local_datetime_expr(column: &str) -> String {
+    let has_explicit_timezone =
+        format!("({column} LIKE '%Z' OR {column} LIKE '%+__:__' OR {column} LIKE '%-__:__')");
+    format!(
+        "CASE WHEN {has_explicit_timezone} THEN datetime({column}, 'localtime') ELSE datetime({column}) END"
+    )
+}
+
 fn format_timestamp(value: NaiveDateTime) -> String {
     value.format("%Y-%m-%d %H:%M:%S").to_string()
 }
@@ -1028,31 +1174,6 @@ fn query_sensor_points(
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .context("failed to read sensor points")
-}
-
-fn query_count_rows(
-    connection: &Connection,
-    date_expr: &'static str,
-    table: &'static str,
-    where_clause: &'static str,
-    parameter: &str,
-    first_count: Option<&'static str>,
-    second_count: Option<&'static str>,
-) -> Result<Vec<(String, i64, i64)>> {
-    let first_count = first_count.unwrap_or("COUNT(*)");
-    let second_count = second_count.unwrap_or("0");
-    let mut statement = connection.prepare(&format!(
-        "SELECT {date_expr} AS date, {first_count} AS first_count, {second_count} AS second_count FROM {table} WHERE {where_clause} GROUP BY {date_expr}"
-    ))?;
-    let rows = statement.query_map(params![parameter], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, i64>(1)?,
-            row.get::<_, i64>(2)?,
-        ))
-    })?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .context("failed to read count rows")
 }
 
 fn durations_from_state_table(
@@ -1566,6 +1687,84 @@ mod tests {
             .expect("read setting")
             .expect("value");
         assert_eq!(stored, value);
+    }
+
+    #[test]
+    fn leverage_history_aggregates_session_output_metrics() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let today = Local::now().naive_local().date();
+        let timestamp = format_timestamp(day_start(today) + Duration::hours(10));
+        {
+            let connection = Connection::open(&db_path).expect("open database");
+            connection
+                .execute(
+                    "INSERT INTO orchestration_activity (timestamp, tool, project, session_id) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+                    (
+                        &timestamp,
+                        "claude",
+                        "office-automate",
+                        "session-1",
+                        &timestamp,
+                        "codex",
+                        "office-automate",
+                        "session-2",
+                    ),
+                )
+                .expect("insert orchestration rows");
+        }
+
+        let telemetry_path = telemetry_database_path(&db_path);
+        ensure_telemetry_database(&telemetry_path).expect("telemetry schema");
+        {
+            let connection = Connection::open(&telemetry_path).expect("open telemetry database");
+            connection
+                .execute(
+                    "INSERT INTO session_output \
+                     (session_id, project, start_time, duration_minutes, lines_added, lines_removed, files_modified, git_commits) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "session-1",
+                        "office-automate",
+                        &timestamp,
+                        30,
+                        150,
+                        20,
+                        4,
+                        5,
+                        "session-2",
+                        "office-automate",
+                        &timestamp,
+                        20,
+                        50,
+                        30,
+                        2,
+                        3,
+                    ),
+                )
+                .expect("insert session output rows");
+        }
+
+        let payload = read_leverage_history(&db_path, 1).expect("leverage history");
+
+        assert_eq!(payload["days"][0]["date"], today.to_string());
+        assert_eq!(payload["days"][0]["prompts"], 2);
+        assert_eq!(payload["days"][0]["sessions"], 2);
+        assert_eq!(payload["days"][0]["lines_added"], 200);
+        assert_eq!(payload["days"][0]["lines_removed"], 50);
+        assert_eq!(payload["days"][0]["lines_changed"], 250);
+        assert_eq!(payload["days"][0]["files_modified"], 6);
+        assert_eq!(payload["days"][0]["commits"], 8);
+        assert_eq!(payload["days"][0]["lines_per_prompt"], 125.0);
+        assert_eq!(payload["days"][0]["commits_per_prompt"], 4.0);
+        assert_eq!(payload["days"][0]["lines_per_session_minute"], 5.0);
+        assert_eq!(payload["week"]["lines_added"], 200);
+        assert_eq!(payload["week"]["lines_removed"], 50);
+        assert_eq!(payload["week"]["files_modified"], 6);
+        assert_eq!(payload["week"]["commits"], 8);
+        assert_eq!(payload["week"]["lines_per_session_minute"], 5.0);
     }
 
     #[test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use axum::{
@@ -26,14 +30,19 @@ use crate::{
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     config::AppConfig,
+    db,
     status::{Status, TemperatureBands},
 };
+
+const HVAC_TEMPERATURE_BANDS_SETTING: &str = "hvac_temperature_bands";
 
 #[derive(Clone)]
 struct AppState {
     config: AppConfig,
     auth: AuthManager,
     artifacts: ArtifactStore,
+    temperature_bands: Arc<RwLock<TemperatureBands>>,
+    temperature_band_defaults: TemperatureBands,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -41,15 +50,20 @@ pub fn app(config: AppConfig) -> Router {
 }
 
 pub fn try_app(config: AppConfig) -> Result<Router> {
+    db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
         config.runtime.artifacts_dir.clone(),
         config.runtime.legacy_apk_path.clone(),
     );
+    let temperature_band_defaults = TemperatureBands::from_config(&config);
+    let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
     let state = AppState {
         config,
         auth,
         artifacts,
+        temperature_bands: Arc::new(RwLock::new(temperature_bands)),
+        temperature_band_defaults,
     };
 
     let cors = CorsLayer::new()
@@ -222,7 +236,7 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 }
 
 async fn status(State(state): State<AppState>) -> Json<Status> {
-    Json(Status::read_only_default(&state.config))
+    Json(status_for_state(&state))
 }
 
 async fn websocket(
@@ -298,8 +312,7 @@ async fn close_ws(socket: &mut WebSocket, reason: &str) {
 }
 
 async fn send_status(socket: &mut WebSocket, state: &AppState) -> Result<(), axum::Error> {
-    let status = serde_json::to_string(&Status::read_only_default(&state.config))
-        .expect("status serializes");
+    let status = serde_json::to_string(&status_for_state(state)).expect("status serializes");
     socket.send(Message::Text(status.into())).await
 }
 
@@ -383,7 +396,7 @@ async fn hvac(Json(payload): Json<HvacRequest>) -> Response {
 }
 
 async fn hvac_temperature_bands(State(state): State<AppState>) -> Json<Value> {
-    temperature_bands_response(TemperatureBands::from_config(&state.config), &state.config)
+    temperature_bands_response(active_temperature_bands(&state), &state)
 }
 
 #[derive(Debug, Deserialize)]
@@ -414,15 +427,62 @@ async fn update_hvac_temperature_bands(
             .into_response();
     }
 
-    temperature_bands_response(bands, &state.config).into_response()
+    if let Err(error) = db::set_setting(
+        &state.config.runtime.database_path,
+        HVAC_TEMPERATURE_BANDS_SETTING,
+        &bands,
+    ) {
+        tracing::error!("failed to persist HVAC temperature bands: {error:#}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": "Failed to persist temperature bands"})),
+        )
+            .into_response();
+    }
+
+    *state
+        .temperature_bands
+        .write()
+        .expect("temperature band lock poisoned") = bands;
+
+    temperature_bands_response(active_temperature_bands(&state), &state).into_response()
 }
 
-fn temperature_bands_response(bands: TemperatureBands, config: &AppConfig) -> Json<Value> {
+fn temperature_bands_response(bands: TemperatureBands, state: &AppState) -> Json<Value> {
     Json(json!({
         "ok": true,
         "temperature_bands": bands,
-        "temperature_band_defaults": TemperatureBands::from_config(config),
+        "temperature_band_defaults": state.temperature_band_defaults,
     }))
+}
+
+fn load_hvac_temperature_bands(config: &AppConfig, defaults: TemperatureBands) -> TemperatureBands {
+    match db::get_setting::<TemperatureBands>(
+        &config.runtime.database_path,
+        HVAC_TEMPERATURE_BANDS_SETTING,
+    ) {
+        Ok(Some(bands)) if validate_temperature_bands(bands).is_ok() => bands,
+        Ok(Some(bands)) => {
+            tracing::warn!("ignoring invalid stored HVAC temperature bands: {bands:?}");
+            defaults
+        }
+        Ok(None) => defaults,
+        Err(error) => {
+            tracing::warn!("failed to load HVAC temperature bands: {error:#}");
+            defaults
+        }
+    }
+}
+
+fn active_temperature_bands(state: &AppState) -> TemperatureBands {
+    *state
+        .temperature_bands
+        .read()
+        .expect("temperature band lock poisoned")
+}
+
+fn status_for_state(state: &AppState) -> Status {
+    Status::read_only_with_temperature_bands(&state.config, active_temperature_bands(state))
 }
 
 fn validate_temperature_bands(bands: TemperatureBands) -> Result<(), &'static str> {
@@ -969,6 +1029,71 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn hvac_temperature_band_updates_persist_for_get_and_status() {
+        let config = test_config();
+        let payload = json!({
+            "temperature_bands": {
+                "heat_on_temp_f": 69,
+                "heat_off_temp_f": 73,
+                "cool_off_temp_f": 79,
+                "cool_on_temp_f": 83,
+            }
+        });
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac/temperature-bands")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/hvac/temperature-bands")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["temperature_bands"]["heat_on_temp_f"], 69);
+        assert_eq!(value["temperature_bands"]["cool_on_temp_f"], 83);
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["hvac"]["temperature_bands"]["heat_on_temp_f"], 69);
+        assert_eq!(value["hvac"]["temperature_bands"]["cool_on_temp_f"], 83);
+        assert_eq!(
+            value["hvac"]["temperature_band_defaults"]["heat_on_temp_f"],
+            71
+        );
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
-use tokio::{net::TcpListener, time::timeout};
+use tokio::{net::TcpListener, sync::broadcast, time::timeout};
 use tower_http::{
     cors::{Any, CorsLayer},
     services::ServeDir,
@@ -49,6 +49,7 @@ struct AppState {
     temperature_bands: Arc<RwLock<TemperatureBands>>,
     temperature_band_defaults: TemperatureBands,
     state_machine: Arc<RwLock<StateMachine>>,
+    status_broadcast: broadcast::Sender<()>,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -65,6 +66,7 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
     let temperature_band_defaults = TemperatureBands::from_config(&config);
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
     let state_machine = StateMachine::from_thresholds(&config.thresholds, unix_timestamp_now());
+    let (status_broadcast, _) = broadcast::channel(32);
     let state = AppState {
         config,
         auth,
@@ -72,6 +74,7 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
         temperature_bands: Arc::new(RwLock::new(temperature_bands)),
         temperature_band_defaults,
         state_machine: Arc::new(RwLock::new(state_machine)),
+        status_broadcast,
     };
 
     let cors = CorsLayer::new()
@@ -260,9 +263,7 @@ fn auth_headers_with_peer(headers: &HeaderMap, remote_addr: Option<SocketAddr>) 
     headers.remove("x-forwarded-for");
 
     let client_ip = match remote_addr {
-        Some(remote_addr) if remote_addr.ip().is_loopback() => {
-            forwarded_for.or_else(|| Some(remote_addr.ip()))
-        }
+        Some(remote_addr) if remote_addr.ip().is_loopback() => forwarded_for,
         Some(remote_addr) => Some(remote_addr.ip()),
         None => None,
     };
@@ -335,20 +336,36 @@ async fn websocket_session(mut socket: WebSocket, state: AppState, auth_mode: We
         }
     }
 
+    let mut status_updates = state.status_broadcast.subscribe();
+
     if send_status(&mut socket, &state).await.is_err() {
         return;
     }
 
-    while let Some(message) = socket.recv().await {
-        match message {
-            Ok(Message::Text(text)) if text == "ping" => {
-                let _ = socket.send(Message::Text("pong".into())).await;
+    loop {
+        tokio::select! {
+            message = socket.recv() => {
+                match message {
+                    Some(Ok(Message::Text(text))) if text == "ping" => {
+                        let _ = socket.send(Message::Text("pong".into())).await;
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(error)) => {
+                        tracing::debug!("websocket receive error: {error}");
+                        break;
+                    }
+                }
             }
-            Ok(Message::Close(_)) => break,
-            Ok(_) => {}
-            Err(error) => {
-                tracing::debug!("websocket receive error: {error}");
-                break;
+            update = status_updates.recv() => {
+                match update {
+                    Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if send_status(&mut socket, &state).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
             }
         }
     }
@@ -366,6 +383,10 @@ async fn close_ws(socket: &mut WebSocket, reason: &str) {
 async fn send_status(socket: &mut WebSocket, state: &AppState) -> Result<(), axum::Error> {
     let status = serde_json::to_string(&status_for_state(state)).expect("status serializes");
     socket.send(Message::Text(status.into())).await
+}
+
+fn broadcast_status(state: &AppState) {
+    let _ = state.status_broadcast.send(());
 }
 
 fn unix_timestamp_now() -> f64 {
@@ -407,6 +428,7 @@ async fn occupancy(
             .into_response();
     }
 
+    broadcast_status(&state);
     Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run})).into_response()
 }
 
@@ -448,6 +470,7 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                     .into_response();
             }
 
+            broadcast_status(&state);
             Json(json!({"ok": true, "state": state_name, "is_present": is_present})).into_response()
         }
         _ => (
@@ -580,6 +603,7 @@ async fn update_hvac_temperature_bands(
         .write()
         .expect("temperature band lock poisoned") = bands;
 
+    broadcast_status(&state);
     temperature_bands_response(active_temperature_bands(&state), &state).into_response()
 }
 
@@ -1380,7 +1404,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oauth_loopback_proxy_preserves_forwarded_client_for_trusted_networks() {
+    async fn oauth_loopback_proxy_requires_forwarded_client_for_trusted_networks() {
         let response = app(oauth_config())
             .oneshot(
                 HttpRequest::builder()
@@ -1399,6 +1423,34 @@ mod tests {
             .oneshot(
                 HttpRequest::builder()
                     .uri("/status")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let config = AppConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: vec!["203.0.113.0/24".to_string()],
+                    ..GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        };
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header("x-forwarded-for", "203.0.113.7")
                     .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
                     .body(Body::empty())
                     .expect("request"),
@@ -1470,6 +1522,64 @@ mod tests {
         assert_eq!(value["device_events"][0]["event"], "manual_present");
         assert_eq!(value["occupancy_history"][0]["state"], "present");
         assert_eq!(value["occupancy_history"][0]["trigger"], "manual");
+    }
+
+    #[tokio::test]
+    async fn websocket_broadcasts_manual_presence_updates() {
+        let service = app(test_config());
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server_service = service.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                server_service.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
+            .await
+            .expect("connect");
+        let initial = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("initial timeout")
+            .expect("initial message")
+            .expect("initial ok");
+        assert!(
+            initial
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"away\"")
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let update = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("update timeout")
+            .expect("update message")
+            .expect("update ok");
+        assert!(
+            update
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"present\"")
+        );
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -9,7 +9,8 @@ use axum::{
     Json, Router,
     body::Body,
     extract::{
-        ConnectInfo, Extension, Multipart, Path, Query, Request, State, WebSocketUpgrade,
+        ConnectInfo, DefaultBodyLimit, Extension, Multipart, Path, Query, Request, State,
+        WebSocketUpgrade,
         ws::{CloseFrame, Message, WebSocket},
     },
     http::{HeaderMap, Method, StatusCode, header},
@@ -27,6 +28,7 @@ use tower_http::{
 };
 
 use crate::{
+    artifacts::ARTIFACT_MAX_SIZE_BYTES,
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     config::AppConfig,
@@ -96,7 +98,10 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
         .route("/history/project-focus", get(history_project_focus))
         .route("/history/leverage", get(history_leverage))
         .route("/history/project-leverage", get(history_project_leverage))
-        .route("/deploy/{app}", post(deploy_app))
+        .route(
+            "/deploy/{app}",
+            post(deploy_app).layer(DefaultBodyLimit::max(artifact_upload_body_limit())),
+        )
         .route("/apps/{app}/latest.apk", get(latest_app_artifact))
         .route("/apps/{app}/{artifact_file}", get(hashed_app_artifact))
         .route("/apps/{app}/meta.json", get(app_artifact_meta))
@@ -141,7 +146,7 @@ async fn auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if should_skip_auth(request.method(), request.uri().path(), request.headers()) {
+    if should_skip_auth(request.method(), request.uri().path()) {
         return next.run(request).await;
     }
 
@@ -157,7 +162,12 @@ async fn auth_middleware(
         }
     }
 
-    match state.auth.mode() {
+    let auth_mode = state.auth.mode();
+    if is_websocket_upgrade(&headers) && auth_mode == HttpAuthMode::OAuth {
+        return next.run(request).await;
+    }
+
+    match auth_mode {
         HttpAuthMode::Open => next.run(request).await,
         HttpAuthMode::OAuth => {
             if state.auth.is_trusted_request(&headers) {
@@ -200,12 +210,8 @@ async fn auth_middleware(
     }
 }
 
-fn should_skip_auth(method: &Method, path: &str, headers: &HeaderMap) -> bool {
+fn should_skip_auth(method: &Method, path: &str) -> bool {
     if *method == Method::OPTIONS {
-        return true;
-    }
-
-    if is_websocket_upgrade(headers) {
         return true;
     }
 
@@ -226,6 +232,10 @@ fn should_skip_auth(method: &Method, path: &str, headers: &HeaderMap) -> bool {
         || path.starts_with("/assets/")
         || path.ends_with(".png")
         || path.ends_with(".json")
+}
+
+fn artifact_upload_body_limit() -> usize {
+    (ARTIFACT_MAX_SIZE_BYTES + 1024 * 1024) as usize
 }
 
 fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
@@ -772,7 +782,8 @@ async fn auth_callback(
         return (
             StatusCode::BAD_REQUEST,
             Html(format!(
-                "<html><body><h1>Login Failed</h1><p>{error}</p></body></html>"
+                "<html><body><h1>Login Failed</h1><p>{}</p></body></html>",
+                escape_html_text(error)
             )),
         )
             .into_response();
@@ -813,6 +824,20 @@ async fn auth_callback(
             (StatusCode::INTERNAL_SERVER_ERROR, "OAuth callback failed").into_response()
         }
     }
+}
+
+fn escape_html_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| match character {
+            '&' => "&amp;".to_string(),
+            '<' => "&lt;".to_string(),
+            '>' => "&gt;".to_string(),
+            '"' => "&quot;".to_string(),
+            '\'' => "&#39;".to_string(),
+            _ => character.to_string(),
+        })
+        .collect()
 }
 
 async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
@@ -989,6 +1014,17 @@ mod tests {
         }
     }
 
+    fn basic_config() -> AppConfig {
+        AppConfig {
+            orchestrator: OrchestratorConfig {
+                auth_username: Some("user".to_string()),
+                auth_password: Some("pass".to_string()),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        }
+    }
+
     fn multipart_body(boundary: &str, bytes: &[u8]) -> Vec<u8> {
         let mut body = Vec::new();
         body.extend_from_slice(
@@ -1117,6 +1153,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn basic_auth_websocket_requires_credentials_before_upgrade() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app(basic_config()).into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let error = connect_async(format!("ws://{address}/ws"))
+            .await
+            .expect_err("unauthenticated websocket should fail");
+        match error {
+            tokio_tungstenite::tungstenite::Error::Http(response) => {
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            }
+            other => panic!("expected HTTP upgrade error, got {other:?}"),
+        }
+
+        let mut request = format!("ws://{address}/ws")
+            .into_client_request()
+            .expect("request");
+        request.headers_mut().insert(
+            header::AUTHORIZATION,
+            "Basic dXNlcjpwYXNz".parse().expect("header"),
+        );
+        let (mut ws, _) = connect_async(request).await.expect("authenticated connect");
+        let message = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("status timeout")
+            .expect("message")
+            .expect("message ok");
+        assert!(
+            message
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"away\"")
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_escapes_error_text() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/auth/callback?error=%3Cscript%3Ealert(1)%3C%2Fscript%3E%26%22%27")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let body = String::from_utf8(body.to_vec()).expect("utf8");
+        assert!(body.contains("&lt;script&gt;alert(1)&lt;/script&gt;&amp;&quot;&#39;"));
+        assert!(!body.contains("<script>"));
+    }
+
+    #[tokio::test]
     async fn artifact_upload_and_download_preserve_metadata_and_headers() {
         let config = oauth_config();
         let token = AuthManager::new(&config.orchestrator)
@@ -1184,6 +1287,39 @@ mod tests {
             response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
             "attachment; filename=office-climate.apk"
         );
+    }
+
+    #[tokio::test]
+    async fn artifact_upload_accepts_apks_larger_than_axum_default_body_limit() {
+        let config = oauth_config();
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let boundary = "large-upload-boundary";
+        let bytes = vec![b'a'; 3 * 1024 * 1024];
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(multipart_body(boundary, &bytes)))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["size_bytes"], bytes.len());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    net::SocketAddr,
     path::Component,
     sync::{Arc, RwLock},
     time::Duration,
@@ -151,20 +152,16 @@ async fn auth_middleware(
         return next.run(request).await;
     }
 
-    let mut headers = request.headers().clone();
-    if !headers.contains_key("x-forwarded-for") {
-        if let Some(ConnectInfo(remote_addr)) = request
-            .extensions()
-            .get::<ConnectInfo<std::net::SocketAddr>>()
-        {
-            if let Ok(value) = remote_addr.ip().to_string().parse() {
-                headers.insert("x-forwarded-for", value);
-            }
-        }
-    }
+    let remote_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(remote_addr)| *remote_addr);
+    let headers = auth_headers_with_peer(request.headers(), remote_addr);
 
     let auth_mode = state.auth.mode();
-    if is_websocket_upgrade(&headers) && auth_mode == HttpAuthMode::OAuth {
+    if is_websocket_upgrade(&headers)
+        && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
+    {
         return next.run(request).await;
     }
 
@@ -246,6 +243,17 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
         .is_some_and(|value| value.eq_ignore_ascii_case("websocket"))
 }
 
+fn auth_headers_with_peer(headers: &HeaderMap, remote_addr: Option<SocketAddr>) -> HeaderMap {
+    let mut headers = headers.clone();
+    headers.remove("x-forwarded-for");
+    if let Some(remote_addr) = remote_addr {
+        if let Ok(value) = remote_addr.ip().to_string().parse() {
+            headers.insert("x-forwarded-for", value);
+        }
+    }
+    headers
+}
+
 async fn status(State(state): State<AppState>) -> Json<Status> {
     Json(status_for_state(&state))
 }
@@ -256,12 +264,7 @@ async fn websocket(
     headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Response {
-    let mut auth_headers = headers.clone();
-    if !auth_headers.contains_key("x-forwarded-for") {
-        if let Ok(value) = remote_addr.ip().to_string().parse() {
-            auth_headers.insert("x-forwarded-for", value);
-        }
-    }
+    let auth_headers = auth_headers_with_peer(&headers, Some(remote_addr));
     let mode = state.auth.websocket_auth(&auth_headers);
     ws.on_upgrade(move |socket| websocket_session(socket, state, mode))
 }
@@ -1160,7 +1163,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn basic_auth_websocket_requires_credentials_before_upgrade() {
+    async fn oauth_trusted_network_ignores_client_supplied_forwarded_for() {
+        let config = AppConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: vec!["203.0.113.0/24".to_string()],
+                    ..GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        };
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header("x-forwarded-for", "203.0.113.7")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn basic_auth_websocket_matches_python_upgrade_bypass() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("addr");
         let server = tokio::spawn(async move {
@@ -1172,24 +1206,9 @@ mod tests {
             .expect("server");
         });
 
-        let error = connect_async(format!("ws://{address}/ws"))
+        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
             .await
-            .expect_err("unauthenticated websocket should fail");
-        match error {
-            tokio_tungstenite::tungstenite::Error::Http(response) => {
-                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-            }
-            other => panic!("expected HTTP upgrade error, got {other:?}"),
-        }
-
-        let mut request = format!("ws://{address}/ws")
-            .into_client_request()
-            .expect("request");
-        request.headers_mut().insert(
-            header::AUTHORIZATION,
-            "Basic dXNlcjpwYXNz".parse().expect("header"),
-        );
-        let (mut ws, _) = connect_async(request).await.expect("authenticated connect");
+            .expect("connect");
         let message = timeout(Duration::from_secs(1), ws.next())
             .await
             .expect("status timeout")

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -165,7 +165,7 @@ async fn auth_middleware(
     let auth_mode = state.auth.mode();
     if request.uri().path() == "/ws"
         && is_websocket_upgrade(&headers)
-        && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
+        && matches!(auth_mode, HttpAuthMode::OAuth)
     {
         return next.run(request).await;
     }
@@ -1512,7 +1512,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn basic_auth_websocket_matches_python_upgrade_bypass() {
+    async fn basic_auth_websocket_requires_credentials_before_upgrade() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("addr");
         let server = tokio::spawn(async move {
@@ -1524,9 +1524,19 @@ mod tests {
             .expect("server");
         });
 
-        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
+        let unauthenticated = connect_async(format!("ws://{address}/ws"))
             .await
-            .expect("connect");
+            .expect_err("unauthenticated websocket should fail");
+        assert!(unauthenticated.to_string().contains("401"));
+
+        let mut request = format!("ws://{address}/ws")
+            .into_client_request()
+            .expect("request");
+        request.headers_mut().insert(
+            header::AUTHORIZATION,
+            "Basic dXNlcjpwYXNz".parse().expect("header"),
+        );
+        let (mut ws, _) = connect_async(request).await.expect("connect");
         let message = timeout(Duration::from_secs(1), ws.next())
             .await
             .expect("status timeout")

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::Component,
     sync::{Arc, RwLock},
     time::Duration,
@@ -35,6 +35,7 @@ use crate::{
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     config::AppConfig,
     db,
+    state::{StateMachine, StateTransition},
     status::{Status, TemperatureBands},
 };
 
@@ -47,6 +48,7 @@ struct AppState {
     artifacts: ArtifactStore,
     temperature_bands: Arc<RwLock<TemperatureBands>>,
     temperature_band_defaults: TemperatureBands,
+    state_machine: Arc<RwLock<StateMachine>>,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -62,12 +64,14 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
     );
     let temperature_band_defaults = TemperatureBands::from_config(&config);
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
+    let state_machine = StateMachine::from_thresholds(&config.thresholds, unix_timestamp_now());
     let state = AppState {
         config,
         auth,
         artifacts,
         temperature_bands: Arc::new(RwLock::new(temperature_bands)),
         temperature_band_defaults,
+        state_machine: Arc::new(RwLock::new(state_machine)),
     };
 
     let cors = CorsLayer::new()
@@ -245,13 +249,35 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 
 fn auth_headers_with_peer(headers: &HeaderMap, remote_addr: Option<SocketAddr>) -> HeaderMap {
     let mut headers = headers.clone();
+    let forwarded_for = forwarded_for_ip(&headers);
     headers.remove("x-forwarded-for");
-    if let Some(remote_addr) = remote_addr {
-        if let Ok(value) = remote_addr.ip().to_string().parse() {
+
+    let client_ip = match remote_addr {
+        Some(remote_addr) if remote_addr.ip().is_loopback() => {
+            forwarded_for.or_else(|| Some(remote_addr.ip()))
+        }
+        Some(remote_addr) => Some(remote_addr.ip()),
+        None => None,
+    };
+
+    if let Some(client_ip) = client_ip {
+        if let Ok(value) = client_ip.to_string().parse() {
             headers.insert("x-forwarded-for", value);
         }
     }
     headers
+}
+
+fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("x-forwarded-for")?
+        .to_str()
+        .ok()?
+        .split(',')
+        .next()?
+        .trim()
+        .parse()
+        .ok()
 }
 
 async fn status(State(state): State<AppState>) -> Json<Status> {
@@ -330,6 +356,10 @@ async fn send_status(socket: &mut WebSocket, state: &AppState) -> Result<(), axu
     socket.send(Message::Text(status.into())).await
 }
 
+fn unix_timestamp_now() -> f64 {
+    chrono::Local::now().timestamp_millis() as f64 / 1_000.0
+}
+
 #[derive(Debug, Deserialize)]
 struct OccupancyRequest {
     last_active_timestamp: f64,
@@ -337,9 +367,35 @@ struct OccupancyRequest {
     external_monitor: bool,
 }
 
-async fn occupancy(Json(payload): Json<OccupancyRequest>) -> Json<Value> {
-    let _ = (payload.last_active_timestamp, payload.external_monitor);
-    Json(json!({"ok": true, "state": "away", "erv_should_run": false}))
+async fn occupancy(
+    State(state): State<AppState>,
+    Json(payload): Json<OccupancyRequest>,
+) -> Response {
+    let now = unix_timestamp_now();
+    let (transition, state_name, erv_should_run) = {
+        let mut machine = state
+            .state_machine
+            .write()
+            .expect("state machine lock poisoned");
+        let transition = machine.update_mac_occupancy(
+            payload.last_active_timestamp,
+            payload.external_monitor,
+            now,
+        );
+        let status = machine.status_at(now);
+        (transition, status.state, status.erv_should_run)
+    };
+
+    if let Err(error) = log_state_transition(&state, transition, "mac_activity") {
+        tracing::error!("failed to log occupancy transition: {error:#}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": "Failed to persist occupancy update"})),
+        )
+            .into_response();
+    }
+
+    Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run})).into_response()
 }
 
 #[derive(Debug, Deserialize)]
@@ -347,18 +403,71 @@ struct PresenceRequest {
     state: String,
 }
 
-async fn presence(Json(payload): Json<PresenceRequest>) -> Response {
+async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceRequest>) -> Response {
     match payload.state.as_str() {
-        "present" => {
-            Json(json!({"ok": true, "state": "present", "is_present": true})).into_response()
+        "present" | "away" => {
+            let requested_state = payload.state.as_str();
+            let now = unix_timestamp_now();
+            let present = requested_state == "present";
+            let (transition, state_name, is_present) = {
+                let mut machine = state
+                    .state_machine
+                    .write()
+                    .expect("state machine lock poisoned");
+                let transition = machine.set_manual_presence(present, now);
+                let status = machine.status_at(now);
+                (transition, status.state, status.is_present)
+            };
+
+            if let Err(error) = db::log_device_event(
+                &state.config.runtime.database_path,
+                "presence",
+                &format!("manual_{requested_state}"),
+                Some("Dashboard"),
+                None,
+            )
+            .and_then(|_| log_state_transition(&state, transition, "manual"))
+            {
+                tracing::error!("failed to persist manual presence update: {error:#}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"ok": false, "error": "Failed to persist presence update"})),
+                )
+                    .into_response();
+            }
+
+            Json(json!({"ok": true, "state": state_name, "is_present": is_present})).into_response()
         }
-        "away" => Json(json!({"ok": true, "state": "away", "is_present": false})).into_response(),
         _ => (
             StatusCode::BAD_REQUEST,
             Json(json!({"ok": false, "error": "state must be present or away"})),
         )
             .into_response(),
     }
+}
+
+fn log_state_transition(
+    state: &AppState,
+    transition: Option<StateTransition>,
+    trigger: &str,
+) -> Result<()> {
+    let Some(transition) = transition else {
+        return Ok(());
+    };
+
+    let co2_ppm = state
+        .state_machine
+        .read()
+        .expect("state machine lock poisoned")
+        .sensors
+        .co2_ppm;
+    db::log_occupancy_change(
+        &state.config.runtime.database_path,
+        transition.new_state.as_str(),
+        Some(trigger),
+        Some(co2_ppm),
+        Some(&json!({"old_state": transition.old_state.as_str()})),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -496,7 +605,34 @@ fn active_temperature_bands(state: &AppState) -> TemperatureBands {
 }
 
 fn status_for_state(state: &AppState) -> Status {
-    Status::read_only_with_temperature_bands(&state.config, active_temperature_bands(state))
+    let mut status =
+        Status::read_only_with_temperature_bands(&state.config, active_temperature_bands(state));
+    let now = unix_timestamp_now();
+    let state_status = {
+        let mut machine = state
+            .state_machine
+            .write()
+            .expect("state machine lock poisoned");
+        machine.advance_timers(now);
+        machine.status_at(now)
+    };
+
+    status.state = state_status.state;
+    status.is_present = state_status.is_present;
+    status.presence_signal_active = state_status.presence_signal_active;
+    status.safety_interlock = state_status.safety_interlock;
+    status.erv_should_run = state_status.erv_should_run;
+    status.verifying_departure = state_status.verifying_departure;
+    status.in_door_open_mode = state_status.in_door_open_mode;
+    status.sensors.mac_last_active = state_status.sensors.mac_last_active;
+    status.sensors.mac_active =
+        state_status.sensors.external_monitor && state_status.sensors.mac_last_active > 0.0;
+    status.sensors.external_monitor = state_status.sensors.external_monitor;
+    status.sensors.motion_detected = state_status.sensors.motion_detected;
+    status.sensors.door_open = state_status.sensors.door_open;
+    status.sensors.window_open = state_status.sensors.window_open;
+    status.sensors.co2_ppm = state_status.sensors.co2_ppm;
+    status
 }
 
 fn validate_temperature_bands(bands: TemperatureBands) -> Result<(), &'static str> {
@@ -554,16 +690,31 @@ fn clamp(value: Option<i64>, default: i64, min: i64, max: i64) -> i64 {
     value.unwrap_or(default).clamp(min, max)
 }
 
-async fn history(Query(query): Query<HistoryQuery>) -> Json<Value> {
+async fn history(State(state): State<AppState>, Query(query): Query<HistoryQuery>) -> Response {
+    let hours = clamp(query.hours, 24, 1, 168);
+    let limit = clamp(query.limit, 1000, 10, 10000);
+    let history = match db::read_history(&state.config.runtime.database_path, hours, limit) {
+        Ok(history) => history,
+        Err(error) => {
+            tracing::error!("failed to read history: {error:#}");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
     Json(json!({
         "ok": true,
-        "hours": clamp(query.hours, 24, 1, 168),
-        "sensor_readings": [],
-        "occupancy_history": [],
-        "device_events": [],
-        "climate_actions": [],
-        "limit": clamp(query.limit, 1000, 10, 10000),
+        "hours": hours,
+        "sensor_readings": history.sensor_readings,
+        "occupancy_history": history.occupancy_history,
+        "device_events": history.device_events,
+        "climate_actions": history.climate_actions,
+        "limit": limit,
     }))
+    .into_response()
 }
 
 async fn history_sessions(Query(query): Query<HistoryQuery>) -> Json<Value> {
@@ -1191,6 +1342,149 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn oauth_loopback_proxy_preserves_forwarded_client_for_trusted_networks() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header("x-forwarded-for", "198.51.100.24")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn presence_route_updates_status_and_history() {
+        let service = app(test_config());
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["state"], "present");
+        assert_eq!(value["is_present"], true);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["state"], "present");
+        assert_eq!(value["is_present"], true);
+        assert_eq!(value["sensors"]["motion_detected"], true);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["device_events"][0]["device_type"], "presence");
+        assert_eq!(value["device_events"][0]["event"], "manual_present");
+        assert_eq!(value["occupancy_history"][0]["state"], "present");
+        assert_eq!(value["occupancy_history"][0]["trigger"], "manual");
+    }
+
+    #[tokio::test]
+    async fn history_route_queries_persisted_rows() {
+        let config = test_config();
+        db::migrate_database(&config.runtime.database_path).expect("migration");
+        let connection =
+            rusqlite::Connection::open(&config.runtime.database_path).expect("open database");
+        let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        connection
+            .execute(
+                r#"
+                INSERT INTO sensor_readings (timestamp, co2_ppm, temp_c, source)
+                VALUES (?, ?, ?, ?)
+                "#,
+                (&timestamp, 612, 22.5, "qingping"),
+            )
+            .expect("insert sensor");
+        connection
+            .execute(
+                r#"
+                INSERT INTO climate_actions (timestamp, system, action, setpoint, co2_ppm, reason)
+                VALUES (?, ?, ?, ?, ?, ?)
+                "#,
+                (&timestamp, "erv", "turbo", Option::<f64>::None, 612, "test"),
+            )
+            .expect("insert climate action");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1&limit=10")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["sensor_readings"][0]["co2_ppm"], 612);
+        assert_eq!(value["sensor_readings"][0]["temp_c"], 22.5);
+        assert_eq!(value["sensor_readings"][0]["source"], "qingping");
+        assert_eq!(value["climate_actions"][0]["system"], "erv");
+        assert_eq!(value["climate_actions"][0]["action"], "turbo");
+        assert_eq!(value["climate_actions"][0]["reason"], "test");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::Component,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -941,7 +942,7 @@ async fn spa_fallback(State(state): State<AppState>, Path(path): Path<String>) -
 
 async fn serve_static_or_index(state: &AppState, path: &str) -> Response {
     let requested = state.config.runtime.frontend_dist.join(path);
-    let target = if requested.exists() && requested.is_file() {
+    let target = if is_safe_spa_path(path) && requested.exists() && requested.is_file() {
         requested
     } else {
         state.config.runtime.frontend_dist.join("index.html")
@@ -954,6 +955,12 @@ async fn serve_static_or_index(state: &AppState, path: &str) -> Response {
             .expect("static response"),
         Err(_) => StatusCode::NOT_FOUND.into_response(),
     }
+}
+
+fn is_safe_spa_path(path: &str) -> bool {
+    std::path::Path::new(path)
+        .components()
+        .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
 }
 
 #[cfg(test)]
@@ -1460,5 +1467,38 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_rejects_parent_directory_traversal() {
+        let config = test_config();
+        tokio::fs::create_dir_all(&config.runtime.frontend_dist)
+            .await
+            .expect("create frontend dist");
+        tokio::fs::write(
+            config.runtime.frontend_dist.join("index.html"),
+            b"spa-index",
+        )
+        .await
+        .expect("write index");
+        tokio::fs::write(config.runtime.root.join("secret.txt"), b"secret")
+            .await
+            .expect("write escaped file");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/%2e%2e/secret.txt")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        assert_eq!(&body[..], b"spa-index");
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -155,7 +155,8 @@ async fn auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if should_skip_auth(request.method(), request.uri().path()) {
+    let auth_mode = state.auth.mode();
+    if should_skip_auth(request.method(), request.uri().path(), auth_mode) {
         return next.run(request).await;
     }
 
@@ -165,7 +166,6 @@ async fn auth_middleware(
         .map(|ConnectInfo(remote_addr)| *remote_addr);
     let headers = auth_headers_with_peer(request.headers(), remote_addr);
 
-    let auth_mode = state.auth.mode();
     if request.uri().path() == "/ws"
         && is_websocket_upgrade(&headers)
         && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
@@ -222,7 +222,7 @@ async fn auth_middleware(
     }
 }
 
-fn should_skip_auth(method: &Method, path: &str) -> bool {
+fn should_skip_auth(method: &Method, path: &str, auth_mode: HttpAuthMode) -> bool {
     if *method == Method::OPTIONS {
         return true;
     }
@@ -231,19 +231,16 @@ fn should_skip_auth(method: &Method, path: &str) -> bool {
         return true;
     }
 
-    if path == "/auth/login"
-        || path == "/auth/callback"
-        || path == "/auth/device/start"
-        || path == "/auth/device/poll"
-    {
-        return true;
-    }
-
-    path == "/"
-        || path == "/index.html"
-        || path.starts_with("/assets/")
-        || path.ends_with(".png")
-        || path.ends_with(".json")
+    matches!(auth_mode, HttpAuthMode::OAuth)
+        && (path == "/auth/login"
+            || path == "/auth/callback"
+            || path == "/auth/device/start"
+            || path == "/auth/device/poll"
+            || path == "/"
+            || path == "/index.html"
+            || path.starts_with("/assets/")
+            || path.ends_with(".png")
+            || path.ends_with(".json"))
 }
 
 fn artifact_upload_body_limit() -> usize {
@@ -997,11 +994,14 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => Html(format!(
-            "<html><head><script>localStorage.setItem('auth_token', '{}');localStorage.setItem('user_email', '{}');window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
-            login.jwt, login.email
-        ))
-        .into_response(),
+        Ok(Some(login)) => {
+            let token = script_json_string(&login.jwt);
+            let email = script_json_string(&login.email);
+            Html(format!(
+                "<html><head><script>localStorage.setItem('auth_token', {token});localStorage.setItem('user_email', {email});window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
+            ))
+            .into_response()
+        }
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -1029,6 +1029,14 @@ fn escape_html_text(value: &str) -> String {
             _ => character.to_string(),
         })
         .collect()
+}
+
+fn script_json_string(value: &str) -> String {
+    serde_json::to_string(value)
+        .expect("string serializes")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026")
 }
 
 async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
@@ -1347,6 +1355,56 @@ mod tests {
             .expect("read body");
         let value: Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(value["login_url"], "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn basic_auth_protects_frontend_static_routes() {
+        let config = basic_config();
+        tokio::fs::create_dir_all(&config.runtime.frontend_dist)
+            .await
+            .expect("create dist");
+        tokio::fs::create_dir_all(config.runtime.frontend_dist.join("assets"))
+            .await
+            .expect("create assets");
+        tokio::fs::write(config.runtime.frontend_dist.join("index.html"), "dashboard")
+            .await
+            .expect("write index");
+        tokio::fs::write(
+            config.runtime.frontend_dist.join("assets/app.js"),
+            "console.log('dashboard')",
+        )
+        .await
+        .expect("write asset");
+
+        for path in ["/", "/index.html", "/assets/app.js", "/manifest.json"] {
+            let response = app(config.clone())
+                .oneshot(
+                    HttpRequest::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{path}");
+            assert_eq!(
+                response.headers().get(header::WWW_AUTHENTICATE),
+                Some(&"Basic realm=\"Office Climate\"".parse().expect("header"))
+            );
+        }
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/")
+                    .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -1740,6 +1798,23 @@ mod tests {
         let body = String::from_utf8(body.to_vec()).expect("utf8");
         assert!(body.contains("&lt;script&gt;alert(1)&lt;/script&gt;&amp;&quot;&#39;"));
         assert!(!body.contains("<script>"));
+    }
+
+    #[test]
+    fn script_json_string_round_trips_and_escapes_script_delimiters() {
+        let value = "quote'\"\\</script><script>&";
+        let literal = script_json_string(value);
+
+        assert_eq!(
+            serde_json::from_str::<String>(&literal).expect("json string"),
+            value
+        );
+        assert!(literal.contains("\\\""));
+        assert!(literal.contains("\\\\"));
+        assert!(literal.contains("\\u003c/script\\u003e"));
+        assert!(literal.contains("\\u0026"));
+        assert!(!literal.contains("</script>"));
+        assert!(!literal.contains("<script>"));
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -163,7 +163,8 @@ async fn auth_middleware(
     let headers = auth_headers_with_peer(request.headers(), remote_addr);
 
     let auth_mode = state.auth.mode();
-    if is_websocket_upgrade(&headers)
+    if request.uri().path() == "/ws"
+        && is_websocket_upgrade(&headers)
         && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
     {
         return next.run(request).await;
@@ -1311,6 +1312,29 @@ mod tests {
             .expect("read body");
         let value: Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(value["login_url"], "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn websocket_upgrade_header_does_not_bypass_non_ws_route_auth() {
+        let boundary = "deploy-boundary";
+        let body = multipart_body(boundary, b"apk-bytes");
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::UPGRADE, "websocket")
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -165,7 +165,7 @@ async fn auth_middleware(
     let auth_mode = state.auth.mode();
     if request.uri().path() == "/ws"
         && is_websocket_upgrade(&headers)
-        && matches!(auth_mode, HttpAuthMode::OAuth)
+        && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
     {
         return next.run(request).await;
     }
@@ -199,7 +199,13 @@ async fn auth_middleware(
         }
         HttpAuthMode::Basic => {
             if state.auth.verify_basic_header(&headers) {
-                return next.run(request).await;
+                let mut response = next.run(request).await;
+                if let Some(cookie) = state.auth.issue_basic_websocket_cookie() {
+                    if let Ok(cookie) = cookie.parse() {
+                        response.headers_mut().insert(header::SET_COOKIE, cookie);
+                    }
+                }
+                return response;
             }
 
             let mut response =
@@ -297,6 +303,11 @@ async fn websocket(
 }
 
 async fn websocket_session(mut socket: WebSocket, state: AppState, auth_mode: WebSocketAuth) {
+    if auth_mode == WebSocketAuth::Reject {
+        close_ws(&mut socket, "Authentication required").await;
+        return;
+    }
+
     if auth_mode == WebSocketAuth::FirstMessage {
         match timeout(Duration::from_secs(10), socket.recv()).await {
             Ok(Some(Ok(Message::Text(message)))) => {
@@ -1512,22 +1523,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn basic_auth_websocket_requires_credentials_before_upgrade() {
+    async fn basic_auth_websocket_requires_header_or_session_cookie() {
+        let service = app(basic_config());
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let websocket_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("basic websocket cookie")
+            .to_str()
+            .expect("cookie")
+            .split(';')
+            .next()
+            .expect("cookie pair")
+            .to_string();
+
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("addr");
         let server = tokio::spawn(async move {
             axum::serve(
                 listener,
-                app(basic_config()).into_make_service_with_connect_info::<std::net::SocketAddr>(),
+                service.into_make_service_with_connect_info::<std::net::SocketAddr>(),
             )
             .await
             .expect("server");
         });
 
-        let unauthenticated = connect_async(format!("ws://{address}/ws"))
+        let (mut unauthenticated, _) = connect_async(format!("ws://{address}/ws"))
             .await
-            .expect_err("unauthenticated websocket should fail");
-        assert!(unauthenticated.to_string().contains("401"));
+            .expect("unauthenticated websocket should upgrade for close frame");
+        let close = timeout(Duration::from_secs(1), unauthenticated.next())
+            .await
+            .expect("close timeout")
+            .expect("close message")
+            .expect("close ok");
+        assert!(matches!(close, TungsteniteMessage::Close(_)));
 
         let mut request = format!("ws://{address}/ws")
             .into_client_request()
@@ -1537,6 +1577,25 @@ mod tests {
             "Basic dXNlcjpwYXNz".parse().expect("header"),
         );
         let (mut ws, _) = connect_async(request).await.expect("connect");
+        let message = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("status timeout")
+            .expect("message")
+            .expect("message ok");
+        assert!(
+            message
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"away\"")
+        );
+
+        let mut request = format!("ws://{address}/ws")
+            .into_client_request()
+            .expect("request");
+        request
+            .headers_mut()
+            .insert(header::COOKIE, websocket_cookie.parse().expect("cookie"));
+        let (mut ws, _) = connect_async(request).await.expect("connect with cookie");
         let message = timeout(Duration::from_secs(1), ws.next())
             .await
             .expect("status timeout")

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -849,8 +849,13 @@ async fn deploy_app(
 }
 
 async fn latest_app_artifact(State(state): State<AppState>, Path(app): Path<String>) -> Response {
-    let Ok(Some(metadata)) = state.artifacts.read_metadata(&app).await else {
-        return StatusCode::NOT_FOUND.into_response();
+    let metadata = match state.artifacts.read_metadata(&app).await {
+        Ok(Some(metadata)) => metadata,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(error) => {
+            tracing::error!("artifact metadata read failed: {error:#}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
     };
 
     if !is_valid_artifact_hash(&metadata.artifact_hash) {
@@ -1885,6 +1890,30 @@ mod tests {
             response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
             "attachment; filename=office-climate.apk"
         );
+    }
+
+    #[tokio::test]
+    async fn latest_artifact_surfaces_malformed_metadata_as_server_error() {
+        let config = test_config();
+        let app_dir = config.runtime.artifacts_dir.join("office-climate");
+        tokio::fs::create_dir_all(&app_dir)
+            .await
+            .expect("create app dir");
+        tokio::fs::write(app_dir.join("meta.json"), "{not json")
+            .await
+            .expect("write malformed metadata");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/office-climate/latest.apk")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -714,7 +714,9 @@ async fn qingping_interval(Json(payload): Json<QingpingIntervalRequest>) -> Resp
 #[derive(Debug, Deserialize)]
 struct HistoryQuery {
     hours: Option<i64>,
+    days: Option<i64>,
     limit: Option<i64>,
+    bucket_minutes: Option<i64>,
 }
 
 fn clamp(value: Option<i64>, default: i64, min: i64, max: i64) -> i64 {
@@ -748,49 +750,143 @@ async fn history(State(state): State<AppState>, Query(query): Query<HistoryQuery
     .into_response()
 }
 
-async fn history_sessions() -> Response {
-    history_not_implemented("history sessions")
+async fn history_sessions(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_office_sessions(&state.config.runtime.database_path, days) {
+        Ok(payload) => Json(json!({"ok": true, "days": days, "sessions": payload["sessions"], "summary": payload["summary"]})).into_response(),
+        Err(error) => history_error("history/sessions", error),
+    }
 }
 
-async fn history_co2_ohlc() -> Response {
-    history_not_implemented("CO2 OHLC history")
+async fn history_co2_ohlc(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let hours = clamp(query.hours, 24, 1, 168);
+    let bucket_minutes = query
+        .bucket_minutes
+        .unwrap_or(default_co2_bucket(hours))
+        .max(1);
+    match db::read_co2_ohlc(&state.config.runtime.database_path, hours, bucket_minutes) {
+        Ok(payload) => Json(json!({"ok": true, "hours": hours, "bucket_minutes": payload["bucket_minutes"], "candles": payload["candles"]})).into_response(),
+        Err(error) => history_error("history/co2-ohlc", error),
+    }
 }
 
-async fn history_temperature() -> Response {
-    history_not_implemented("temperature history")
+async fn history_temperature(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let hours = clamp(query.hours, 24, 1, 168);
+    let bucket_minutes = query
+        .bucket_minutes
+        .unwrap_or(default_temperature_bucket(hours))
+        .max(1);
+    match db::read_temperature_history(&state.config.runtime.database_path, hours, bucket_minutes) {
+        Ok(payload) => Json(json!({"ok": true, "hours": hours, "bucket_minutes": payload["bucket_minutes"], "points": payload["points"]})).into_response(),
+        Err(error) => history_error("history/temperature", error),
+    }
 }
 
-async fn history_daily_stats() -> Response {
-    history_not_implemented("daily stats history")
+async fn history_daily_stats(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_daily_stats(&state.config.runtime.database_path, days) {
+        Ok(stats) => Json(json!({"ok": true, "days": days, "stats": stats})).into_response(),
+        Err(error) => history_error("history/daily-stats", error),
+    }
 }
 
-async fn history_openings() -> Response {
-    history_not_implemented("opening history")
+async fn history_openings(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_openings(&state.config.runtime.database_path, days) {
+        Ok(days) => Json(json!({"ok": true, "days": days})).into_response(),
+        Err(error) => history_error("history/openings", error),
+    }
 }
 
-async fn history_orchestration() -> Response {
-    history_not_implemented("orchestration history")
+async fn history_orchestration(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_orchestration_activity(&state.config.runtime.database_path, days) {
+        Ok(days) => Json(json!({"ok": true, "days": days})).into_response(),
+        Err(error) => history_error("history/orchestration", error),
+    }
 }
 
-async fn history_project_focus() -> Response {
-    history_not_implemented("project focus history")
+async fn history_project_focus(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_project_focus(&state.config.runtime.database_path, days) {
+        Ok(days) => Json(json!({"ok": true, "days": days})).into_response(),
+        Err(error) => history_error("history/project-focus", error),
+    }
 }
 
-async fn history_leverage() -> Response {
-    history_not_implemented("leverage history")
+async fn history_leverage(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_leverage_history(&state.config.runtime.database_path, days) {
+        Ok(payload) => Json(json!({"ok": true, "days": payload["days"], "week": payload["week"]}))
+            .into_response(),
+        Err(error) => history_error("history/leverage", error),
+    }
 }
 
-async fn history_project_leverage() -> Response {
-    history_not_implemented("project leverage history")
+async fn history_project_leverage(
+    State(state): State<AppState>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    let days = clamp(query.days, 7, 1, 30);
+    match db::read_project_leverage(&state.config.runtime.database_path, days) {
+        Ok(payload) => Json(json!({"ok": true, "projects": payload["projects"]})).into_response(),
+        Err(error) => history_error("history/project-leverage", error),
+    }
 }
 
-fn history_not_implemented(name: &str) -> Response {
+fn default_co2_bucket(hours: i64) -> i64 {
+    if hours <= 1 {
+        5
+    } else if hours <= 6 {
+        15
+    } else if hours <= 24 {
+        60
+    } else {
+        240
+    }
+}
+
+fn default_temperature_bucket(hours: i64) -> i64 {
+    if hours <= 1 {
+        5
+    } else if hours <= 6 {
+        15
+    } else if hours <= 24 {
+        30
+    } else {
+        120
+    }
+}
+
+fn history_error(route: &str, error: anyhow::Error) -> Response {
+    tracing::error!("failed to read {route}: {error:#}");
     (
-        StatusCode::NOT_IMPLEMENTED,
-        Json(json!({
-            "ok": false,
-            "error": format!("{name} is not implemented in the Rust compatibility server yet"),
-        })),
+        StatusCode::BAD_REQUEST,
+        Json(json!({"ok": false, "error": error.to_string()})),
     )
         .into_response()
 }
@@ -1668,19 +1764,116 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn secondary_history_routes_fail_loudly_until_ported() {
-        for path in [
-            "/history/sessions?days=7",
-            "/history/co2-ohlc?hours=24",
-            "/history/temperature?hours=24",
-            "/history/daily-stats?days=7",
-            "/history/openings?days=7",
-            "/history/orchestration?days=7",
-            "/history/project-focus?days=7",
-            "/history/leverage?days=7",
-            "/history/project-leverage?days=7",
+    async fn secondary_history_routes_return_compatible_payloads() {
+        let config = test_config();
+        db::migrate_database(&config.runtime.database_path).expect("migration");
+        let connection =
+            rusqlite::Connection::open(&config.runtime.database_path).expect("open database");
+        let now = chrono::Local::now().naive_local();
+        let today = now.date();
+        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+        let present_at = today
+            .and_hms_opt(9, 0, 0)
+            .expect("present timestamp")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let away_at = today
+            .and_hms_opt(12, 0, 0)
+            .expect("away timestamp")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let open_at = today
+            .and_hms_opt(10, 0, 0)
+            .expect("open timestamp")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let close_at = today
+            .and_hms_opt(10, 15, 0)
+            .expect("close timestamp")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        connection
+            .execute(
+                "INSERT INTO occupancy_log (timestamp, state) VALUES (?, ?), (?, ?)",
+                (&present_at, "present", &away_at, "away"),
+            )
+            .expect("insert occupancy");
+        connection
+            .execute(
+                "INSERT INTO sensor_readings (timestamp, co2_ppm, temp_c, source) VALUES (?, ?, ?, ?)",
+                (&timestamp, 900, 22.0, "qingping"),
+            )
+            .expect("insert sensor");
+        connection
+            .execute(
+                "INSERT INTO device_events (timestamp, device_type, event) VALUES (?, ?, ?), (?, ?, ?)",
+                (&open_at, "door", "open", &close_at, "door", "closed"),
+            )
+            .expect("insert device events");
+        connection
+            .execute(
+                "INSERT INTO climate_actions (timestamp, system, action) VALUES (?, ?, ?), (?, ?, ?)",
+                (&present_at, "erv", "quiet", &away_at, "erv", "off"),
+            )
+            .expect("insert climate");
+        connection
+            .execute(
+                "INSERT INTO orchestration_activity (timestamp, tool, project, session_id) VALUES (?, ?, ?, ?)",
+                (&timestamp, "codex", "fractal-1234-work", "session-1"),
+            )
+            .expect("insert orchestration");
+        connection
+            .execute(
+                "INSERT INTO github_prs (repo, pr_number, title, state, created_at, merged_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "rajeshgoli/office-automation",
+                    83,
+                    "Port HTTP contracts",
+                    "MERGED",
+                    &timestamp,
+                    &timestamp,
+                ),
+            )
+            .expect("insert pr");
+        connection
+            .execute(
+                "INSERT INTO project_leverage (date, project, metric, value) VALUES (?, ?, ?, ?)",
+                (today.to_string(), "session-manager", "sm_dispatches", 2.0),
+            )
+            .expect("insert project leverage");
+
+        let service = app(config);
+        for (path, checks) in [
+            (
+                "/history/sessions?days=1",
+                vec![("sessions", "array"), ("summary", "object")],
+            ),
+            (
+                "/history/co2-ohlc?hours=1&bucket_minutes=60",
+                vec![("candles", "array"), ("bucket_minutes", "number")],
+            ),
+            (
+                "/history/temperature?hours=1&bucket_minutes=60",
+                vec![("points", "array"), ("bucket_minutes", "number")],
+            ),
+            (
+                "/history/daily-stats?days=1",
+                vec![("stats", "array"), ("days", "number")],
+            ),
+            ("/history/openings?days=1", vec![("days", "array")]),
+            ("/history/orchestration?days=1", vec![("days", "array")]),
+            ("/history/project-focus?days=1", vec![("days", "array")]),
+            (
+                "/history/leverage?days=1",
+                vec![("days", "array"), ("week", "object")],
+            ),
+            (
+                "/history/project-leverage?days=1",
+                vec![("projects", "object")],
+            ),
         ] {
-            let response = app(test_config())
+            let response = service
+                .clone()
                 .oneshot(
                     HttpRequest::builder()
                         .uri(path)
@@ -1690,19 +1883,20 @@ mod tests {
                 .await
                 .expect("response");
 
-            assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED, "{path}");
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
             let body = to_bytes(response.into_body(), usize::MAX)
                 .await
                 .expect("read body");
             let value: Value = serde_json::from_slice(&body).expect("json body");
-            assert_eq!(value["ok"], false, "{path}");
-            assert!(
-                value["error"]
-                    .as_str()
-                    .expect("error")
-                    .contains("not implemented"),
-                "{path}"
-            );
+            assert_eq!(value["ok"], true, "{path}");
+            for (field, kind) in checks {
+                match kind {
+                    "array" => assert!(value[field].is_array(), "{path} {field}"),
+                    "object" => assert!(value[field].is_object(), "{path} {field}"),
+                    "number" => assert!(value[field].is_number(), "{path} {field}"),
+                    _ => unreachable!("unknown kind"),
+                }
+            }
         }
     }
 

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1,33 +1,108 @@
+use std::{collections::HashMap, time::Duration};
+
 use anyhow::{Context, Result};
 use axum::{
     Json, Router,
-    http::{Method, header},
-    routing::get,
+    body::Body,
+    extract::{
+        ConnectInfo, Extension, Multipart, Path, Query, Request, State, WebSocketUpgrade,
+        ws::{CloseFrame, Message, WebSocket},
+    },
+    http::{HeaderMap, Method, StatusCode, header},
+    middleware::{self, Next},
+    response::{Html, IntoResponse, Response},
+    routing::{get, get_service, post},
 };
-use tokio::net::TcpListener;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, time::timeout};
 use tower_http::{
     cors::{Any, CorsLayer},
+    services::ServeDir,
     trace::TraceLayer,
 };
 
-use crate::{config::AppConfig, status::Status};
+use crate::{
+    artifacts::{ArtifactStore, is_valid_artifact_hash},
+    auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
+    config::AppConfig,
+    status::{Status, TemperatureBands},
+};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct AppState {
     config: AppConfig,
+    auth: AuthManager,
+    artifacts: ArtifactStore,
 }
 
 pub fn app(config: AppConfig) -> Router {
+    try_app(config).expect("failed to build HTTP app")
+}
+
+pub fn try_app(config: AppConfig) -> Result<Router> {
+    let auth = AuthManager::new(&config.orchestrator)?;
+    let artifacts = ArtifactStore::new(
+        config.runtime.artifacts_dir.clone(),
+        config.runtime.legacy_apk_path.clone(),
+    );
+    let state = AppState {
+        config,
+        auth,
+        artifacts,
+    };
+
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 
-    Router::new()
+    let frontend_dist = state.config.runtime.frontend_dist.clone();
+    let assets_dir = frontend_dist.join("assets");
+
+    Ok(Router::new()
         .route("/status", get(status))
-        .with_state(AppState { config })
+        .route("/ws", get(websocket))
+        .route("/occupancy", post(occupancy))
+        .route("/presence", post(presence))
+        .route("/erv", post(erv))
+        .route("/hvac", post(hvac))
+        .route(
+            "/hvac/temperature-bands",
+            get(hvac_temperature_bands).post(update_hvac_temperature_bands),
+        )
+        .route("/qingping/interval", post(qingping_interval))
+        .route("/history", get(history))
+        .route("/history/sessions", get(history_sessions))
+        .route("/history/co2-ohlc", get(history_co2_ohlc))
+        .route("/history/temperature", get(history_temperature))
+        .route("/history/daily-stats", get(history_daily_stats))
+        .route("/history/openings", get(history_openings))
+        .route("/history/orchestration", get(history_orchestration))
+        .route("/history/project-focus", get(history_project_focus))
+        .route("/history/leverage", get(history_leverage))
+        .route("/history/project-leverage", get(history_project_leverage))
+        .route("/deploy/{app}", post(deploy_app))
+        .route("/apps/{app}/latest.apk", get(latest_app_artifact))
+        .route("/apps/{app}/{artifact_file}", get(hashed_app_artifact))
+        .route("/apps/{app}/meta.json", get(app_artifact_meta))
+        .route("/apk", get(legacy_apk))
+        .route("/auth/login", get(auth_login))
+        .route("/auth/callback", get(auth_callback))
+        .route("/auth/logout", post(auth_logout))
+        .route("/auth/device/start", post(auth_device_start))
+        .route("/auth/device/poll", post(auth_device_poll))
+        .route("/localtunnel/password", get(localtunnel_gone))
+        .nest_service("/assets", get_service(ServeDir::new(assets_dir)))
+        .route("/", get(index))
+        .route("/{*path}", get(spa_fallback))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ))
+        .with_state(state)
         .layer(cors)
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http()))
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
@@ -37,38 +112,798 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         .with_context(|| format!("failed to bind HTTP listener at {bind_address}"))?;
 
     tracing::info!("office-automate-server listening on {}", bind_address);
-    axum::serve(listener, app(config))
-        .await
-        .context("HTTP server failed")
+    axum::serve(
+        listener,
+        try_app(config)
+            .context("failed to build HTTP app")?
+            .into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await
+    .context("HTTP server failed")
 }
 
-async fn status(axum::extract::State(state): axum::extract::State<AppState>) -> Json<Status> {
+async fn auth_middleware(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    if should_skip_auth(request.method(), request.uri().path(), request.headers()) {
+        return next.run(request).await;
+    }
+
+    let mut headers = request.headers().clone();
+    if !headers.contains_key("x-forwarded-for") {
+        if let Some(ConnectInfo(remote_addr)) = request
+            .extensions()
+            .get::<ConnectInfo<std::net::SocketAddr>>()
+        {
+            if let Ok(value) = remote_addr.ip().to_string().parse() {
+                headers.insert("x-forwarded-for", value);
+            }
+        }
+    }
+
+    match state.auth.mode() {
+        HttpAuthMode::Open => next.run(request).await,
+        HttpAuthMode::OAuth => {
+            if state.auth.is_trusted_request(&headers) {
+                request.extensions_mut().insert(AuthenticatedUser {
+                    email: "trusted_network".to_string(),
+                });
+                return next.run(request).await;
+            }
+
+            let Some(user) = state.auth.verify_bearer_header(&headers) else {
+                let missing = bearer_token(&headers).is_none();
+                let message = if missing {
+                    "Authentication required"
+                } else {
+                    "Invalid or expired token"
+                };
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": message, "login_url": "/auth/login"})),
+                )
+                    .into_response();
+            };
+
+            request.extensions_mut().insert(user);
+            next.run(request).await
+        }
+        HttpAuthMode::Basic => {
+            if state.auth.verify_basic_header(&headers) {
+                return next.run(request).await;
+            }
+
+            let mut response =
+                (StatusCode::UNAUTHORIZED, "Authentication required").into_response();
+            response.headers_mut().insert(
+                header::WWW_AUTHENTICATE,
+                "Basic realm=\"Office Climate\"".parse().expect("header"),
+            );
+            response
+        }
+    }
+}
+
+fn should_skip_auth(method: &Method, path: &str, headers: &HeaderMap) -> bool {
+    if *method == Method::OPTIONS {
+        return true;
+    }
+
+    if is_websocket_upgrade(headers) {
+        return true;
+    }
+
+    if path == "/apk" || path.starts_with("/apps/") {
+        return true;
+    }
+
+    if path == "/auth/login"
+        || path == "/auth/callback"
+        || path == "/auth/device/start"
+        || path == "/auth/device/poll"
+    {
+        return true;
+    }
+
+    path == "/"
+        || path == "/index.html"
+        || path.starts_with("/assets/")
+        || path.ends_with(".png")
+        || path.ends_with(".json")
+}
+
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"))
+}
+
+async fn status(State(state): State<AppState>) -> Json<Status> {
     Json(Status::read_only_default(&state.config))
+}
+
+async fn websocket(
+    State(state): State<AppState>,
+    ConnectInfo(remote_addr): ConnectInfo<std::net::SocketAddr>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let mut auth_headers = headers.clone();
+    if !auth_headers.contains_key("x-forwarded-for") {
+        if let Ok(value) = remote_addr.ip().to_string().parse() {
+            auth_headers.insert("x-forwarded-for", value);
+        }
+    }
+    let mode = state.auth.websocket_auth(&auth_headers);
+    ws.on_upgrade(move |socket| websocket_session(socket, state, mode))
+}
+
+async fn websocket_session(mut socket: WebSocket, state: AppState, auth_mode: WebSocketAuth) {
+    if auth_mode == WebSocketAuth::FirstMessage {
+        match timeout(Duration::from_secs(10), socket.recv()).await {
+            Ok(Some(Ok(Message::Text(message)))) => {
+                let Ok(value) = serde_json::from_str::<Value>(&message) else {
+                    close_ws(&mut socket, "Authentication required").await;
+                    return;
+                };
+                if value.get("type").and_then(Value::as_str) != Some("auth") {
+                    close_ws(&mut socket, "Authentication required").await;
+                    return;
+                }
+                let Some(token) = value.get("token").and_then(Value::as_str) else {
+                    close_ws(&mut socket, "Authentication required").await;
+                    return;
+                };
+                if state.auth.verify_jwt(token).is_none() {
+                    close_ws(&mut socket, "Invalid token").await;
+                    return;
+                }
+            }
+            _ => {
+                close_ws(&mut socket, "Authentication failed").await;
+                return;
+            }
+        }
+    }
+
+    if send_status(&mut socket, &state).await.is_err() {
+        return;
+    }
+
+    while let Some(message) = socket.recv().await {
+        match message {
+            Ok(Message::Text(text)) if text == "ping" => {
+                let _ = socket.send(Message::Text("pong".into())).await;
+            }
+            Ok(Message::Close(_)) => break,
+            Ok(_) => {}
+            Err(error) => {
+                tracing::debug!("websocket receive error: {error}");
+                break;
+            }
+        }
+    }
+}
+
+async fn close_ws(socket: &mut WebSocket, reason: &str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: 4001,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
+async fn send_status(socket: &mut WebSocket, state: &AppState) -> Result<(), axum::Error> {
+    let status = serde_json::to_string(&Status::read_only_default(&state.config))
+        .expect("status serializes");
+    socket.send(Message::Text(status.into())).await
+}
+
+#[derive(Debug, Deserialize)]
+struct OccupancyRequest {
+    last_active_timestamp: f64,
+    #[serde(default)]
+    external_monitor: bool,
+}
+
+async fn occupancy(Json(payload): Json<OccupancyRequest>) -> Json<Value> {
+    let _ = (payload.last_active_timestamp, payload.external_monitor);
+    Json(json!({"ok": true, "state": "away", "erv_should_run": false}))
+}
+
+#[derive(Debug, Deserialize)]
+struct PresenceRequest {
+    state: String,
+}
+
+async fn presence(Json(payload): Json<PresenceRequest>) -> Response {
+    match payload.state.as_str() {
+        "present" => {
+            Json(json!({"ok": true, "state": "present", "is_present": true})).into_response()
+        }
+        "away" => Json(json!({"ok": true, "state": "away", "is_present": false})).into_response(),
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "state must be present or away"})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ErvRequest {
+    speed: String,
+}
+
+async fn erv(Json(payload): Json<ErvRequest>) -> Response {
+    if !matches!(payload.speed.as_str(), "off" | "quiet" | "medium" | "turbo") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "Invalid ERV speed"})),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(
+            json!({"ok": false, "error": "ERV control is not enabled in Rust compatibility mode"}),
+        ),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+struct HvacRequest {
+    mode: String,
+    setpoint_f: Option<f64>,
+}
+
+async fn hvac(Json(payload): Json<HvacRequest>) -> Response {
+    if !matches!(payload.mode.as_str(), "off" | "heat" | "cool") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "Invalid HVAC mode"})),
+        )
+            .into_response();
+    }
+    let _ = payload.setpoint_f;
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(
+            json!({"ok": false, "error": "HVAC control is not enabled in Rust compatibility mode"}),
+        ),
+    )
+        .into_response()
+}
+
+async fn hvac_temperature_bands(State(state): State<AppState>) -> Json<Value> {
+    temperature_bands_response(TemperatureBands::from_config(&state.config), &state.config)
+}
+
+#[derive(Debug, Deserialize)]
+struct TemperatureBandsPayload {
+    temperature_bands: Option<TemperatureBands>,
+    heat_on_temp_f: Option<i64>,
+    heat_off_temp_f: Option<i64>,
+    cool_off_temp_f: Option<i64>,
+    cool_on_temp_f: Option<i64>,
+}
+
+async fn update_hvac_temperature_bands(
+    State(state): State<AppState>,
+    Json(payload): Json<TemperatureBandsPayload>,
+) -> Response {
+    let bands = payload.temperature_bands.unwrap_or(TemperatureBands {
+        heat_on_temp_f: payload.heat_on_temp_f.unwrap_or_default(),
+        heat_off_temp_f: payload.heat_off_temp_f.unwrap_or_default(),
+        cool_off_temp_f: payload.cool_off_temp_f.unwrap_or_default(),
+        cool_on_temp_f: payload.cool_on_temp_f.unwrap_or_default(),
+    });
+
+    if let Err(error) = validate_temperature_bands(bands) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": error})),
+        )
+            .into_response();
+    }
+
+    temperature_bands_response(bands, &state.config).into_response()
+}
+
+fn temperature_bands_response(bands: TemperatureBands, config: &AppConfig) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "temperature_bands": bands,
+        "temperature_band_defaults": TemperatureBands::from_config(config),
+    }))
+}
+
+fn validate_temperature_bands(bands: TemperatureBands) -> Result<(), &'static str> {
+    if !(45..=85).contains(&bands.heat_on_temp_f) {
+        return Err("heat_on_temp_f must be between 45 and 85");
+    }
+    if !(46..=90).contains(&bands.heat_off_temp_f) {
+        return Err("heat_off_temp_f must be between 46 and 90");
+    }
+    if !(55..=95).contains(&bands.cool_off_temp_f) {
+        return Err("cool_off_temp_f must be between 55 and 95");
+    }
+    if !(56..=100).contains(&bands.cool_on_temp_f) {
+        return Err("cool_on_temp_f must be between 56 and 100");
+    }
+    if bands.heat_on_temp_f >= bands.heat_off_temp_f {
+        return Err("heat_on_temp_f must be below heat_off_temp_f");
+    }
+    if bands.cool_off_temp_f >= bands.cool_on_temp_f {
+        return Err("cool_off_temp_f must be below cool_on_temp_f");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct QingpingIntervalRequest {
+    interval: i64,
+}
+
+async fn qingping_interval(Json(payload): Json<QingpingIntervalRequest>) -> Response {
+    if payload.interval < 15 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "interval must be >= 15"})),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"ok": false, "error": "MQTT command path is not enabled yet"})),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryQuery {
+    hours: Option<i64>,
+    days: Option<i64>,
+    limit: Option<i64>,
+    bucket_minutes: Option<i64>,
+}
+
+fn clamp(value: Option<i64>, default: i64, min: i64, max: i64) -> i64 {
+    value.unwrap_or(default).clamp(min, max)
+}
+
+async fn history(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({
+        "ok": true,
+        "hours": clamp(query.hours, 24, 1, 168),
+        "sensor_readings": [],
+        "occupancy_history": [],
+        "device_events": [],
+        "climate_actions": [],
+        "limit": clamp(query.limit, 1000, 10, 10000),
+    }))
+}
+
+async fn history_sessions(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": clamp(query.days, 7, 1, 30), "sessions": [], "summary": {}}))
+}
+
+async fn history_co2_ohlc(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    let hours = clamp(query.hours, 24, 1, 168);
+    Json(json!({
+        "ok": true,
+        "hours": hours,
+        "bucket_minutes": query.bucket_minutes.unwrap_or(default_co2_bucket(hours)),
+        "candles": [],
+    }))
+}
+
+async fn history_temperature(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    let hours = clamp(query.hours, 24, 1, 168);
+    Json(json!({
+        "ok": true,
+        "hours": hours,
+        "bucket_minutes": query.bucket_minutes.unwrap_or(default_temperature_bucket(hours)),
+        "points": [],
+    }))
+}
+
+async fn history_daily_stats(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": clamp(query.days, 7, 1, 30), "stats": []}))
+}
+
+async fn history_openings(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+}
+
+async fn history_orchestration(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+}
+
+async fn history_project_focus(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+}
+
+async fn history_leverage(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    Json(json!({"ok": true, "days": [], "week": {}, "requested_days": clamp(query.days, 7, 1, 30)}))
+}
+
+async fn history_project_leverage(Query(query): Query<HistoryQuery>) -> Json<Value> {
+    let _ = clamp(query.days, 7, 1, 30);
+    Json(json!({"ok": true, "projects": {}}))
+}
+
+fn default_co2_bucket(hours: i64) -> i64 {
+    if hours <= 6 {
+        5
+    } else if hours <= 24 {
+        15
+    } else if hours <= 72 {
+        60
+    } else {
+        240
+    }
+}
+
+fn default_temperature_bucket(hours: i64) -> i64 {
+    if hours <= 6 {
+        5
+    } else if hours <= 24 {
+        15
+    } else if hours <= 72 {
+        30
+    } else {
+        120
+    }
+}
+
+async fn deploy_app(
+    State(state): State<AppState>,
+    user: Option<Extension<AuthenticatedUser>>,
+    Path(app): Path<String>,
+    multipart: Multipart,
+) -> Response {
+    let user_email = user
+        .map(|Extension(user)| user.email)
+        .unwrap_or_else(|| "unknown".to_string());
+    match state
+        .artifacts
+        .store_upload(&app, multipart, &user_email)
+        .await
+    {
+        Ok(outcome) => Json(json!({
+            "ok": true,
+            "app": outcome.app,
+            "size_bytes": outcome.size_bytes,
+            "download_url": outcome.download_url,
+        }))
+        .into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn latest_app_artifact(State(state): State<AppState>, Path(app): Path<String>) -> Response {
+    let Ok(Some(metadata)) = state.artifacts.read_metadata(&app).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    if !is_valid_artifact_hash(&metadata.artifact_hash) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let mut response = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(
+            header::LOCATION,
+            format!("/apps/{app}/{}.apk", metadata.artifact_hash),
+        )
+        .body(Body::empty())
+        .expect("valid redirect response");
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, "no-cache".parse().expect("header"));
+    response
+}
+
+async fn hashed_app_artifact(
+    State(state): State<AppState>,
+    Path((app, artifact_file)): Path<(String, String)>,
+) -> Response {
+    let Some(artifact_hash) = artifact_file.strip_suffix(".apk") else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    match state
+        .artifacts
+        .serve_hashed_artifact(&app, artifact_hash)
+        .await
+    {
+        Ok(Some(response)) => response,
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => {
+            tracing::error!("artifact read failed: {error:#}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn app_artifact_meta(State(state): State<AppState>, Path(app): Path<String>) -> Response {
+    match state.artifacts.read_metadata(&app).await {
+        Ok(Some(metadata)) => Json(metadata).into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => {
+            tracing::error!("artifact metadata read failed: {error:#}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn legacy_apk(State(state): State<AppState>) -> Response {
+    match state.artifacts.serve_legacy_apk().await {
+        Ok(Some(response)) => response,
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => {
+            tracing::error!("legacy APK read failed: {error:#}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn auth_login(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !state.auth.oauth_enabled() {
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(json!({"error": "OAuth not configured"})),
+        )
+            .into_response();
+    }
+
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Missing Host header"})),
+        )
+            .into_response();
+    };
+    let platform = query
+        .get("platform")
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty());
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok());
+
+    match state.auth.begin_login(host, forwarded_proto, platform) {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("failed to start OAuth login: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "Failed to start OAuth"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn auth_callback(
+    State(state): State<AppState>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !state.auth.oauth_enabled() {
+        return (StatusCode::NOT_IMPLEMENTED, "OAuth not configured").into_response();
+    }
+
+    if let Some(error) = query.get("error") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html(format!(
+                "<html><body><h1>Login Failed</h1><p>{error}</p></body></html>"
+            )),
+        )
+            .into_response();
+    }
+
+    let (Some(code), Some(oauth_state)) = (query.get("code"), query.get("state")) else {
+        return (StatusCode::BAD_REQUEST, "Missing code or state").into_response();
+    };
+
+    match state.auth.finish_callback(code, oauth_state).await {
+        Ok(Some(login)) if login.platform.as_deref() == Some("android") => Response::builder()
+            .status(StatusCode::FOUND)
+            .header(
+                header::LOCATION,
+                format!(
+                    "officeclimate://auth?token={}&email={}",
+                    urlencoding::encode(&login.jwt),
+                    urlencoding::encode(&login.email)
+                ),
+            )
+            .body(Body::empty())
+            .expect("valid android redirect response"),
+        Ok(Some(login)) => Html(format!(
+            "<html><head><script>localStorage.setItem('auth_token', '{}');localStorage.setItem('user_email', '{}');window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
+            login.jwt, login.email
+        ))
+        .into_response(),
+        Ok(None) => (
+            StatusCode::FORBIDDEN,
+            Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
+        )
+            .into_response(),
+        Err(error) if error.to_string() == "Invalid state" => {
+            (StatusCode::BAD_REQUEST, "Invalid state").into_response()
+        }
+        Err(error) => {
+            tracing::error!("OAuth callback failed: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "OAuth callback failed").into_response()
+        }
+    }
+}
+
+async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if !state.auth.oauth_enabled() {
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(json!({"error": "OAuth not configured"})),
+        )
+            .into_response();
+    }
+
+    let Some(token) = bearer_token(&headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "No token provided"})),
+        )
+            .into_response();
+    };
+
+    state.auth.invalidate_token(token);
+    Json(json!({"ok": true, "message": "Logged out"})).into_response()
+}
+
+async fn auth_device_start(State(state): State<AppState>) -> Response {
+    if !state.auth.oauth_enabled() {
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(json!({"error": "OAuth not configured"})),
+        )
+            .into_response();
+    }
+
+    match state.auth.start_device_flow().await {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("device flow start failed: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": error.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicePollRequest {
+    device_code: Option<String>,
+}
+
+async fn auth_device_poll(
+    State(state): State<AppState>,
+    Json(payload): Json<DevicePollRequest>,
+) -> Response {
+    if !state.auth.oauth_enabled() {
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(json!({"error": "OAuth not configured"})),
+        )
+            .into_response();
+    }
+
+    let Some(device_code) = payload.device_code.filter(|code| !code.is_empty()) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Missing device_code"})),
+        )
+            .into_response();
+    };
+
+    match state.auth.poll_device_flow(&device_code).await {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("device flow poll failed: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "error", "message": error.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn localtunnel_gone() -> impl IntoResponse {
+    (
+        StatusCode::GONE,
+        Json(json!({
+            "ok": false,
+            "error": "LocalTunnel is not supported; use Cloudflare Tunnel",
+        })),
+    )
+}
+
+async fn index(State(state): State<AppState>) -> Response {
+    serve_static_or_index(&state, "index.html").await
+}
+
+async fn spa_fallback(State(state): State<AppState>, Path(path): Path<String>) -> Response {
+    serve_static_or_index(&state, &path).await
+}
+
+async fn serve_static_or_index(state: &AppState, path: &str) -> Response {
+    let requested = state.config.runtime.frontend_dist.join(path);
+    let target = if requested.exists() && requested.is_file() {
+        requested
+    } else {
+        state.config.runtime.frontend_dist.join("index.html")
+    };
+
+    match tokio::fs::read(&target).await {
+        Ok(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(bytes))
+            .expect("static response"),
+        Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use axum::{
         body::{Body, to_bytes},
-        http::{Request, StatusCode},
+        http::Request as HttpRequest,
+    };
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::{
+        connect_async,
+        tungstenite::{Message as TungsteniteMessage, client::IntoClientRequest},
     };
     use tower::ServiceExt;
 
     use super::*;
-    use crate::config::{OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig};
+    use crate::config::{
+        GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
+    };
 
     fn test_config() -> AppConfig {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.keep();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
             qingping: QingpingConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
-                root: PathBuf::from("/tmp/office"),
-                config_path: PathBuf::from("/tmp/office/config.yaml"),
-                data_dir: PathBuf::from("/tmp/office/data"),
-                database_path: PathBuf::from("/tmp/office/data/office_climate.db"),
+                root: root.clone(),
+                config_path: root.join("config.yaml"),
+                data_dir: root.join("data"),
+                database_path: root.join("data/office_climate.db"),
+                frontend_dist: root.join("frontend/dist"),
+                artifacts_dir: root.join("data/apps"),
+                legacy_apk_path: root.join("data/app-debug.apk"),
                 base_url: None,
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
@@ -77,11 +912,43 @@ mod tests {
         }
     }
 
+    fn oauth_config() -> AppConfig {
+        AppConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: vec!["127.0.0.1/32".to_string()],
+                    ..GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        }
+    }
+
+    fn multipart_body(boundary: &str, bytes: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"version_code\"\r\n\r\n7\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(format!("--{boundary}\r\nContent-Disposition: form-data; name=\"version_name\"\r\n\r\n1.2.0\r\n").as_bytes());
+        body.extend_from_slice(format!("--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"artifact.apk\"\r\nContent-Type: application/vnd.android.package-archive\r\n\r\n").as_bytes());
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        body
+    }
+
     #[tokio::test]
     async fn status_route_returns_compatibility_skeleton() {
         let response = app(test_config())
             .oneshot(
-                Request::builder()
+                HttpRequest::builder()
                     .uri("/status")
                     .body(Body::empty())
                     .expect("request"),
@@ -94,7 +961,7 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("read body");
-        let value: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
 
         assert_eq!(value["state"], "away");
         assert!(value.get("sensors").is_some());
@@ -102,5 +969,235 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn oauth_middleware_requires_bearer_for_protected_routes() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["login_url"], "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn artifact_upload_and_download_preserve_metadata_and_headers() {
+        let config = oauth_config();
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let boundary = "test-boundary";
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["download_url"], "/apps/office-climate/latest.apk");
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/office-climate/meta.json")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let metadata: Value = serde_json::from_slice(&body).expect("json body");
+        let artifact_hash = metadata["artifact_hash"].as_str().expect("hash");
+        assert_eq!(metadata["uploaded_by"], "engineer@rajeshgo.li");
+        assert_eq!(metadata["version_code"], 7);
+        assert_eq!(metadata["version_name"], "1.2.0");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri(format!("/apps/office-climate/{artifact_hash}.apk"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=31536000, immutable"
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=office-climate.apk"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_first_message_auth_delays_initial_status_until_token() {
+        let config = AppConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: Vec::new(),
+                    ..GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        };
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app(config).into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
+            .await
+            .expect("connect");
+        assert!(
+            timeout(Duration::from_millis(100), ws.next())
+                .await
+                .is_err()
+        );
+
+        ws.send(TungsteniteMessage::Text(
+            json!({"type": "auth", "token": token}).to_string().into(),
+        ))
+        .await
+        .expect("send auth");
+        let message = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("status timeout")
+            .expect("message")
+            .expect("message ok");
+        assert!(
+            message
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"away\"")
+        );
+
+        ws.send(TungsteniteMessage::Text("ping".to_string().into()))
+            .await
+            .expect("send ping");
+        let message = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("pong timeout")
+            .expect("message")
+            .expect("message ok");
+        assert_eq!(message.into_text().expect("text"), "pong");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_upgrade_bearer_auth_receives_initial_status_immediately() {
+        let config = AppConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: Vec::new(),
+                    ..GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            ..test_config()
+        };
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app(config).into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let mut request = format!("ws://{address}/ws")
+            .into_client_request()
+            .expect("request");
+        request.headers_mut().insert(
+            header::AUTHORIZATION,
+            format!("Bearer {token}").parse().expect("header"),
+        );
+        let (mut ws, _) = connect_async(request).await.expect("connect");
+
+        let message = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("status timeout")
+            .expect("message")
+            .expect("message ok");
+        assert!(
+            message
+                .into_text()
+                .expect("text")
+                .contains("\"state\":\"away\"")
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn localtunnel_route_is_gone_for_cloudflared_target() {
+        let response = app(test_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/localtunnel/password")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::GONE);
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -714,9 +714,7 @@ async fn qingping_interval(Json(payload): Json<QingpingIntervalRequest>) -> Resp
 #[derive(Debug, Deserialize)]
 struct HistoryQuery {
     hours: Option<i64>,
-    days: Option<i64>,
     limit: Option<i64>,
-    bucket_minutes: Option<i64>,
 }
 
 fn clamp(value: Option<i64>, default: i64, min: i64, max: i64) -> i64 {
@@ -750,77 +748,51 @@ async fn history(State(state): State<AppState>, Query(query): Query<HistoryQuery
     .into_response()
 }
 
-async fn history_sessions(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": clamp(query.days, 7, 1, 30), "sessions": [], "summary": {}}))
+async fn history_sessions() -> Response {
+    history_not_implemented("history sessions")
 }
 
-async fn history_co2_ohlc(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    let hours = clamp(query.hours, 24, 1, 168);
-    Json(json!({
-        "ok": true,
-        "hours": hours,
-        "bucket_minutes": query.bucket_minutes.unwrap_or(default_co2_bucket(hours)),
-        "candles": [],
-    }))
+async fn history_co2_ohlc() -> Response {
+    history_not_implemented("CO2 OHLC history")
 }
 
-async fn history_temperature(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    let hours = clamp(query.hours, 24, 1, 168);
-    Json(json!({
-        "ok": true,
-        "hours": hours,
-        "bucket_minutes": query.bucket_minutes.unwrap_or(default_temperature_bucket(hours)),
-        "points": [],
-    }))
+async fn history_temperature() -> Response {
+    history_not_implemented("temperature history")
 }
 
-async fn history_daily_stats(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": clamp(query.days, 7, 1, 30), "stats": []}))
+async fn history_daily_stats() -> Response {
+    history_not_implemented("daily stats history")
 }
 
-async fn history_openings(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+async fn history_openings() -> Response {
+    history_not_implemented("opening history")
 }
 
-async fn history_orchestration(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+async fn history_orchestration() -> Response {
+    history_not_implemented("orchestration history")
 }
 
-async fn history_project_focus(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": [], "requested_days": clamp(query.days, 7, 1, 30)}))
+async fn history_project_focus() -> Response {
+    history_not_implemented("project focus history")
 }
 
-async fn history_leverage(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    Json(json!({"ok": true, "days": [], "week": {}, "requested_days": clamp(query.days, 7, 1, 30)}))
+async fn history_leverage() -> Response {
+    history_not_implemented("leverage history")
 }
 
-async fn history_project_leverage(Query(query): Query<HistoryQuery>) -> Json<Value> {
-    let _ = clamp(query.days, 7, 1, 30);
-    Json(json!({"ok": true, "projects": {}}))
+async fn history_project_leverage() -> Response {
+    history_not_implemented("project leverage history")
 }
 
-fn default_co2_bucket(hours: i64) -> i64 {
-    if hours <= 6 {
-        5
-    } else if hours <= 24 {
-        15
-    } else if hours <= 72 {
-        60
-    } else {
-        240
-    }
-}
-
-fn default_temperature_bucket(hours: i64) -> i64 {
-    if hours <= 6 {
-        5
-    } else if hours <= 24 {
-        15
-    } else if hours <= 72 {
-        30
-    } else {
-        120
-    }
+fn history_not_implemented(name: &str) -> Response {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(json!({
+            "ok": false,
+            "error": format!("{name} is not implemented in the Rust compatibility server yet"),
+        })),
+    )
+        .into_response()
 }
 
 async fn deploy_app(
@@ -1693,6 +1665,45 @@ mod tests {
         assert_eq!(value["climate_actions"][0]["system"], "erv");
         assert_eq!(value["climate_actions"][0]["action"], "turbo");
         assert_eq!(value["climate_actions"][0]["reason"], "test");
+    }
+
+    #[tokio::test]
+    async fn secondary_history_routes_fail_loudly_until_ported() {
+        for path in [
+            "/history/sessions?days=7",
+            "/history/co2-ohlc?hours=24",
+            "/history/temperature?hours=24",
+            "/history/daily-stats?days=7",
+            "/history/openings?days=7",
+            "/history/orchestration?days=7",
+            "/history/project-focus?days=7",
+            "/history/leverage?days=7",
+            "/history/project-leverage?days=7",
+        ] {
+            let response = app(test_config())
+                .oneshot(
+                    HttpRequest::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED, "{path}");
+            let body = to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read body");
+            let value: Value = serde_json::from_slice(&body).expect("json body");
+            assert_eq!(value["ok"], false, "{path}");
+            assert!(
+                value["error"]
+                    .as_str()
+                    .expect("error")
+                    .contains("not implemented"),
+                "{path}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod artifacts;
+pub mod auth;
 pub mod cli;
 pub mod config;
 pub mod db;

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -182,7 +182,7 @@ pub struct TemperatureBands {
 }
 
 impl TemperatureBands {
-    fn from_config(config: &AppConfig) -> Self {
+    pub fn from_config(config: &AppConfig) -> Self {
         Self {
             heat_on_temp_f: config.thresholds.hvac_heat_on_temp_f,
             heat_off_temp_f: config.thresholds.hvac_heat_off_temp_f,
@@ -254,6 +254,9 @@ mod tests {
                 config_path: PathBuf::from("/tmp/office/config.yaml"),
                 data_dir: PathBuf::from("/tmp/office/data"),
                 database_path: PathBuf::from("/tmp/office/data/office_climate.db"),
+                frontend_dist: PathBuf::from("/tmp/office/frontend/dist"),
+                artifacts_dir: PathBuf::from("/tmp/office/data/apps"),
+                legacy_apk_path: PathBuf::from("/tmp/office/data/app-debug.apk"),
                 base_url: None,
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -21,6 +21,13 @@ pub struct Status {
 
 impl Status {
     pub fn read_only_default(config: &AppConfig) -> Self {
+        Self::read_only_with_temperature_bands(config, TemperatureBands::from_config(config))
+    }
+
+    pub fn read_only_with_temperature_bands(
+        config: &AppConfig,
+        temperature_bands: TemperatureBands,
+    ) -> Self {
         let sensors = SensorsStatus::default();
 
         Self {
@@ -41,7 +48,7 @@ impl Status {
                 ..ErvStatus::default()
             },
             hvac: HvacStatus {
-                temperature_bands: TemperatureBands::from_config(config),
+                temperature_bands,
                 temperature_band_defaults: TemperatureBands::from_config(config),
                 ..HvacStatus::default()
             },


### PR DESCRIPTION
## Summary
- Add Rust auth support for OAuth/JWT, basic fallback checks, trusted-network bypass, OAuth login/callback/logout/device-flow compatibility, and WebSocket first-message or upgrade-header Bearer auth.
- Expand the Rust router to expose the public HTTP/WebSocket/static/history/control route surface from the #62 interface map, with LocalTunnel returning 410 in favor of Cloudflare Tunnel.
- Add artifact upload/download/meta/legacy APK handling with stable metadata schema, atomic writes, redirects, cache headers, and multipart validation.

## Scope Notes
- ERV/HVAC/Qingping write endpoints are present and validate request shape, but return 503 until the later active-device tickets wire safe device clients.
- History/productivity endpoints expose route-compatible empty scaffolds; collector/query parity remains in later tickets.

## Spec Reference
- #62
- docs/working/62_primary_host_modern_stack.md

## Test Plan
- [x] cargo fmt --all --check
- [x] cargo check --workspace
- [x] cargo test --workspace
- [x] venv/bin/python -m pytest tests/ -v

Fixes #66