### PR TITLE
Add passive Qingping MQTT ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,22 +125,56 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
- "base64",
+ "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "multer",
@@ -139,14 +196,35 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -155,6 +233,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -167,6 +251,9 @@ name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -188,6 +275,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -210,6 +300,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -271,6 +372,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "config"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +433,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -329,6 +508,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -379,6 +567,23 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -493,6 +698,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -504,6 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -523,6 +730,15 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
@@ -537,6 +753,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,12 +781,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -564,8 +808,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -589,6 +833,29 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -597,8 +864,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -614,8 +881,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "tokio",
@@ -630,18 +897,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -823,12 +1090,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -879,6 +1157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1188,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -910,6 +1203,48 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "metrics"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d05972e8cbac2671e85aa9d04d9160d193f8bebd1a5c1a2f4542c62e65d1d0"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.32",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -926,6 +1261,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -947,12 +1288,22 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.4.1",
  "httparse",
  "memchr",
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -999,12 +1350,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "office-automate-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum",
- "base64",
+ "axum 0.8.9",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "futures-util",
@@ -1012,6 +1373,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.6",
  "reqwest",
+ "rumqttd",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1040,12 +1402,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1054,6 +1455,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1066,6 +1510,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1111,6 +1561,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,8 +1588,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1145,7 +1610,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1160,7 +1625,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1208,6 +1673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1722,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,13 +1768,13 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -1315,6 +1815,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rumqttd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32399b9dee6e96350790223dd7356bf7f8f15009d7e58e20f4093f1137213e16"
+dependencies = [
+ "axum 0.7.9",
+ "bytes",
+ "clap",
+ "config",
+ "flume",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "parking_lot",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "slab",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,9 +1861,19 @@ dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1395,6 +1943,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +2009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1497,7 +2060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1534,9 +2097,15 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -1549,6 +2118,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1565,6 +2144,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1630,11 +2212,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1689,6 +2291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +2335,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1776,6 +2387,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,8 +2453,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -1907,12 +2559,12 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1920,6 +2572,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -1932,6 +2590,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -1980,6 +2644,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "rand 0.10.1",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2149,6 +2825,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2366,6 +3064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +3171,17 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.8.4",
+]
 
 [[package]]
 name = "yoke"

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -15,6 +15,7 @@ ipnet = "2"
 jsonwebtoken = "9"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rumqttd = { version = "0.20", default-features = false }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -10,7 +10,7 @@ use rusqlite::{Connection, OptionalExtension, params, types::ValueRef};
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
-use crate::config::AppConfig;
+use crate::{config::AppConfig, qingping::QingpingReading};
 
 const SESSION_OUTPUT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS session_output (
@@ -213,6 +213,38 @@ where
             params![key, encoded, updated_at],
         )
         .with_context(|| format!("failed to write app setting {key}"))?;
+
+    Ok(())
+}
+
+pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) -> Result<()> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    connection
+        .execute(
+            r#"
+            INSERT INTO sensor_readings
+                (timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            params![
+                reading.database_timestamp(),
+                reading.co2_ppm,
+                reading.temp_c,
+                reading.humidity,
+                reading.pm25,
+                reading.pm10,
+                reading.tvoc,
+                reading.noise_db,
+                "qingping",
+            ],
+        )
+        .context("failed to insert Qingping sensor reading")?;
 
     Ok(())
 }
@@ -1793,5 +1825,67 @@ mod tests {
         assert_eq!(history.occupancy_history[0]["state"], "present");
         assert_eq!(history.occupancy_history[0]["trigger"], "manual");
         assert_eq!(history.occupancy_history[0]["co2_ppm"], 500);
+    }
+
+    #[test]
+    fn inserts_qingping_sensor_readings() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let reading = QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(620),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: "2026-06-05T12:05:00".to_string(),
+            raw_data: "{}".to_string(),
+        };
+
+        insert_sensor_reading(&db_path, &reading).expect("insert reading");
+
+        let connection = Connection::open(&db_path).expect("open database");
+        let row = connection
+            .query_row(
+                r#"
+                SELECT timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source
+                FROM sensor_readings
+                "#,
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, f64>(2)?,
+                        row.get::<_, f64>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, i64>(5)?,
+                        row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
+                        row.get::<_, String>(8)?,
+                    ))
+                },
+            )
+            .expect("read inserted row");
+
+        assert_eq!(
+            row,
+            (
+                "2026-06-05 12:05:00".to_string(),
+                620,
+                22.5,
+                45.0,
+                3,
+                4,
+                25,
+                37,
+                "qingping".to_string()
+            )
+        );
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -34,7 +34,8 @@ use crate::{
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     config::AppConfig,
-    db,
+    db, mqtt,
+    qingping::QingpingState,
     state::{StateMachine, StateTransition},
     status::{Status, TemperatureBands},
 };
