### PR TITLE
Add passive YoLink sensor client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +577,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
@@ -1373,6 +1389,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.6",
  "reqwest",
+ "rumqttc",
  "rumqttd",
  "rusqlite",
  "serde",
@@ -1400,6 +1417,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-multimap"
@@ -1827,6 +1850,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
+dependencies = [
+ "bytes",
+ "fixedbitset",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
 name = "rumqttd"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,9 +1948,30 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1917,6 +1982,17 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1943,10 +2019,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2358,6 +2466,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -16,6 +16,7 @@ jsonwebtoken = "9"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rumqttd = { version = "0.20", default-features = false }
+rumqttc = { version = "0.25", default-features = false, features = ["use-rustls-no-provider"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
     pub qingping: QingpingConfig,
+    pub yolink: YoLinkConfig,
     pub thresholds: ThresholdsConfig,
     pub runtime: RuntimeConfig,
 }
@@ -78,6 +79,36 @@ impl Default for QingpingConfig {
             mqtt_port: 1883,
             device_mac: None,
             report_interval: 60,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct YoLinkConfig {
+    pub uaid: String,
+    pub secret_key: String,
+    pub http_url: String,
+    pub mqtt_host: String,
+    pub mqtt_port: u16,
+    pub reconnect_delay_seconds: u64,
+}
+
+impl YoLinkConfig {
+    pub fn is_configured(&self) -> bool {
+        !self.uaid.trim().is_empty() && !self.secret_key.trim().is_empty()
+    }
+}
+
+impl Default for YoLinkConfig {
+    fn default() -> Self {
+        Self {
+            uaid: String::new(),
+            secret_key: String::new(),
+            http_url: "https://api.yosmart.com".to_string(),
+            mqtt_host: "api.yosmart.com".to_string(),
+            mqtt_port: 8003,
+            reconnect_delay_seconds: 5,
         }
     }
 }
@@ -190,6 +221,7 @@ pub struct RuntimeConfig {
 struct FileConfig {
     orchestrator: OrchestratorConfig,
     qingping: QingpingConfig,
+    yolink: YoLinkConfig,
     thresholds: ThresholdsConfig,
 }
 
@@ -234,6 +266,14 @@ impl AppConfig {
                 .with_context(|| format!("invalid OFFICE_AUTOMATE_MQTT_PORT value {port:?}"))?;
         }
 
+        if let Some(uaid) = env_lookup("OFFICE_AUTOMATE_YOLINK_UAID") {
+            file_config.yolink.uaid = uaid;
+        }
+
+        if let Some(secret_key) = env_lookup("OFFICE_AUTOMATE_YOLINK_SECRET_KEY") {
+            file_config.yolink.secret_key = secret_key;
+        }
+
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
             root,
@@ -251,6 +291,7 @@ impl AppConfig {
         Ok(Self {
             orchestrator: file_config.orchestrator,
             qingping: file_config.qingping,
+            yolink: file_config.yolink,
             thresholds: file_config.thresholds,
             runtime,
         })
@@ -276,6 +317,9 @@ qingping:
   mqtt_port: 1883
   device_mac: "AA:BB:CC:DD:EE:FF"
   report_interval: 30
+yolink:
+  uaid: "yaml-uaid"
+  secret_key: "yaml-secret"
 thresholds:
   hvac_heat_on_temp_f: 70
   hvac_heat_off_temp_f: 74
@@ -290,6 +334,8 @@ thresholds:
             "OFFICE_AUTOMATE_DATA_DIR" => Some(temp_dir.path().join("db").display().to_string()),
             "OFFICE_AUTOMATE_MQTT_HOST" => Some("rust-broker".to_string()),
             "OFFICE_AUTOMATE_MQTT_PORT" => Some("2883".to_string()),
+            "OFFICE_AUTOMATE_YOLINK_UAID" => Some("env-uaid".to_string()),
+            "OFFICE_AUTOMATE_YOLINK_SECRET_KEY" => Some("env-secret".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             _ => None,
         })
@@ -299,6 +345,13 @@ thresholds:
         assert_eq!(config.orchestrator.port, 9001);
         assert_eq!(config.qingping.mqtt_broker, "rust-broker");
         assert_eq!(config.qingping.mqtt_port, 2883);
+        assert_eq!(config.yolink.uaid, "env-uaid");
+        assert_eq!(config.yolink.secret_key, "env-secret");
+        assert_eq!(config.yolink.http_url, "https://api.yosmart.com");
+        assert_eq!(config.yolink.mqtt_host, "api.yosmart.com");
+        assert_eq!(config.yolink.mqtt_port, 8003);
+        assert_eq!(config.yolink.reconnect_delay_seconds, 5);
+        assert!(config.yolink.is_configured());
         assert_eq!(config.runtime.mqtt_host, "rust-broker");
         assert_eq!(config.runtime.mqtt_port, 2883);
         assert_eq!(config.runtime.data_dir, temp_dir.path().join("db"));

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1097,6 +1097,24 @@ fn sqlite_value_to_json(value: ValueRef<'_>) -> Value {
     }
 }
 
+pub fn get_latest_device_state(database_path: &Path, device_type: &str) -> Result<Option<String>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    connection
+        .query_row(
+            r#"
+            SELECT event FROM device_events
+            WHERE device_type = ?
+            ORDER BY timestamp DESC, id DESC
+            LIMIT 1
+            "#,
+            params![device_type],
+            |row| row.get(0),
+        )
+        .optional()
+        .with_context(|| format!("failed to read latest {device_type} device state"))
+}
+
 fn parse_timestamp(value: &str) -> Option<NaiveDateTime> {
     NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S")
         .ok()
@@ -1887,5 +1905,42 @@ mod tests {
                 "qingping".to_string()
             )
         );
+    }
+
+    #[test]
+    fn logs_and_reads_latest_device_state() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        log_device_event(
+            &db_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&serde_json::json!({"state": "open"})),
+        )
+        .expect("log open");
+        log_device_event(&db_path, "door", "closed", Some("Office Door"), None)
+            .expect("log closed");
+
+        assert_eq!(
+            get_latest_device_state(&db_path, "door").expect("latest"),
+            Some("closed".to_string())
+        );
+        assert_eq!(
+            get_latest_device_state(&db_path, "window").expect("missing"),
+            None
+        );
+
+        let connection = Connection::open(&db_path).expect("open database");
+        let details: Option<String> = connection
+            .query_row(
+                "SELECT details FROM device_events WHERE event = 'open'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read details");
+        assert_eq!(details, Some(r#"{"state":"open"}"#.to_string()));
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -87,6 +87,7 @@ fn try_app_with_state(
     let temperature_band_defaults = TemperatureBands::from_config(&config);
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
     let (status_broadcast, _) = broadcast::channel(32);
+    yolink.set_status_broadcast(status_broadcast.clone());
     yolink.restore_from_database(unix_timestamp_now())?;
     let state = AppState {
         config,

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -38,6 +38,7 @@ use crate::{
     qingping::QingpingState,
     state::{StateMachine, StateTransition},
     status::{Status, TemperatureBands},
+    yolink::{self, YoLinkState},
 };
 
 const HVAC_TEMPERATURE_BANDS_SETTING: &str = "hvac_temperature_bands";
@@ -63,6 +64,20 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
 }
 
 fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<Router> {
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+        &config.thresholds,
+        unix_timestamp_now(),
+    )));
+    let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+    try_app_with_state(config, qingping, state_machine, yolink)
+}
+
+fn try_app_with_state(
+    config: AppConfig,
+    qingping: QingpingState,
+    state_machine: Arc<RwLock<StateMachine>>,
+    yolink: YoLinkState,
+) -> Result<Router> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
@@ -71,15 +86,15 @@ fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<R
     );
     let temperature_band_defaults = TemperatureBands::from_config(&config);
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
-    let state_machine = StateMachine::from_thresholds(&config.thresholds, unix_timestamp_now());
     let (status_broadcast, _) = broadcast::channel(32);
