### PR TITLE
Add ERV read health and smoke support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.6.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +134,28 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -265,10 +322,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -326,6 +407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +487,12 @@ dependencies = [
  "toml",
  "yaml-rust2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -436,6 +540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +562,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-epoch"
@@ -485,6 +610,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,8 +659,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -527,6 +693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "ecb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -720,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +957,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "http"
@@ -846,6 +1039,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1076,6 +1278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1425,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1392,10 +1614,11 @@ dependencies = [
  "rumqttc",
  "rumqttd",
  "rusqlite",
+ "rustuya",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -1519,7 +1742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1533,6 +1756,17 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1838,6 +2072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2250,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustuya"
+version = "0.3.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914d825bd2465f37554a2ac624a16ac15f5668ff7ae500b1fe726444788645b9"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-stream",
+ "base64 0.22.1",
+ "byteorder",
+ "cipher",
+ "crc",
+ "ecb",
+ "futures-core",
+ "futures-util",
+ "hmac",
+ "log",
+ "md-5",
+ "parking_lot",
+ "rand 0.10.1",
+ "rlimit",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,7 +2433,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2169,7 +2444,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2478,6 +2764,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2501,6 +2788,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2721,6 +3009,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rumqttd = { version = "0.20", default-features = false }
 rumqttc = { version = "0.25", default-features = false, features = ["use-rustls-no-provider"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+rustuya = "0.3.0-rc.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-use crate::{config::AppConfig, db, http};
+use crate::{config::AppConfig, db, erv, http};
 
 #[derive(Debug, Parser)]
 #[command(name = "office-automate-server")]
@@ -19,12 +19,28 @@ pub enum Command {
     Serve(ConfigArgs),
     /// Create or upgrade the SQLite schema.
     Migrate(ConfigArgs),
+    /// Run local dependency checks without changing device state.
+    Smoke(SmokeArgs),
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct ConfigArgs {
     #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
     pub config: PathBuf,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct SmokeArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[command(subcommand)]
+    pub target: Option<SmokeTarget>,
+}
+
+#[derive(Debug, Subcommand, Clone, Copy, PartialEq, Eq)]
+pub enum SmokeTarget {
+    /// Verify local ERV read credential and connectivity.
+    Erv,
 }
 
 pub async fn run_cli() -> Result<()> {
@@ -49,7 +65,29 @@ pub async fn run(cli: Cli) -> Result<()> {
             db::migrate(&config)?;
             Ok(())
         }
+        Command::Smoke(args) => {
+            let config = AppConfig::load(&args.config)?;
+            run_smoke(&config, args.target).await
+        }
     }
+}
+
+async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()> {
+    match target {
+        Some(SmokeTarget::Erv) | None => {
+            let status = erv::smoke_erv(config).await?;
+            println!(
+                "ERV local status OK: running={} speed={}",
+                status.power,
+                status
+                    .fan_speed
+                    .map(|speed| speed.as_str())
+                    .unwrap_or("unknown")
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -86,6 +124,26 @@ mod tests {
         match cli.command {
             Command::Migrate(args) => assert_eq!(args.config, PathBuf::from("/tmp/office.yaml")),
             other => panic!("expected migrate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_smoke_erv_command_with_config() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "smoke",
+            "--config",
+            "/tmp/office.yaml",
+            "erv",
+        ])
+        .expect("smoke command should parse");
+
+        match cli.command {
+            Command::Smoke(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.target, Some(SmokeTarget::Erv));
+            }
+            other => panic!("expected smoke command, got {other:?}"),
         }
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -11,6 +11,7 @@ pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
+    pub erv: ErvConfig,
     pub thresholds: ThresholdsConfig,
     pub runtime: RuntimeConfig,
 }
@@ -109,6 +110,44 @@ impl Default for YoLinkConfig {
             mqtt_host: "api.yosmart.com".to_string(),
             mqtt_port: 8003,
             reconnect_delay_seconds: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ErvConfig {
+    #[serde(rename = "type")]
+    pub device_type: String,
+    pub ip: String,
+    pub device_id: String,
+    pub local_key: String,
+    pub version: String,
+    pub port: u16,
+    pub status_timeout_seconds: u64,
+    pub poll_interval_seconds: u64,
+}
+
+impl ErvConfig {
+    pub fn is_configured(&self) -> bool {
+        self.device_type == "tuya"
+            && !self.ip.trim().is_empty()
+            && !self.device_id.trim().is_empty()
+            && !self.local_key.trim().is_empty()
+    }
+}
+
+impl Default for ErvConfig {
+    fn default() -> Self {
+        Self {
+            device_type: "tuya".to_string(),
+            ip: String::new(),
+            device_id: String::new(),
+            local_key: String::new(),
+            version: "3.4".to_string(),
+            port: 6668,
+            status_timeout_seconds: 5,
+            poll_interval_seconds: 60,
         }
     }
 }
@@ -222,6 +261,7 @@ struct FileConfig {
     orchestrator: OrchestratorConfig,
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
+    erv: ErvConfig,
     thresholds: ThresholdsConfig,
 }
 
@@ -274,6 +314,18 @@ impl AppConfig {
             file_config.yolink.secret_key = secret_key;
         }
 
+        if let Some(ip) = env_lookup("OFFICE_AUTOMATE_ERV_IP") {
+            file_config.erv.ip = ip;
+        }
+
+        if let Some(device_id) = env_lookup("OFFICE_AUTOMATE_ERV_DEVICE_ID") {
+            file_config.erv.device_id = device_id;
+        }
+
+        if let Some(local_key) = env_lookup("OFFICE_AUTOMATE_ERV_LOCAL_KEY") {
+            file_config.erv.local_key = local_key;
+        }
+
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
             root,
@@ -292,6 +344,7 @@ impl AppConfig {
             orchestrator: file_config.orchestrator,
             qingping: file_config.qingping,
             yolink: file_config.yolink,
+            erv: file_config.erv,
             thresholds: file_config.thresholds,
             runtime,
         })
@@ -320,6 +373,11 @@ qingping:
 yolink:
   uaid: "yaml-uaid"
   secret_key: "yaml-secret"
+erv:
+  type: "tuya"
+  ip: "192.0.2.10"
+  device_id: "yaml-erv-device"
+  local_key: "yaml-erv-key"
 thresholds:
   hvac_heat_on_temp_f: 70
   hvac_heat_off_temp_f: 74
@@ -336,6 +394,9 @@ thresholds:
             "OFFICE_AUTOMATE_MQTT_PORT" => Some("2883".to_string()),
             "OFFICE_AUTOMATE_YOLINK_UAID" => Some("env-uaid".to_string()),
             "OFFICE_AUTOMATE_YOLINK_SECRET_KEY" => Some("env-secret".to_string()),
+            "OFFICE_AUTOMATE_ERV_IP" => Some("192.0.2.11".to_string()),
+            "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
+            "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             _ => None,
         })
@@ -352,6 +413,13 @@ thresholds:
         assert_eq!(config.yolink.mqtt_port, 8003);
         assert_eq!(config.yolink.reconnect_delay_seconds, 5);
         assert!(config.yolink.is_configured());
+        assert_eq!(config.erv.device_type, "tuya");
+        assert_eq!(config.erv.ip, "192.0.2.11");
+        assert_eq!(config.erv.device_id, "env-erv-device");
+        assert_eq!(config.erv.local_key, "env-erv-key");
+        assert_eq!(config.erv.version, "3.4");
+        assert_eq!(config.erv.port, 6668);
+        assert!(config.erv.is_configured());
         assert_eq!(config.runtime.mqtt_host, "rust-broker");
         assert_eq!(config.runtime.mqtt_port, 2883);
         assert_eq!(config.runtime.data_dir, temp_dir.path().join("db"));

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1,0 +1,532 @@
+use std::{
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    str::FromStr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::Local;
+use serde_json::{Map, Value, json};
+use tokio::{task::JoinHandle, time};
+
+use crate::{
+    config::{AppConfig, ErvConfig},
+    db,
+    status::{AppNotification, ErvControlStatus, Status},
+};
+
+const DP_POWER: &str = "1";
+const DP_SUPPLY_SPEED: &str = "101";
+const DP_EXHAUST_SPEED: &str = "102";
+const LOCAL_KEY_ERROR_THRESHOLD: u64 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErvFanSpeed {
+    Off,
+    Quiet,
+    Medium,
+    Turbo,
+}
+
+impl ErvFanSpeed {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Quiet => "quiet",
+            Self::Medium => "medium",
+            Self::Turbo => "turbo",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ErvDeviceStatus {
+    pub power: bool,
+    pub fan_speed: Option<ErvFanSpeed>,
+    pub supply_speed: Option<i64>,
+    pub exhaust_speed: Option<i64>,
+    pub raw_dps: Value,
+}
+
+type BoxFutureResult<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+pub trait ErvStatusReader: Send + Sync {
+    fn read_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RustuyaErvStatusReader;
+
+impl ErvStatusReader for RustuyaErvStatusReader {
+    fn read_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            if !config.is_configured() {
+                bail!("ERV local Tuya config is incomplete");
+            }
+
+            let version = rustuya::Version::from_str(&config.version)
+                .map_err(|error| anyhow!("invalid ERV Tuya protocol version: {error}"))?;
+            let device = rustuya::Device::builder(
+                config.device_id.clone(),
+                config.local_key.as_bytes().to_vec(),
+            )
+            .address(config.ip.clone())
+            .version(version)
+            .port(config.port)
+            .persist(false)
+            .timeout(Duration::from_secs(config.status_timeout_seconds.max(1)))
+            .build();
+
+            let result = device.status().await;
+            device.close().await;
+            let payload = result
+                .context("failed to read ERV local Tuya status")?
+                .ok_or_else(|| anyhow!("ERV local Tuya status returned no payload"))?;
+            parse_erv_status_payload(&payload)
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ErvState {
+    inner: Arc<RwLock<ErvInner>>,
+    database_path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct ErvInner {
+    latest_status: Option<ErvDeviceStatus>,
+    control: ErvControlStatus,
+    notification: Option<AppNotification>,
+}
+
+impl ErvState {
+    pub fn new(database_path: PathBuf) -> Self {
+        Self {
+            inner: Arc::default(),
+            database_path,
+        }
+    }
+
+    pub async fn refresh_with<R>(&self, config: &ErvConfig, reader: &R) -> Result<ErvDeviceStatus>
+    where
+        R: ErvStatusReader + ?Sized,
+    {
+        match reader.read_status(config).await {
+            Ok(status) => {
+                self.record_local_success(status.clone());
+                Ok(status)
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                self.record_local_failure(&message);
+                Err(error)
+            }
+        }
+    }
+
+    pub fn overlay_status(&self, status: &mut Status) {
+        let inner = self.inner.read().expect("ERV state lock poisoned");
+        status.erv.control = inner.control.clone();
+
+        if let Some(device_status) = &inner.latest_status {
+            status.erv.running = device_status.power;
+            status.erv.speed = device_status
+                .fan_speed
+                .map(ErvFanSpeed::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+        }
+
+        if let Some(notification) = &inner.notification {
+            status.notifications.push(notification.clone());
+        }
+    }
+
+    fn record_local_success(&self, device_status: ErvDeviceStatus) {
+        let now = local_iso_now();
+        let (was_invalid, invalid_since) = {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            let was_invalid = inner.control.local_key_invalid;
+            let invalid_since = inner.control.local_key_invalid_since.clone();
+
+            inner.latest_status = Some(device_status);
+            inner.control.last_ok_at = Some(now.clone());
+            inner.control.last_local_ok_at = Some(now.clone());
+            inner.control.last_error = None;
+            inner.control.using_cloud = false;
+            inner.control.local_key_invalid = false;
+            inner.control.local_key_invalid_since = None;
+            inner.control.consecutive_local_key_errors = 0;
+
+            if was_invalid {
+                inner.notification = Some(recovered_notification(&now));
+            }
+
+            (was_invalid, invalid_since)
+        };
+
+        if was_invalid {
+            self.log_health_event(
+                "local_key_recovered",
+                json!({
+                    "type": "erv_local_key_recovered",
+                    "recovered_at": now,
+                    "invalid_since": invalid_since,
+                }),
+            );
+        }
+    }
+
+    fn record_local_failure(&self, message: &str) {
+        let now = local_iso_now();
+        let mut invalid_event = None;
+        {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            inner.control.last_error = Some(format!("Local status failed: {message}"));
+            inner.control.last_error_at = Some(now.clone());
+            inner.control.using_cloud = false;
+
+            if !is_local_key_error(message) {
+                inner.control.consecutive_local_key_errors = 0;
+                return;
+            }
+
+            inner.control.consecutive_local_key_errors += 1;
+            if inner.control.consecutive_local_key_errors >= LOCAL_KEY_ERROR_THRESHOLD
+                && !inner.control.local_key_invalid
+            {
+                inner.control.local_key_invalid = true;
+                inner.control.local_key_invalid_since = Some(now.clone());
+                inner.notification = Some(invalid_key_notification(&now));
+                invalid_event = Some(json!({
+                    "type": "erv_local_key_invalid",
+                    "started_at": now,
+                    "consecutive_errors": inner.control.consecutive_local_key_errors,
+                    "last_local_ok_at": inner.control.last_local_ok_at,
+                    "last_error": inner.control.last_error,
+                }));
+            }
+        }
+
+        if let Some(event) = invalid_event {
+            self.log_health_event("local_key_invalid", event);
+        }
+    }
+
+    fn log_health_event(&self, event: &str, details: Value) {
+        if let Err(error) = db::log_device_event(
+            &self.database_path,
+            "erv",
+            event,
+            Some("Pioneer ECOasis 150"),
+            Some(&details),
+        ) {
+            tracing::warn!("failed to log ERV health event: {error:#}");
+        }
+    }
+}
+
+pub fn start_erv_status_poll(config: &AppConfig, erv: ErvState) -> Option<JoinHandle<()>> {
+    if !config.erv.is_configured() {
+        tracing::info!("ERV local Tuya config is incomplete; read-only ERV polling disabled");
+        return None;
+    }
+
+    let config = config.erv.clone();
+    Some(tokio::spawn(async move {
+        let reader = RustuyaErvStatusReader;
+        let mut interval = time::interval(Duration::from_secs(config.poll_interval_seconds.max(5)));
+        loop {
+            interval.tick().await;
+            if let Err(error) = erv.refresh_with(&config, &reader).await {
+                tracing::warn!("ERV read-only status poll failed: {error:#}");
+            }
+        }
+    }))
+}
+
+pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {
+    let reader = RustuyaErvStatusReader;
+    reader.read_status(&config.erv).await
+}
+
+pub fn parse_erv_status_payload(payload: &str) -> Result<ErvDeviceStatus> {
+    let value: Value = serde_json::from_str(payload).context("ERV status payload is not JSON")?;
+    parse_erv_status_value(&value)
+}
+
+fn parse_erv_status_value(value: &Value) -> Result<ErvDeviceStatus> {
+    let dps = dps_object(value).ok_or_else(|| anyhow!("ERV status payload missing dps object"))?;
+    let power = dps.get(DP_POWER).and_then(value_as_bool).unwrap_or(false);
+    let supply_speed = dps.get(DP_SUPPLY_SPEED).and_then(value_as_i64);
+    let exhaust_speed = dps.get(DP_EXHAUST_SPEED).and_then(value_as_i64);
+    let fan_speed = fan_speed(power, supply_speed, exhaust_speed);
+
+    Ok(ErvDeviceStatus {
+        power,
+        fan_speed,
+        supply_speed,
+        exhaust_speed,
+        raw_dps: Value::Object(dps.clone()),
+    })
+}
+
+fn dps_object(value: &Value) -> Option<&Map<String, Value>> {
+    value
+        .get("dps")
+        .and_then(Value::as_object)
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(|data| data.get("dps"))
+                .and_then(Value::as_object)
+        })
+        .or_else(|| {
+            value
+                .as_object()
+                .and_then(|object| object.contains_key(DP_POWER).then_some(object))
+        })
+}
+
+fn fan_speed(
+    power: bool,
+    supply_speed: Option<i64>,
+    exhaust_speed: Option<i64>,
+) -> Option<ErvFanSpeed> {
+    if !power {
+        return Some(ErvFanSpeed::Off);
+    }
+
+    match (supply_speed, exhaust_speed) {
+        (Some(1), Some(1)) => Some(ErvFanSpeed::Quiet),
+        (Some(3), Some(2)) => Some(ErvFanSpeed::Medium),
+        (Some(8), Some(8)) => Some(ErvFanSpeed::Turbo),
+        _ => None,
+    }
+}
+
+fn value_as_bool(value: &Value) -> Option<bool> {
+    value.as_bool().or_else(|| {
+        value
+            .as_str()
+            .and_then(|value| match value.to_ascii_lowercase().as_str() {
+                "true" | "1" | "on" => Some(true),
+                "false" | "0" | "off" => Some(false),
+                _ => None,
+            })
+    })
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+}
+
+fn is_local_key_error(message: &str) -> bool {
+    message.contains("Check device key or version")
+        || (message.contains("914") && message.to_ascii_lowercase().contains("err"))
+}
+
+fn invalid_key_notification(created_at: &str) -> AppNotification {
+    AppNotification {
+        id: format!("erv_local_key_invalid:{created_at}"),
+        notification_type: "erv_local_key_invalid".to_string(),
+        severity: "critical".to_string(),
+        title: "ERV local key rotated".to_string(),
+        message:
+            "Local Tuya control is failing with Err 914. Run docs/tuya-local-key.md to recover it."
+                .to_string(),
+        created_at: Some(created_at.to_string()),
+        active: true,
+        runbook_path: Some("docs/tuya-local-key.md".to_string()),
+    }
+}
+
+fn recovered_notification(created_at: &str) -> AppNotification {
+    AppNotification {
+        id: format!("erv_local_key_recovered:{created_at}"),
+        notification_type: "erv_local_key_recovered".to_string(),
+        severity: "info".to_string(),
+        title: "ERV local control recovered".to_string(),
+        message: "Local Tuya control is working again.".to_string(),
+        created_at: Some(created_at.to_string()),
+        active: true,
+        runbook_path: Some("docs/tuya-local-key.md".to_string()),
+    }
+}
+
+fn local_iso_now() -> String {
+    Local::now()
+        .naive_local()
+        .format("%Y-%m-%dT%H:%M:%S")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
+    use super::*;
+    use crate::{
+        config::{
+            AppConfig, ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+            ThresholdsConfig, YoLinkConfig,
+        },
+        db,
+        status::Status,
+    };
+
+    struct FakeErvReader {
+        results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+    }
+
+    impl FakeErvReader {
+        fn new(results: Vec<Result<ErvDeviceStatus>>) -> Self {
+            Self {
+                results: Mutex::new(results.into()),
+            }
+        }
+    }
+
+    impl ErvStatusReader for FakeErvReader {
+        fn read_status<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            let result = self
+                .results
+                .lock()
+                .expect("fake reader lock")
+                .pop_front()
+                .unwrap_or_else(|| bail!("no fake ERV result configured"));
+            Box::pin(async move { result })
+        }
+    }
+
+    fn test_config() -> ErvConfig {
+        ErvConfig {
+            ip: "192.0.2.10".to_string(),
+            device_id: "device-id".to_string(),
+            local_key: "local-key".to_string(),
+            ..ErvConfig::default()
+        }
+    }
+
+    fn app_config(erv: ErvConfig) -> AppConfig {
+        AppConfig {
+            orchestrator: OrchestratorConfig::default(),
+            qingping: QingpingConfig::default(),
+            yolink: YoLinkConfig::default(),
+            erv,
+            thresholds: ThresholdsConfig::default(),
+            runtime: RuntimeConfig {
+                root: PathBuf::from("/tmp/office"),
+                config_path: PathBuf::from("/tmp/office/config.yaml"),
+                data_dir: PathBuf::from("/tmp/office/data"),
+                database_path: PathBuf::from("/tmp/office/data/office_climate.db"),
+                frontend_dist: PathBuf::from("/tmp/office/frontend/dist"),
+                artifacts_dir: PathBuf::from("/tmp/office/data/apps"),
+                legacy_apk_path: PathBuf::from("/tmp/office/data/app-debug.apk"),
+                base_url: None,
+                public_url: None,
+                mqtt_host: "127.0.0.1".to_string(),
+                mqtt_port: 1883,
+            },
+        }
+    }
+
+    fn medium_status() -> ErvDeviceStatus {
+        parse_erv_status_payload(r#"{"dps":{"1":true,"101":3,"102":2}}"#).expect("status")
+    }
+
+    #[test]
+    fn parses_local_tuya_status_payload() {
+        let status =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":8,"102":8}}"#).expect("status");
+
+        assert!(status.power);
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+        assert_eq!(status.supply_speed, Some(8));
+        assert_eq!(status.exhaust_speed, Some(8));
+
+        let status =
+            parse_erv_status_payload(r#"{"dps":{"1":false,"101":"1","102":"1"}}"#).expect("status");
+        assert!(!status.power);
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Off));
+    }
+
+    #[tokio::test]
+    async fn local_key_error_threshold_sets_control_notification_and_logs_event() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path.clone());
+        let reader = FakeErvReader::new(
+            (0..LOCAL_KEY_ERROR_THRESHOLD)
+                .map(|_| bail!("Check device key or version (Error 914)"))
+                .collect(),
+        );
+
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+        }
+
+        let mut status = Status::read_only_default(&app_config(test_config()));
+        state.overlay_status(&mut status);
+
+        assert!(status.erv.control.local_key_invalid);
+        assert_eq!(
+            status.erv.control.consecutive_local_key_errors,
+            LOCAL_KEY_ERROR_THRESHOLD
+        );
+        assert_eq!(
+            status.notifications[0].notification_type,
+            "erv_local_key_invalid"
+        );
+
+        let latest = db::get_latest_device_state(&database_path, "erv")
+            .expect("query")
+            .expect("event");
+        assert_eq!(latest, "local_key_invalid");
+    }
+
+    #[tokio::test]
+    async fn local_success_updates_status_and_recovers_invalid_key_notification() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let mut results = (0..LOCAL_KEY_ERROR_THRESHOLD)
+            .map(|_| bail!("Check device key or version (Error 914)"))
+            .collect::<Vec<_>>();
+        results.push(Ok(medium_status()));
+        let reader = FakeErvReader::new(results);
+
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+        }
+        let refreshed = state
+            .refresh_with(&test_config(), &reader)
+            .await
+            .expect("success");
+
+        assert_eq!(refreshed.fan_speed, Some(ErvFanSpeed::Medium));
+
+        let mut status = Status::read_only_default(&app_config(test_config()));
+        state.overlay_status(&mut status);
+
+        assert!(status.erv.running);
+        assert_eq!(status.erv.speed, "medium");
+        assert!(!status.erv.control.local_key_invalid);
+        assert_eq!(status.erv.control.consecutive_local_key_errors, 0);
+        assert_eq!(
+            status.notifications[0].notification_type,
+            "erv_local_key_recovered"
+        );
+    }
+}

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Local;
 use serde_json::{Map, Value, json};
-use tokio::{task::JoinHandle, time};
+use tokio::{sync::broadcast, task::JoinHandle, time};
 
 use crate::{
     config::{AppConfig, ErvConfig},
@@ -94,6 +94,7 @@ impl ErvStatusReader for RustuyaErvStatusReader {
 pub struct ErvState {
     inner: Arc<RwLock<ErvInner>>,
     database_path: PathBuf,
+    status_broadcast: Arc<RwLock<Option<broadcast::Sender<()>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -108,7 +109,15 @@ impl ErvState {
         Self {
             inner: Arc::default(),
             database_path,
+            status_broadcast: Arc::default(),
         }
+    }
+
+    pub fn set_status_broadcast(&self, sender: broadcast::Sender<()>) {
+        *self
+            .status_broadcast
+            .write()
+            .expect("ERV broadcast lock poisoned") = Some(sender);
     }
 
     pub async fn refresh_with<R>(&self, config: &ErvConfig, reader: &R) -> Result<ErvDeviceStatus>
@@ -117,12 +126,16 @@ impl ErvState {
     {
         match reader.read_status(config).await {
             Ok(status) => {
-                self.record_local_success(status.clone());
+                if self.record_local_success(status.clone()) {
+                    self.notify_status();
+                }
                 Ok(status)
             }
             Err(error) => {
                 let message = format!("{error:#}");
-                self.record_local_failure(&message);
+                if self.record_local_failure(&message) {
+                    self.notify_status();
+                }
                 Err(error)
             }
         }
@@ -146,10 +159,11 @@ impl ErvState {
         }
     }
 
-    fn record_local_success(&self, device_status: ErvDeviceStatus) {
+    fn record_local_success(&self, device_status: ErvDeviceStatus) -> bool {
         let now = local_iso_now();
-        let (was_invalid, invalid_since) = {
+        let (status_changed, was_invalid, invalid_since) = {
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            let status_changed = inner.latest_status.as_ref() != Some(&device_status);
             let was_invalid = inner.control.local_key_invalid;
             let invalid_since = inner.control.local_key_invalid_since.clone();
 
@@ -166,7 +180,7 @@ impl ErvState {
                 inner.notification = Some(recovered_notification(&now));
             }
 
-            (was_invalid, invalid_since)
+            (status_changed, was_invalid, invalid_since)
         };
 
         if was_invalid {
@@ -179,9 +193,10 @@ impl ErvState {
                 }),
             );
         }
+        status_changed || was_invalid
     }
 
-    fn record_local_failure(&self, message: &str) {
+    fn record_local_failure(&self, message: &str) -> bool {
         let now = local_iso_now();
         let mut invalid_event = None;
         {
@@ -192,7 +207,7 @@ impl ErvState {
 
             if !is_local_key_error(message) {
                 inner.control.consecutive_local_key_errors = 0;
-                return;
+                return false;
             }
 
             inner.control.consecutive_local_key_errors += 1;
@@ -214,7 +229,21 @@ impl ErvState {
 
         if let Some(event) = invalid_event {
             self.log_health_event("local_key_invalid", event);
+            return true;
         }
+        false
+    }
+
+    fn notify_status(&self) {
+        let Some(sender) = self
+            .status_broadcast
+            .read()
+            .expect("ERV broadcast lock poisoned")
+            .clone()
+        else {
+            return;
+        };
+        let _ = sender.send(());
     }
 
     fn log_health_event(&self, event: &str, details: Value) {
@@ -493,6 +522,51 @@ mod tests {
             .expect("query")
             .expect("event");
         assert_eq!(latest, "local_key_invalid");
+    }
+
+    #[tokio::test]
+    async fn local_status_change_notifies_status_broadcast() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let (sender, mut receiver) = tokio::sync::broadcast::channel(4);
+        state.set_status_broadcast(sender);
+        let reader = FakeErvReader::new(vec![Ok(medium_status())]);
+
+        state
+            .refresh_with(&test_config(), &reader)
+            .await
+            .expect("success");
+
+        tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast message");
+    }
+
+    #[tokio::test]
+    async fn local_key_invalid_transition_notifies_status_broadcast() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let (sender, mut receiver) = tokio::sync::broadcast::channel(4);
+        state.set_status_broadcast(sender);
+        let reader = FakeErvReader::new(
+            (0..LOCAL_KEY_ERROR_THRESHOLD)
+                .map(|_| bail!("Check device key or version (Error 914)"))
+                .collect(),
+        );
+
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast message");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -93,6 +93,7 @@ fn try_app_with_state(
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
     let (status_broadcast, _) = broadcast::channel(32);
     yolink.set_status_broadcast(status_broadcast.clone());
+    erv_state.set_status_broadcast(status_broadcast.clone());
     yolink.restore_from_database(unix_timestamp_now())?;
     let state = AppState {
         config,

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -34,7 +34,9 @@ use crate::{
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     config::AppConfig,
-    db, mqtt,
+    db,
+    erv::ErvState,
+    mqtt,
     qingping::QingpingState,
     state::{StateMachine, StateTransition},
     status::{Status, TemperatureBands},
@@ -53,6 +55,7 @@ struct AppState {
     state_machine: Arc<RwLock<StateMachine>>,
     status_broadcast: broadcast::Sender<()>,
     qingping: QingpingState,
+    erv: ErvState,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -69,7 +72,8 @@ fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<R
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
-    try_app_with_state(config, qingping, state_machine, yolink)
+    let erv_state = ErvState::new(config.runtime.database_path.clone());
+    try_app_with_state(config, qingping, state_machine, yolink, erv_state)
 }
 
 fn try_app_with_state(
@@ -77,6 +81,7 @@ fn try_app_with_state(
     qingping: QingpingState,
     state_machine: Arc<RwLock<StateMachine>>,
     yolink: YoLinkState,
+    erv_state: ErvState,
 ) -> Result<Router> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
@@ -98,6 +103,7 @@ fn try_app_with_state(
         state_machine,
         status_broadcast,
         qingping,
+        erv: erv_state,
     };
 
     let cors = CorsLayer::new()
@@ -167,16 +173,19 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+    let erv_state = ErvState::new(config.runtime.database_path.clone());
     let app = try_app_with_state(
         config.clone(),
         qingping.clone(),
         state_machine,
         yolink.clone(),
+        erv_state.clone(),
     )
     .context("failed to build HTTP app")?;
     let _mqtt_runtime =
         mqtt::start_qingping_ingress(&config, qingping).context("failed to start MQTT ingress")?;
     let _yolink_task = yolink::start_yolink_client(&config, yolink);
+    let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
 
     tracing::info!("office-automate-server listening on {}", bind_address);
     axum::serve(
@@ -703,6 +712,7 @@ fn status_for_state(state: &AppState) -> Status {
     status.sensors.window_open = state_status.sensors.window_open;
     status.sensors.co2_ppm = state_status.sensors.co2_ppm;
     state.qingping.overlay_status(&mut status);
+    state.erv.overlay_status(&mut status);
     status
 }
 
@@ -1287,8 +1297,8 @@ mod tests {
 
     use super::*;
     use crate::config::{
-        GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
-        YoLinkConfig,
+        ErvConfig, GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+        ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -1298,6 +1308,7 @@ mod tests {
             orchestrator: OrchestratorConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            erv: ErvConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod cli;
 pub mod config;
 pub mod db;
+pub mod erv;
 pub mod http;
 pub mod mqtt;
 pub mod policy;

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -240,7 +240,8 @@ mod tests {
 
     use super::*;
     use crate::config::{
-        OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+        ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
+        YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -251,6 +252,7 @@ mod tests {
                 ..QingpingConfig::default()
             },
             yolink: YoLinkConfig::default(),
+            erv: ErvConfig::default(),
             thresholds: ThresholdsConfig {
                 hvac_heat_on_temp_f: 70,
                 hvac_heat_off_temp_f: 74,


### PR DESCRIPTION
## Summary
- Port read-only ERV local Tuya status parsing and health tracking into the Rust server.
- Preserve the full `erv.control` status surface, including local-key-invalid notification state.
- Add `office-automate-server smoke erv` coverage that verifies read credentials without changing speed.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `venv/bin/python -m pytest tests/ -v`

Fixes #69