@@ -50,6 +51,7 @@ struct AppState {
     temperature_band_defaults: TemperatureBands,
     state_machine: Arc<RwLock<StateMachine>>,
     status_broadcast: broadcast::Sender<()>,
+    qingping: QingpingState,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -57,6 +59,10 @@ pub fn app(config: AppConfig) -> Router {
 }
 
 pub fn try_app(config: AppConfig) -> Result<Router> {
+    try_app_with_qingping(config, QingpingState::default())
+}
+
+fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<Router> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
@@ -75,6 +81,7 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
         temperature_band_defaults,
         state_machine: Arc::new(RwLock::new(state_machine)),
         status_broadcast,
+        qingping,
     };
 
     let cors = CorsLayer::new()
@@ -138,13 +145,16 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     let listener = TcpListener::bind(&bind_address)
         .await
         .with_context(|| format!("failed to bind HTTP listener at {bind_address}"))?;
+    let qingping = QingpingState::default();
+    let app = try_app_with_qingping(config.clone(), qingping.clone())
+        .context("failed to build HTTP app")?;
+    let _mqtt_runtime =
+        mqtt::start_qingping_ingress(&config, qingping).context("failed to start MQTT ingress")?;
 
     tracing::info!("office-automate-server listening on {}", bind_address);
     axum::serve(
         listener,
-        try_app(config)
-            .context("failed to build HTTP app")?
-            .into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
     .await
     .context("HTTP server failed")
@@ -665,6 +675,7 @@ fn status_for_state(state: &AppState) -> Status {
     status.sensors.door_open = state_status.sensors.door_open;
     status.sensors.window_open = state_status.sensors.window_open;
     status.sensors.co2_ppm = state_status.sensors.co2_ppm;
+    state.qingping.overlay_status(&mut status);
     status
 }
 
@@ -1343,6 +1354,50 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn status_route_reflects_latest_qingping_reading() {
+        let qingping = QingpingState::default();
+        qingping.apply_reading(crate::qingping::QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(640),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: "2026-06-05T12:30:00".to_string(),
+            raw_data: "{}".to_string(),
+        });
+
+        let response = try_app_with_qingping(test_config(), qingping)
+            .expect("app")
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["sensors"]["co2_ppm"], 640);
+        assert_eq!(value["air_quality"]["co2_ppm"], 640);
+        assert_eq!(value["air_quality"]["temp_c"], 22.5);
+        assert_eq!(value["air_quality"]["humidity"], 45.0);
+        assert_eq!(value["air_quality"]["pm25"], 3.0);
+        assert_eq!(value["air_quality"]["tvoc"], 25);
+        assert_eq!(value["air_quality"]["noise_db"], 37.0);
+        assert_eq!(value["air_quality"]["last_update"], "2026-06-05T12:30:00");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -4,7 +4,9 @@ pub mod cli;
 pub mod config;
 pub mod db;
 pub mod http;
+pub mod mqtt;
 pub mod policy;