+    yolink.restore_from_database(unix_timestamp_now())?;
     let state = AppState {
         config,
         auth,
         artifacts,
         temperature_bands: Arc::new(RwLock::new(temperature_bands)),
         temperature_band_defaults,
-        state_machine: Arc::new(RwLock::new(state_machine)),
+        state_machine,
         status_broadcast,
         qingping,
     };
@@ -146,10 +161,21 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         .await
         .with_context(|| format!("failed to bind HTTP listener at {bind_address}"))?;
     let qingping = QingpingState::default();
-    let app = try_app_with_qingping(config.clone(), qingping.clone())
-        .context("failed to build HTTP app")?;
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+        &config.thresholds,
+        unix_timestamp_now(),
+    )));
+    let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+    let app = try_app_with_state(
+        config.clone(),
+        qingping.clone(),
+        state_machine,
+        yolink.clone(),
+    )
+    .context("failed to build HTTP app")?;
     let _mqtt_runtime =
         mqtt::start_qingping_ingress(&config, qingping).context("failed to start MQTT ingress")?;
+    let _yolink_task = yolink::start_yolink_client(&config, yolink);
 
     tracing::info!("office-automate-server listening on {}", bind_address);
     axum::serve(
@@ -1261,6 +1287,7 @@ mod tests {
     use super::*;
     use crate::config::{
         GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
+        YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -1269,6 +1296,7 @@ mod tests {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
             qingping: QingpingConfig::default(),
+            yolink: YoLinkConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),
@@ -1398,6 +1426,56 @@ mod tests {
         assert_eq!(value["air_quality"]["tvoc"], 25);
         assert_eq!(value["air_quality"]["noise_db"], 37.0);
         assert_eq!(value["air_quality"]["last_update"], "2026-06-05T12:30:00");
+    }
+
+    #[tokio::test]
+    async fn status_route_restores_yolink_device_state_from_database() {
+        let config = test_config();
+        db::migrate_database(&config.runtime.database_path).expect("migration");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            None,
+        )
+        .expect("log door");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "window",
+            "closed",
+            Some("Office Window"),
+            None,
+        )
+        .expect("log window");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "motion",
+            "detected",
+            Some("Office Motion"),
+            None,
+        )
+        .expect("log motion");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["sensors"]["door_open"], true);
+        assert_eq!(value["sensors"]["window_open"], false);
+        assert_eq!(value["sensors"]["motion_detected"], true);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -9,5 +9,6 @@ pub mod policy;
 pub mod qingping;
 pub mod state;
 pub mod status;