+pub mod qingping;
 pub mod state;
 pub mod status;
 

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -1,0 +1,187 @@
+use std::{
+    collections::HashMap,
+    net::{SocketAddr, ToSocketAddrs},
+    path::PathBuf,
+    thread::{self, JoinHandle},
+};
+
+use anyhow::{Context, Result, anyhow};
+use rumqttd::{
+    Broker, Config as BrokerConfig, ConnectionSettings, Notification, RouterConfig, ServerSettings,
+};
+
+use crate::{
+    config::AppConfig,
+    db,
+    qingping::{QingpingState, parse_qingping_payload, qingping_up_topic},
+};
+
+pub struct MqttRuntime {
+    _broker_thread: JoinHandle<()>,
+    _ingest_thread: JoinHandle<()>,
+}
+
+pub fn start_qingping_ingress(
+    config: &AppConfig,
+    qingping: QingpingState,
+) -> Result<Option<MqttRuntime>> {
+    let Some(device_mac) = config.qingping.device_mac.as_deref() else {
+        tracing::warn!("Qingping device_mac is not configured; MQTT broker not started");
+        return Ok(None);
+    };
+
+    let topic = qingping_up_topic(device_mac);
+    let broker_config = build_broker_config(&config.runtime.mqtt_host, config.runtime.mqtt_port)?;
+    let database_path = config.runtime.database_path.clone();
+    let configured_mac = device_mac.to_string();
+
+    let mut broker = Broker::new(broker_config);
+    let (mut link_tx, mut link_rx) = broker
+        .link("office-automate-qingping")
+        .context("failed to create internal MQTT link")?;
+    link_tx
+        .subscribe(topic.clone())
+        .with_context(|| format!("failed to subscribe to {topic}"))?;
+
+    let ingest_thread = thread::Builder::new()
+        .name("qingping-mqtt-ingest".to_string())
+        .spawn(move || {
+            let _link_tx = link_tx;
+            ingest_loop(
+                &mut link_rx,
+                &topic,
+                &configured_mac,
+                database_path,
+                qingping,
+            );
+        })
+        .context("failed to spawn Qingping MQTT ingest thread")?;
+
+    let broker_thread = thread::Builder::new()
+        .name("qingping-mqtt-broker".to_string())
+        .spawn(move || {
+            if let Err(error) = broker.start() {
+                tracing::error!("Qingping MQTT broker stopped: {error:#}");
+            }
+        })
+        .context("failed to spawn Qingping MQTT broker thread")?;
+
+    Ok(Some(MqttRuntime {
+        _broker_thread: broker_thread,
+        _ingest_thread: ingest_thread,
+    }))
+}
+
+fn ingest_loop(
+    link_rx: &mut rumqttd::local::LinkRx,
+    topic: &str,
+    configured_mac: &str,
+    database_path: PathBuf,
+    qingping: QingpingState,
+) {
+    loop {
+        match link_rx.recv() {
+            Ok(Some(Notification::Forward(forward))) => {
+                if forward.publish.topic.as_ref() != topic.as_bytes() {
+                    continue;
+                }
+                match parse_qingping_payload(&forward.publish.payload, configured_mac) {
+                    Ok(Some(reading)) => {
+                        if let Err(error) = db::insert_sensor_reading(&database_path, &reading) {
+                            tracing::warn!("failed to store Qingping reading: {error:#}");
+                        }
+                        qingping.apply_reading(reading);
+                    }
+                    Ok(None) => {
+                        tracing::debug!("ignoring Qingping MQTT message without sensor data");
+                    }
+                    Err(error) => {
+                        tracing::warn!("failed to parse Qingping MQTT payload: {error}");
+                    }
+                }
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error) => {
+                tracing::warn!("Qingping MQTT internal link stopped: {error}");
+                break;
+            }
+        }
+    }
+}
+
+pub(crate) fn build_broker_config(host: &str, port: u16) -> Result<BrokerConfig> {
+    let listen = resolve_listen_address(host, port)?;
+    let mut v4 = HashMap::new();
+    v4.insert(
+        "qingping".to_string(),
+        ServerSettings {
+            name: "qingping-v4".to_string(),
+            listen,
+            tls: None,
+            next_connection_delay_ms: 1,
+            connections: ConnectionSettings {
+                connection_timeout_ms: 60_000,
+                max_payload_size: 20_480,
+                max_inflight_count: 100,
+                auth: None,
+                external_auth: None,
+                dynamic_filters: true,
+            },
+        },
+    );
+
+    Ok(BrokerConfig {
+        id: 0,
+        router: RouterConfig {
+            max_connections: 128,
+            max_outgoing_packet_count: 200,
+            max_segment_size: 1024 * 1024,
+            max_segment_count: 10,
+            custom_segment: None,
+            initialized_filters: None,
+            shared_subscriptions_strategy: rumqttd::Strategy::RoundRobin,
+        },
+        v4: Some(v4),
+        v5: None,
+        ws: None,
+        cluster: None,
+        console: None,
+        bridge: None,
+        prometheus: None,
+        metrics: None,
+    })
+}
+
+fn resolve_listen_address(host: &str, port: u16) -> Result<SocketAddr> {
+    format!("{}:{port}", host.trim())
+        .to_socket_addrs()
+        .with_context(|| format!("failed to resolve MQTT listen address {host}:{port}"))?
+        .next()
+        .ok_or_else(|| anyhow!("no MQTT listen address resolved for {host}:{port}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qingping::{normalize_device_mac, qingping_up_topic};
+
+    #[test]
+    fn broker_config_uses_configured_listener() {
+        let config = build_broker_config("127.0.0.1", 2883).expect("broker config");
+        let v4 = config.v4.expect("v4 config");
+        let server = v4.get("qingping").expect("qingping server");
+
+        assert_eq!(server.listen, "127.0.0.1:2883".parse().expect("addr"));
+        assert_eq!(server.connections.max_payload_size, 20_480);
+        assert_eq!(config.router.max_connections, 128);
+    }
+
+    #[test]
+    fn qingping_topic_normalizes_device_mac() {
+        assert_eq!(normalize_device_mac("aa:bb-cc"), "AABBCC");
+        assert_eq!(
+            qingping_up_topic("aa:bb:cc:dd:ee:ff"),
+            "qingping/AABBCCDDEEFF/up"
+        );
+    }
+}

--- a/rust/office-automate-server/src/qingping.rs
+++ b/rust/office-automate-server/src/qingping.rs
@@ -1,0 +1,234 @@
+use std::sync::{Arc, RwLock};
+
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::status::Status;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QingpingReading {
+    pub device_name: String,
+    pub mac_hint: String,
+    pub temp_c: Option<f64>,
+    pub humidity: Option<f64>,
+    pub co2_ppm: Option<i64>,
+    pub pm25: Option<i64>,
+    pub pm10: Option<i64>,
+    pub tvoc: Option<i64>,
+    pub noise_db: Option<i64>,
+    pub timestamp: String,
+    pub raw_data: String,
+}
+
+impl QingpingReading {
+    pub fn database_timestamp(&self) -> String {
+        self.timestamp.replace('T', " ")
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QingpingState {
+    latest: Arc<RwLock<Option<QingpingReading>>>,
+}
+
+impl QingpingState {
+    pub fn apply_reading(&self, reading: QingpingReading) {
+        *self.latest.write().expect("qingping state lock poisoned") = Some(reading);
+    }
+
+    pub fn latest(&self) -> Option<QingpingReading> {
+        self.latest
+            .read()
+            .expect("qingping state lock poisoned")
+            .clone()
+    }
+
+    pub fn overlay_status(&self, status: &mut Status) {
+        let Some(reading) = self.latest() else {
+            return;
+        };
+
+        status.air_quality.co2_ppm = reading.co2_ppm;
+        status.air_quality.temp_c = reading.temp_c;
+        status.air_quality.humidity = reading.humidity;
+        status.air_quality.pm25 = reading.pm25.map(|value| value as f64);
+        status.air_quality.pm10 = reading.pm10.map(|value| value as f64);
+        status.air_quality.tvoc = reading.tvoc;
+        status.air_quality.noise_db = reading.noise_db.map(|value| value as f64);
+        status.air_quality.last_update = Some(reading.timestamp);
+
+        if let Some(co2_ppm) = status.air_quality.co2_ppm {
+            status.sensors.co2_ppm = co2_ppm;
+        }
+    }
+}
+
+pub fn normalize_device_mac(device_mac: &str) -> String {
+    device_mac
+        .trim()
+        .chars()
+        .filter(|character| *character != ':' && *character != '-')
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+pub fn qingping_up_topic(device_mac: &str) -> String {
+    format!("qingping/{}/up", normalize_device_mac(device_mac))
+}
+
+pub fn parse_qingping_payload(
+    payload: &[u8],
+    configured_mac: &str,
+) -> Result<Option<QingpingReading>, serde_json::Error> {
+    let value: Value = serde_json::from_slice(payload)?;
+    let Some(sensor_data) = sensor_data(&value) else {
+        return Ok(None);
+    };
+
+    let Some(sensor_object) = sensor_data.as_object() else {
+        return Ok(None);
+    };
+
+    if sensor_object.is_empty() {
+        return Ok(None);
+    }
+
+    let configured_mac = normalize_device_mac(configured_mac);
+    let mac_hint = value
+        .get("mac")
+        .and_then(Value::as_str)
+        .map(normalize_device_mac)
+        .filter(|mac| !mac.is_empty())
+        .unwrap_or(configured_mac);
+    let tvoc = nested_i64(sensor_data, "tvoc_index").or_else(|| nested_i64(sensor_data, "tvoc"));
+
+    Ok(Some(QingpingReading {
+        device_name: "Qingping Air Monitor".to_string(),
+        mac_hint,
+        temp_c: nested_f64(sensor_data, "temperature"),
+        humidity: nested_f64(sensor_data, "humidity"),
+        co2_ppm: nested_i64(sensor_data, "co2"),
+        pm25: nested_i64(sensor_data, "pm25"),
+        pm10: nested_i64(sensor_data, "pm10"),
+        tvoc,
+        noise_db: nested_i64(sensor_data, "noise"),
+        timestamp: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+        raw_data: String::from_utf8_lossy(payload).to_string(),
+    }))
+}
+
+fn sensor_data(value: &Value) -> Option<&Value> {
+    if let Some(local_sensor_data) = value.get("sensorData").and_then(Value::as_array) {
+        return local_sensor_data.first();
+    }
+
+    let is_cloud_sensor_payload = value
+        .get("type")
+        .is_some_and(|payload_type| payload_type.as_i64() == Some(17));
+    if is_cloud_sensor_payload {
+        value.get("sensor_data")
+    } else {
+        None
+    }
+}
+
+fn nested_value<'a>(sensor_data: &'a Value, name: &str) -> Option<&'a Value> {
+    sensor_data.get(name)?.get("value")
+}
+
+fn nested_f64(sensor_data: &Value, name: &str) -> Option<f64> {
+    nested_value(sensor_data, name).and_then(Value::as_f64)
+}
+
+fn nested_i64(sensor_data: &Value, name: &str) -> Option<i64> {
+    let value = nested_value(sensor_data, name)?;
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|number| number.round() as i64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_local_sensor_data_payload() {
+        let payload = br#"{
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "sensorData": [{
+                "temperature": {"value": 22.5},
+                "humidity": {"value": 47.1},
+                "co2": {"value": 612},
+                "pm25": {"value": 3},
+                "pm10": {"value": 4},
+                "tvoc_index": {"value": 28},
+                "noise": {"value": 36}
+            }]
+        }"#;
+
+        let reading = parse_qingping_payload(payload, "112233445566")
+            .expect("parse")
+            .expect("reading");
+
+        assert_eq!(reading.mac_hint, "AABBCCDDEEFF");
+        assert_eq!(reading.temp_c, Some(22.5));
+        assert_eq!(reading.humidity, Some(47.1));
+        assert_eq!(reading.co2_ppm, Some(612));
+        assert_eq!(reading.pm25, Some(3));
+        assert_eq!(reading.pm10, Some(4));
+        assert_eq!(reading.tvoc, Some(28));
+        assert_eq!(reading.noise_db, Some(36));
+        assert!(reading.raw_data.contains("sensorData"));
+    }
+
+    #[test]
+    fn parses_cloud_sensor_data_payload_with_tvoc_fallback() {
+        let payload = br#"{
+            "type": 17,
+            "sensor_data": {
+                "temperature": {"value": 21.0},
+                "humidity": {"value": 41.0},
+                "co2": {"value": 505},
+                "tvoc": {"value": 19}
+            }
+        }"#;
+
+        let reading = parse_qingping_payload(payload, "aa:bb:cc:dd:ee:ff")
+            .expect("parse")
+            .expect("reading");
+
+        assert_eq!(reading.mac_hint, "AABBCCDDEEFF");
+        assert_eq!(reading.temp_c, Some(21.0));
+        assert_eq!(reading.humidity, Some(41.0));
+        assert_eq!(reading.co2_ppm, Some(505));
+        assert_eq!(reading.tvoc, Some(19));
+        assert_eq!(reading.pm25, None);
+    }
+
+    #[test]
+    fn ignores_payload_without_sensor_data() {
+        let payload = br#"{"sensorData": []}"#;
+
+        let reading = parse_qingping_payload(payload, "aa:bb").expect("parse empty sensor payload");
+
+        assert_eq!(reading, None);
+    }
+
+    #[test]
+    fn malformed_payload_returns_error_without_state_change() {
+        let state = QingpingState::default();
+        let existing = parse_qingping_payload(
+            br#"{"sensorData":[{"co2":{"value":700}}]}"#,
+            "aa:bb:cc:dd:ee:ff",
+        )
+        .expect("parse")
+        .expect("reading");
+        state.apply_reading(existing.clone());
+
+        let error = parse_qingping_payload(b"{not-json", "aa:bb").expect_err("malformed payload");
+
+        assert!(error.is_syntax());
+        assert_eq!(state.latest(), Some(existing));
+    }
+}


### PR DESCRIPTION
## Summary
- Add the embedded Rust MQTT broker runtime for Qingping topic ingestion.
- Parse local `sensorData` and cloud-style `sensor_data` payloads into the shared Qingping state.
- Persist accepted Qingping readings to `sensor_readings` and expose the latest air-quality values through `/status`.

## Scope Notes
- `/qingping/interval` remains a guarded 503 until the MQTT command/down-topic path is enabled in a later ticket.
- This ticket is passive sensor ingestion only; it does not change ERV or HVAC active writes.

## Spec Reference
- #62
- docs/working/62_primary_host_modern_stack.md

## Test Plan
- [x] cargo fmt --all --check
- [x] cargo check --workspace
- [x] cargo test --workspace
- [x] venv/bin/python -m pytest tests/ -v

Fixes #67