+pub mod yolink;
 
 pub use cli::run_cli;

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -239,7 +239,9 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::config::{OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig};
+    use crate::config::{
+        OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+    };
 
     fn test_config() -> AppConfig {
         AppConfig {
@@ -248,6 +250,7 @@ mod tests {
                 report_interval: 45,
                 ..QingpingConfig::default()
             },
+            yolink: YoLinkConfig::default(),
             thresholds: ThresholdsConfig {
                 hvac_heat_on_temp_f: 70,
                 hvac_heat_off_temp_f: 74,

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::task::JoinHandle;
+use tokio::{sync::broadcast, task::JoinHandle};
 
 use crate::{
     config::{AppConfig, YoLinkConfig},
@@ -109,6 +109,7 @@ pub struct YoLinkState {
     inner: Arc<RwLock<YoLinkInner>>,
     state_machine: Arc<RwLock<StateMachine>>,
     database_path: PathBuf,
+    status_broadcast: Arc<RwLock<Option<broadcast::Sender<()>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -132,7 +133,15 @@ impl YoLinkState {
             inner: Arc::default(),
             state_machine,
             database_path,
+            status_broadcast: Arc::default(),
         }
+    }
+
+    pub fn set_status_broadcast(&self, sender: broadcast::Sender<()>) {
+        *self
+            .status_broadcast
+            .write()
+            .expect("yolink broadcast lock poisoned") = Some(sender);
     }
 
     pub fn apply_devices(&self, devices: Vec<YoLinkDevice>) {
@@ -243,6 +252,7 @@ impl YoLinkState {
             Some(&device_name),
             Some(&event_data),
         )?;
+        self.notify_status();
 
         Ok(Some(YoLinkAppliedEvent {
             device_type: device_type.to_string(),
@@ -311,6 +321,18 @@ impl YoLinkState {
         status.sensors.door_open = machine_status.sensors.door_open;
         status.sensors.window_open = machine_status.sensors.window_open;
     }
+
+    fn notify_status(&self) {
+        let Some(sender) = self
+            .status_broadcast
+            .read()
+            .expect("yolink broadcast lock poisoned")
+            .clone()
+        else {
+            return;
+        };
+        let _ = sender.send(());
+    }
 }
 
 pub struct YoLinkCloudClient {
@@ -338,11 +360,11 @@ impl YoLinkCloudClient {
         let response: Value = self
             .http
             .post(format!("{}/open/yolink/token", self.config.http_url))
-            .json(&json!({
-                "grant_type": "client_credentials",
-                "client_id": self.config.uaid,
-                "client_secret": self.config.secret_key,
-            }))
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", self.config.uaid.as_str()),
+                ("client_secret", self.config.secret_key.as_str()),
+            ])
             .send()
             .await
             .context("failed to call YoLink auth endpoint")?
@@ -553,6 +575,7 @@ mod tests {
         db::migrate_database,
         state::{OccupancyState, StateConfig},
     };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn test_state(database_path: PathBuf) -> YoLinkState {
         YoLinkState::new(
@@ -637,6 +660,81 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn authenticates_with_form_encoded_token_request() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind auth server");
+        let address = listener.local_addr().expect("auth server address");
+        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept auth request");
+            let mut buffer = vec![0_u8; 4096];
+            let mut read = 0_usize;
+            loop {
+                let n = stream
+                    .read(&mut buffer[read..])
+                    .await
+                    .expect("read auth request");
+                if n == 0 {
+                    break;
+                }
+                read += n;
+                let request = String::from_utf8_lossy(&buffer[..read]);
+                if let Some(header_end) = request.find("\r\n\r\n") {
+                    let content_length = request
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length:")
+                                .and_then(|value| value.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or_default();
+                    if read >= header_end + 4 + content_length {
+                        break;
+                    }
+                }
+                if read == buffer.len() {
+                    buffer.resize(buffer.len() * 2, 0);
+                }
+            }
+
+            let request = String::from_utf8(buffer[..read].to_vec()).expect("utf8 request");
+            request_tx.send(request).expect("send captured request");
+            let body = r#"{"access_token":"token-123"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write auth response");
+        });
+
+        let client = YoLinkCloudClient::new(YoLinkConfig {
+            uaid: "client id".to_string(),
+            secret_key: "secret/key".to_string(),
+            http_url: format!("http://{address}"),
+            ..YoLinkConfig::default()
+        });
+
+        let token = client.authenticate().await.expect("authenticate");
+        assert_eq!(token, "token-123");
+        let request = request_rx.await.expect("captured request");
+        let lower_request = request.to_ascii_lowercase();
+        assert!(request.starts_with("POST /open/yolink/token HTTP/1.1"));
+        assert!(lower_request.contains("content-type: application/x-www-form-urlencoded"));
+        let body = request.split("\r\n\r\n").nth(1).expect("request body");
+        assert!(body.contains("grant_type=client_credentials"));
+        assert!(body.contains("client_id=client+id"));
+        assert!(body.contains("client_secret=secret%2Fkey"));
+
+        server.await.expect("auth server task");
+    }
+
     #[test]
     fn classifies_devices_by_python_name_rules() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -712,6 +810,33 @@ mod tests {
             db::get_latest_device_state(&db_path, "motion").expect("motion state"),
             Some("detected".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn applying_report_notifies_status_broadcast() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let yolink = test_state(db_path);
+        yolink.apply_devices(sample_devices());
+        let (sender, mut receiver) = tokio::sync::broadcast::channel(4);
+        yolink.set_status_broadcast(sender);
+
+        let applied = yolink
+            .apply_report(
+                YoLinkReport {
+                    device_id: "door-1".to_string(),
+                    data: json!({"state": "open"}),
+                },
+                1_010.0,
+            )
+            .expect("apply report");
+
+        assert!(applied.is_some());
+        tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast received");
     }
 
     #[test]

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -1,0 +1,759 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+
+use crate::{
+    config::{AppConfig, YoLinkConfig},
+    db,
+    state::{StateMachine, StateTransition},
+    status::Status,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeviceType {
+    DoorSensor,
+    MotionSensor,
+    ContactSensor,
+    Unknown,
+}
+
+impl DeviceType {
+    fn from_api(value: &str) -> Self {
+        match value {
+            "DoorSensor" => Self::DoorSensor,
+            "MotionSensor" => Self::MotionSensor,
+            "ContactSensor" => Self::ContactSensor,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_api_method_prefix(self) -> &'static str {
+        match self {
+            Self::DoorSensor => "DoorSensor",
+            Self::MotionSensor => "MotionSensor",
+            Self::ContactSensor => "ContactSensor",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct YoLinkDevice {
+    pub device_id: String,
+    pub name: String,
+    pub token: String,
+    pub device_type: DeviceType,
+    pub state: serde_json::Map<String, Value>,
+}
+
+impl YoLinkDevice {
+    pub fn is_open(&self) -> Option<bool> {
+        self.state
+            .get("state")?
+            .as_str()
+            .map(|state| state == "open")
+    }
+
+    pub fn motion_detected(&self) -> Option<bool> {
+        self.state
+            .get("state")?
+            .as_str()
+            .map(|state| state == "alert")
+    }
+
+    pub fn is_online(&self) -> bool {
+        self.state
+            .get("online")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    fn merge_state(&mut self, event_data: &Value) {
+        let Some(object) = event_data.as_object() else {
+            return;
+        };
+
+        for (key, value) in object {
+            self.state.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct YoLinkReport {
+    pub device_id: String,
+    pub data: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct YoLinkAppliedEvent {
+    pub device_type: String,
+    pub event: String,
+    pub device_name: String,
+    pub transition: Option<StateTransition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct YoLinkState {
+    inner: Arc<RwLock<YoLinkInner>>,
+    state_machine: Arc<RwLock<StateMachine>>,
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct YoLinkInner {
+    devices: HashMap<String, YoLinkDevice>,
+    door_device_id: Option<String>,
+    window_device_id: Option<String>,
+    motion_device_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeviceRole {
+    Door,
+    Window,
+    Motion,
+}
+
+impl YoLinkState {
+    pub fn new(state_machine: Arc<RwLock<StateMachine>>, database_path: PathBuf) -> Self {
+        Self {
+            inner: Arc::default(),
+            state_machine,
+            database_path,
+        }
+    }
+
+    pub fn apply_devices(&self, devices: Vec<YoLinkDevice>) {
+        let mut inner = self.inner.write().expect("yolink state lock poisoned");
+        inner.devices.clear();
+        inner.door_device_id = None;
+        inner.window_device_id = None;
+        inner.motion_device_id = None;
+
+        for device in devices {
+            let name_lower = device.name.to_ascii_lowercase();
+            match device.device_type {
+                DeviceType::MotionSensor => inner.motion_device_id = Some(device.device_id.clone()),
+                DeviceType::DoorSensor if name_lower.contains("door") => {
+                    inner.door_device_id = Some(device.device_id.clone());
+                }
+                DeviceType::DoorSensor if name_lower.contains("window") => {
+                    inner.window_device_id = Some(device.device_id.clone());
+                }
+                _ => {}
+            }
+            inner.devices.insert(device.device_id.clone(), device);
+        }
+    }
+
+    pub fn device(&self, device_id: &str) -> Option<YoLinkDevice> {
+        self.inner
+            .read()
+            .expect("yolink state lock poisoned")
+            .devices
+            .get(device_id)
+            .cloned()
+    }
+
+    pub fn classified_device_ids(&self) -> (Option<String>, Option<String>, Option<String>) {
+        let inner = self.inner.read().expect("yolink state lock poisoned");
+        (
+            inner.door_device_id.clone(),
+            inner.window_device_id.clone(),
+            inner.motion_device_id.clone(),
+        )
+    }
+
+    pub fn apply_report(
+        &self,
+        report: YoLinkReport,
+        now: f64,
+    ) -> Result<Option<YoLinkAppliedEvent>> {
+        self.apply_event(&report.device_id, report.data, now)
+    }
+
+    pub fn apply_event(
+        &self,
+        device_id: &str,
+        event_data: Value,
+        now: f64,
+    ) -> Result<Option<YoLinkAppliedEvent>> {
+        let Some((role, device_name)) = self.record_device_event(device_id, &event_data) else {
+            return Ok(None);
+        };
+
+        let Some(state_value) = event_data.get("state").and_then(Value::as_str) else {
+            return Ok(None);
+        };
+
+        let (device_type, event, transition) = match role {
+            DeviceRole::Door => {
+                let is_open = state_value == "open";
+                let transition = self
+                    .state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .update_door(is_open, now);
+                ("door", if is_open { "open" } else { "closed" }, transition)
+            }
+            DeviceRole::Window => {
+                let is_open = state_value == "open";
+                let transition = self
+                    .state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .update_window(is_open, now);
+                (
+                    "window",
+                    if is_open { "open" } else { "closed" },
+                    transition,
+                )
+            }
+            DeviceRole::Motion => {
+                let detected = state_value == "alert";
+                let transition = self
+                    .state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .update_motion(detected, now);
+                (
+                    "motion",
+                    if detected { "detected" } else { "clear" },
+                    transition,
+                )
+            }
+        };
+
+        db::log_device_event(
+            &self.database_path,
+            device_type,
+            event,
+            Some(&device_name),
+            Some(&event_data),
+        )?;
+
+        Ok(Some(YoLinkAppliedEvent {
+            device_type: device_type.to_string(),
+            event: event.to_string(),
+            device_name,
+            transition,
+        }))
+    }
+
+    fn record_device_event(
+        &self,
+        device_id: &str,
+        event_data: &Value,
+    ) -> Option<(DeviceRole, String)> {
+        let mut inner = self.inner.write().expect("yolink state lock poisoned");
+        let role = if inner.door_device_id.as_deref() == Some(device_id) {
+            DeviceRole::Door
+        } else if inner.window_device_id.as_deref() == Some(device_id) {
+            DeviceRole::Window
+        } else if inner.motion_device_id.as_deref() == Some(device_id) {
+            DeviceRole::Motion
+        } else {
+            return None;
+        };
+        let device = inner.devices.get_mut(device_id)?;
+        device.merge_state(event_data);
+        Some((role, device.name.clone()))
+    }
+
+    pub fn restore_from_database(&self, now: f64) -> Result<()> {
+        if let Some(state) = db::get_latest_device_state(&self.database_path, "door")? {
+            self.state_machine
+                .write()
+                .expect("state machine lock poisoned")
+                .update_door(state == "open", now);
+        }
+        if let Some(state) = db::get_latest_device_state(&self.database_path, "window")? {
+            self.state_machine
+                .write()
+                .expect("state machine lock poisoned")
+                .update_window(state == "open", now);
+        }
+        if let Some(state) = db::get_latest_device_state(&self.database_path, "motion")? {
+            self.state_machine
+                .write()
+                .expect("state machine lock poisoned")
+                .update_motion(state == "detected", now);
+        }
+        Ok(())
+    }
+
+    pub fn overlay_status(&self, status: &mut Status, now: f64) {
+        let machine_status = self
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned")
+            .status_at(now);
+        status.state = machine_status.state;
+        status.is_present = machine_status.is_present;
+        status.presence_signal_active = machine_status.presence_signal_active;
+        status.safety_interlock = machine_status.safety_interlock;
+        status.erv_should_run = machine_status.erv_should_run;
+        status.verifying_departure = machine_status.verifying_departure;
+        status.in_door_open_mode = machine_status.in_door_open_mode;
+        status.sensors.motion_detected = machine_status.sensors.motion_detected;
+        status.sensors.door_open = machine_status.sensors.door_open;
+        status.sensors.window_open = machine_status.sensors.window_open;
+    }
+}
+
+pub struct YoLinkCloudClient {
+    config: YoLinkConfig,
+    http: reqwest::Client,
+}
+
+type BoxFutureResult<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+pub trait YoLinkApi: Send + Sync {
+    fn authenticate(&self) -> BoxFutureResult<'_, String>;
+    fn get_home_id<'a>(&'a self, access_token: &'a str) -> BoxFutureResult<'a, String>;
+    fn get_devices<'a>(&'a self, access_token: &'a str) -> BoxFutureResult<'a, Vec<YoLinkDevice>>;
+}
+
+impl YoLinkCloudClient {
+    pub fn new(config: YoLinkConfig) -> Self {
+        Self {
+            config,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn authenticate(&self) -> Result<String> {
+        let response: Value = self
+            .http
+            .post(format!("{}/open/yolink/token", self.config.http_url))
+            .json(&json!({
+                "grant_type": "client_credentials",
+                "client_id": self.config.uaid,
+                "client_secret": self.config.secret_key,
+            }))
+            .send()
+            .await
+            .context("failed to call YoLink auth endpoint")?
+            .error_for_status()
+            .context("YoLink auth endpoint returned an error")?
+            .json()
+            .await
+            .context("failed to decode YoLink auth response")?;
+
+        response
+            .get("access_token")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("YoLink auth response missing access_token"))
+    }
+
+    async fn api_call(&self, access_token: &str, method: &str) -> Result<Value> {
+        let response: Value = self
+            .http
+            .post(format!("{}/open/yolink/v2/api", self.config.http_url))
+            .bearer_auth(access_token)
+            .json(&json!({
+                "method": method,
+                "time": chrono::Utc::now().timestamp_millis(),
+            }))
+            .send()
+            .await
+            .with_context(|| format!("failed to call YoLink API method {method}"))?
+            .error_for_status()
+            .with_context(|| format!("YoLink API method {method} returned an HTTP error"))?
+            .json()
+            .await
+            .with_context(|| format!("failed to decode YoLink API method {method} response"))?;
+
+        if response.get("code").and_then(Value::as_str) != Some("000000") {
+            bail!("YoLink API method {method} returned error: {response}");
+        }
+
+        Ok(response)
+    }
+
+    pub async fn get_home_id(&self, access_token: &str) -> Result<String> {
+        parse_home_id(&self.api_call(access_token, "Home.getGeneralInfo").await?)
+    }
+
+    pub async fn get_devices(&self, access_token: &str) -> Result<Vec<YoLinkDevice>> {
+        parse_devices(&self.api_call(access_token, "Home.getDeviceList").await?)
+    }
+}
+
+impl YoLinkApi for YoLinkCloudClient {
+    fn authenticate(&self) -> BoxFutureResult<'_, String> {
+        Box::pin(async { YoLinkCloudClient::authenticate(self).await })
+    }
+
+    fn get_home_id<'a>(&'a self, access_token: &'a str) -> BoxFutureResult<'a, String> {
+        Box::pin(async move { YoLinkCloudClient::get_home_id(self, access_token).await })
+    }
+
+    fn get_devices<'a>(&'a self, access_token: &'a str) -> BoxFutureResult<'a, Vec<YoLinkDevice>> {
+        Box::pin(async move { YoLinkCloudClient::get_devices(self, access_token).await })
+    }
+}
+
+pub async fn initialize_yolink_inventory(
+    client: &dyn YoLinkApi,
+    yolink: &YoLinkState,
+) -> Result<(String, String)> {
+    let access_token = client.authenticate().await?;
+    let home_id = client.get_home_id(&access_token).await?;
+    let devices = client.get_devices(&access_token).await?;
+    yolink.apply_devices(devices);
+    Ok((access_token, home_id))
+}
+
+pub fn parse_home_id(value: &Value) -> Result<String> {
+    value
+        .get("data")
+        .and_then(|data| data.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| anyhow!("YoLink home response missing data.id"))
+}
+
+pub fn parse_devices(value: &Value) -> Result<Vec<YoLinkDevice>> {
+    let Some(devices) = value
+        .get("data")
+        .and_then(|data| data.get("devices"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(Vec::new());
+    };
+
+    devices
+        .iter()
+        .map(|device| {
+            let device_id = device
+                .get("deviceId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("YoLink device missing deviceId"))?;
+            let device_type =
+                DeviceType::from_api(device.get("type").and_then(Value::as_str).unwrap_or(""));
+            Ok(YoLinkDevice {
+                device_id: device_id.to_string(),
+                name: device
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(device_id)
+                    .to_string(),
+                token: device
+                    .get("token")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                device_type,
+                state: serde_json::Map::new(),
+            })
+        })
+        .collect()
+}
+
+pub fn parse_mqtt_report_payload(payload: &[u8]) -> serde_json::Result<Option<YoLinkReport>> {
+    let value: Value = serde_json::from_slice(payload)?;
+    let Some(device_id) = value.get("deviceId").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let data = value.get("data").cloned().unwrap_or_else(|| json!({}));
+    Ok(Some(YoLinkReport {
+        device_id: device_id.to_string(),
+        data,
+    }))
+}
+
+pub fn reconnect_delay(config: &YoLinkConfig) -> Duration {
+    Duration::from_secs(config.reconnect_delay_seconds.max(1))
+}
+
+pub fn start_yolink_client(config: &AppConfig, yolink: YoLinkState) -> Option<JoinHandle<()>> {
+    if !config.yolink.is_configured() {
+        tracing::warn!("YoLink credentials are not configured; client not started");
+        return None;
+    }
+
+    let config = config.clone();
+    Some(tokio::spawn(async move {
+        loop {
+            if let Err(error) = run_yolink_client_once(&config, yolink.clone()).await {
+                tracing::warn!("YoLink client stopped: {error:#}");
+            }
+            tokio::time::sleep(reconnect_delay(&config.yolink)).await;
+        }
+    }))
+}
+
+async fn run_yolink_client_once(config: &AppConfig, yolink: YoLinkState) -> Result<()> {
+    let cloud = YoLinkCloudClient::new(config.yolink.clone());
+    let (access_token, home_id) = initialize_yolink_inventory(&cloud, &yolink).await?;
+    yolink.restore_from_database(chrono::Local::now().timestamp_millis() as f64 / 1_000.0)?;
+    listen_yolink_mqtt(&config.yolink, &access_token, &home_id, yolink).await
+}
+
+async fn listen_yolink_mqtt(
+    config: &YoLinkConfig,
+    access_token: &str,
+    home_id: &str,
+    yolink: YoLinkState,
+) -> Result<()> {
+    let mut options = MqttOptions::new(
+        "office-automate-yolink",
+        config.mqtt_host.clone(),
+        config.mqtt_port,
+    );
+    options.set_credentials(access_token, "");
+    options.set_keep_alive(Duration::from_secs(30));
+
+    let (client, mut event_loop) = AsyncClient::new(options, 10);
+    let topic = format!("yl-home/{home_id}/+/report");
+    client
+        .subscribe(topic.clone(), QoS::AtLeastOnce)
+        .await
+        .with_context(|| format!("failed to subscribe to YoLink MQTT topic {topic}"))?;
+
+    loop {
+        match event_loop.poll().await.context("YoLink MQTT poll failed")? {
+            Event::Incoming(Incoming::Publish(publish)) => {
+                match parse_mqtt_report_payload(&publish.payload) {
+                    Ok(Some(report)) => {
+                        let now = chrono::Local::now().timestamp_millis() as f64 / 1_000.0;
+                        if let Err(error) = yolink.apply_report(report, now) {
+                            tracing::warn!("failed to apply YoLink report: {error:#}");
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => tracing::warn!("failed to parse YoLink MQTT report: {error}"),
+                }
+            }
+            Event::Incoming(_) | Event::Outgoing(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::ThresholdsConfig,
+        db::migrate_database,
+        state::{OccupancyState, StateConfig},
+    };
+
+    fn test_state(database_path: PathBuf) -> YoLinkState {
+        YoLinkState::new(
+            Arc::new(RwLock::new(StateMachine::new(
+                StateConfig::from_thresholds(&ThresholdsConfig::default()),
+                1_000.0,
+            ))),
+            database_path,
+        )
+    }
+
+    fn sample_devices() -> Vec<YoLinkDevice> {
+        parse_devices(&json!({
+            "data": {
+                "devices": [
+                    {"deviceId": "door-1", "name": "Office Door", "token": "door-token", "type": "DoorSensor"},
+                    {"deviceId": "window-1", "name": "Office Window", "token": "window-token", "type": "DoorSensor"},
+                    {"deviceId": "motion-1", "name": "Office Motion", "token": "motion-token", "type": "MotionSensor"}
+                ]
+            }
+        }))
+        .expect("devices")
+    }
+
+    struct FakeYoLinkApi;
+
+    impl YoLinkApi for FakeYoLinkApi {
+        fn authenticate(&self) -> BoxFutureResult<'_, String> {
+            Box::pin(async { Ok("fake-token".to_string()) })
+        }
+
+        fn get_home_id<'a>(&'a self, access_token: &'a str) -> BoxFutureResult<'a, String> {
+            Box::pin(async move {
+                assert_eq!(access_token, "fake-token");
+                Ok("home-123".to_string())
+            })
+        }
+
+        fn get_devices<'a>(
+            &'a self,
+            access_token: &'a str,
+        ) -> BoxFutureResult<'a, Vec<YoLinkDevice>> {
+            Box::pin(async move {
+                assert_eq!(access_token, "fake-token");
+                Ok(sample_devices())
+            })
+        }
+    }
+
+    #[test]
+    fn parses_home_and_device_inventory() {
+        assert_eq!(
+            parse_home_id(&json!({"data": {"id": "home-123"}})).expect("home id"),
+            "home-123"
+        );
+
+        let devices = sample_devices();
+        assert_eq!(devices.len(), 3);
+        assert_eq!(devices[0].device_id, "door-1");
+        assert_eq!(devices[0].device_type, DeviceType::DoorSensor);
+        assert_eq!(devices[2].device_type, DeviceType::MotionSensor);
+    }
+
+    #[tokio::test]
+    async fn initializes_inventory_through_testable_api_client() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let yolink = test_state(temp_dir.path().join("office_climate.db"));
+
+        let (token, home_id) = initialize_yolink_inventory(&FakeYoLinkApi, &yolink)
+            .await
+            .expect("initialize");
+
+        assert_eq!(token, "fake-token");
+        assert_eq!(home_id, "home-123");
+        assert_eq!(
+            yolink.classified_device_ids(),
+            (
+                Some("door-1".to_string()),
+                Some("window-1".to_string()),
+                Some("motion-1".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn classifies_devices_by_python_name_rules() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let yolink = test_state(temp_dir.path().join("office_climate.db"));
+        yolink.apply_devices(sample_devices());
+
+        assert_eq!(
+            yolink.classified_device_ids(),
+            (
+                Some("door-1".to_string()),
+                Some("window-1".to_string()),
+                Some("motion-1".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn parses_mqtt_report_payload() {
+        let report = parse_mqtt_report_payload(br#"{"deviceId":"door-1","data":{"state":"open"}}"#)
+            .expect("parse")
+            .expect("report");
+
+        assert_eq!(report.device_id, "door-1");
+        assert_eq!(report.data["state"], "open");
+        assert_eq!(
+            parse_mqtt_report_payload(br#"{"data":{"state":"open"}}"#).expect("parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn applies_door_window_and_motion_events_to_state_machine_and_database() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let yolink = test_state(db_path.clone());
+        yolink.apply_devices(sample_devices());
+
+        let door = yolink
+            .apply_event("door-1", json!({"state": "open"}), 1_010.0)
+            .expect("door event")
+            .expect("applied");
+        let window = yolink
+            .apply_event("window-1", json!({"state": "open"}), 1_011.0)
+            .expect("window event")
+            .expect("applied");
+        let motion = yolink
+            .apply_event("motion-1", json!({"state": "alert"}), 1_012.0)
+            .expect("motion event")
+            .expect("applied");
+
+        assert_eq!(door.device_type, "door");
+        assert_eq!(door.event, "open");
+        assert_eq!(window.device_type, "window");
+        assert_eq!(window.event, "open");
+        assert_eq!(motion.device_type, "motion");
+        assert_eq!(motion.event, "detected");
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(machine.sensors.door_open);
+        assert!(machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        drop(machine);
+
+        assert_eq!(
+            db::get_latest_device_state(&db_path, "door").expect("door state"),
+            Some("open".to_string())
+        );
+        assert_eq!(
+            db::get_latest_device_state(&db_path, "motion").expect("motion state"),
+            Some("detected".to_string())
+        );
+    }
+
+    #[test]
+    fn restores_device_state_from_database() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        db::log_device_event(&db_path, "door", "open", Some("Office Door"), None)
+            .expect("log door");
+        db::log_device_event(&db_path, "window", "closed", Some("Office Window"), None)
+            .expect("log window");
+        db::log_device_event(&db_path, "motion", "detected", Some("Office Motion"), None)
+            .expect("log motion");
+
+        let yolink = test_state(db_path);
+        yolink.restore_from_database(1_050.0).expect("restore");
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(machine.sensors.door_open);
+        assert!(!machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        assert_eq!(machine.state, OccupancyState::Away);
+    }
+
+    #[test]
+    fn reconnect_delay_uses_configured_minimum() {
+        assert_eq!(
+            reconnect_delay(&YoLinkConfig {
+                reconnect_delay_seconds: 10,
+                ..YoLinkConfig::default()
+            }),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            reconnect_delay(&YoLinkConfig {
+                reconnect_delay_seconds: 0,
+                ..YoLinkConfig::default()
+            }),
+            Duration::from_secs(1)
+        );
+    }
+}

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -489,14 +489,31 @@ pub fn parse_devices(value: &Value) -> Result<Vec<YoLinkDevice>> {
 
 pub fn parse_mqtt_report_payload(payload: &[u8]) -> serde_json::Result<Option<YoLinkReport>> {
     let value: Value = serde_json::from_slice(payload)?;
-    let Some(device_id) = value.get("deviceId").and_then(Value::as_str) else {
+    let data = value.get("data").cloned().unwrap_or_else(|| json!({}));
+    if let Some(device_id) = value.get("deviceId").and_then(Value::as_str) {
+        return Ok(Some(YoLinkReport {
+            device_id: device_id.to_string(),
+            data,
+        }));
+    }
+
+    let Some(device_id) = data.get("deviceId").and_then(Value::as_str) else {
         return Ok(None);
     };
-    let data = value.get("data").cloned().unwrap_or_else(|| json!({}));
     Ok(Some(YoLinkReport {
         device_id: device_id.to_string(),
-        data,
+        data: normalize_report_data(data),
     }))
+}
+
+fn normalize_report_data(data: Value) -> Value {
+    let Some(state) = data.get("state") else {
+        return data;
+    };
+    if state.as_str().is_some() {
+        return data;
+    }
+    state.clone()
 }
 
 pub fn reconnect_delay(config: &YoLinkConfig) -> Duration {
@@ -759,6 +776,16 @@ mod tests {
 
         assert_eq!(report.device_id, "door-1");
         assert_eq!(report.data["state"], "open");
+
+        let documented_report = parse_mqtt_report_payload(
+            br#"{"event":"DoorSensor.Report","data":{"deviceId":"door-1","state":{"state":"open","battery":4}}}"#,
+        )
+        .expect("parse documented")
+        .expect("documented report");
+        assert_eq!(documented_report.device_id, "door-1");
+        assert_eq!(documented_report.data["state"], "open");
+        assert_eq!(documented_report.data["battery"], 4);
+
         assert_eq!(
             parse_mqtt_report_payload(br#"{"data":{"state":"open"}}"#).expect("parse"),
             None


### PR DESCRIPTION
## Summary
- Add passive YoLink auth, home/device discovery, MQTT event parsing, and reconnect handling to the Rust backend.
- Persist YoLink door/motion sensor state to `device_events` and restore it into `/status` on startup.
- Feed door/window and motion reports into the existing occupancy state machine without enabling active climate writes.

## Scope Notes
- This ticket is passive sensor ingestion only; ERV/HVAC active write behavior remains out of scope.
- YoLink cloud credentials and MQTT topics come from config/env, matching the cutover spec boundary.

## Spec Reference
- #62
- docs/working/62_primary_host_modern_stack.md

## Test Plan
- [x] cargo fmt --all --check
- [x] cargo check --workspace
- [x] cargo test --workspace
- [x] venv/bin/python -m pytest tests/ -v

Fixes #68