### PR TITLE
Gate active ERV write control

### DIFF
--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -1,0 +1,707 @@
+use std::sync::{Arc, Mutex, RwLock};
+
+use anyhow::{Context, Result};
+use tokio::sync::{Mutex as AsyncMutex, broadcast};
+
+use crate::{
+    config::AppConfig,
+    erv::{ErvDeviceStatus, ErvFanSpeed, ErvSpeedWriter, ErvState},
+    policy::{AirQualityReading, ErvDecision, ErvPolicyInput, ErvPolicyState, VentilationSpeed},
+    qingping::QingpingState,
+    state::{OccupancyState, StateMachine, StateTransition},
+};
+
+#[derive(Clone)]
+pub struct ErvPolicyCoordinator {
+    config: AppConfig,
+    state_machine: Arc<RwLock<StateMachine>>,
+    qingping: QingpingState,
+    erv: ErvState,
+    policy: Arc<RwLock<ErvPolicyState>>,
+    writer: Arc<dyn ErvSpeedWriter>,
+    status_broadcast: broadcast::Sender<()>,
+    apply_lock: Arc<AsyncMutex<()>>,
+    last_recorded_qingping: Arc<Mutex<Option<QingpingReadingKey>>>,
+}
+
+impl ErvPolicyCoordinator {
+    pub fn new(
+        config: AppConfig,
+        state_machine: Arc<RwLock<StateMachine>>,
+        qingping: QingpingState,
+        erv: ErvState,
+        policy: Arc<RwLock<ErvPolicyState>>,
+        writer: Arc<dyn ErvSpeedWriter>,
+        status_broadcast: broadcast::Sender<()>,
+    ) -> Self {
+        Self {
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer,
+            status_broadcast,
+            apply_lock: Arc::new(AsyncMutex::new(())),
+            last_recorded_qingping: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn evaluate_erv_policy(&self, bypass_dwell: bool) -> Result<()> {
+        let _apply_guard = self.apply_lock.lock().await;
+        self.evaluate_erv_policy_locked(bypass_dwell).await
+    }
+
+    pub async fn update_state_and_maybe_evaluate<T, F>(&self, update: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<(T, Option<StateTransition>, f64, bool, bool)>,
+    {
+        let _apply_guard = self.apply_lock.lock().await;
+        let (result, transition, now, bypass_dwell, should_evaluate) = update()?;
+        if should_evaluate {
+            self.record_occupancy_transition_locked(transition, now);
+            self.evaluate_erv_policy_locked(bypass_dwell).await?;
+        }
+        Ok(result)
+    }
+
+    async fn evaluate_erv_policy_locked(&self, bypass_dwell: bool) -> Result<()> {
+        let now = unix_timestamp_now();
+        let state_status = {
+            let machine = self
+                .state_machine
+                .read()
+                .expect("state machine lock poisoned");
+            machine.status_at(now)
+        };
+        let qingping_reading = self.qingping.latest();
+        let manual_override = self
+            .erv
+            .active_manual_override_speed(now)
+            .map(ventilation_speed_from_erv);
+        let mut erv_snapshot = self.erv.snapshot();
+        let mut fresh_status_checked = false;
+        if self.should_refresh_unknown_erv_status(
+            &erv_snapshot,
+            &state_status,
+            qingping_reading.as_ref(),
+            manual_override,
+        ) {
+            self.erv
+                .smoke_status_with(&self.config.erv, self.writer.as_ref())
+                .await
+                .context("ERV smoke check failed before policy evaluation")?;
+            erv_snapshot = self.erv.snapshot();
+            fresh_status_checked = true;
+        }
+
+        let decision = {
+            let mut policy = self.policy.write().expect("ERV policy lock poisoned");
+            if let Some(reading) = &qingping_reading {
+                self.record_qingping_reading_once(&mut policy, now, reading);
+            }
+
+            policy.decide_erv(
+                &self.config.thresholds,
+                ErvPolicyInput {
+                    occupancy: if state_status.is_present {
+                        OccupancyState::Present
+                    } else {
+                        OccupancyState::Away
+                    },
+                    door_open: state_status.sensors.door_open,
+                    window_open: state_status.sensors.window_open,
+                    co2_ppm: qingping_reading
+                        .as_ref()
+                        .and_then(|reading| reading.co2_ppm)
+                        .or(Some(state_status.sensors.co2_ppm)),
+                    tvoc: qingping_reading.as_ref().and_then(|reading| reading.tvoc),
+                    current_running: erv_snapshot.running,
+                    current_speed: ventilation_speed_from_erv(erv_snapshot.speed),
+                    manual_override,
+                    last_speed_changed_at: erv_snapshot.last_speed_changed_at,
+                    bypass_dwell,
+                },
+                now,
+            )
+        };
+
+        match decision {
+            ErvDecision::NoChange | ErvDecision::SuppressedByDwell { .. } => Ok(()),
+            ErvDecision::SetSpeed {
+                target_speed,
+                reason,
+                ..
+            } => {
+                self.apply_policy_erv_speed(
+                    erv_speed_from_ventilation(target_speed),
+                    &reason,
+                    self.latest_co2_ppm(),
+                    fresh_status_checked,
+                )
+                .await?;
+                self.broadcast_status();
+                Ok(())
+            }
+        }
+    }
+
+    fn record_occupancy_transition_locked(&self, transition: Option<StateTransition>, now: f64) {
+        let Some(transition) = transition else {
+            return;
+        };
+        let status = {
+            let machine = self
+                .state_machine
+                .read()
+                .expect("state machine lock poisoned");
+            machine.status_at(now)
+        };
+        self.policy
+            .write()
+            .expect("ERV policy lock poisoned")
+            .on_occupancy_transition(
+                &self.config.thresholds,
+                transition.old_state,
+                transition.new_state,
+                now,
+                status.sensors.door_open,
+                status.sensors.window_open,
+            );
+    }
+
+    pub async fn apply_erv_speed(
+        &self,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) -> Result<ErvDeviceStatus> {
+        self.erv
+            .set_speed_with(
+                &self.config.erv,
+                self.writer.as_ref(),
+                speed,
+                reason,
+                co2_ppm,
+            )
+            .await
+    }
+
+    async fn apply_policy_erv_speed(
+        &self,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+        fresh_status_checked: bool,
+    ) -> Result<ErvDeviceStatus> {
+        if fresh_status_checked {
+            return self
+                .erv
+                .set_speed_after_smoke_with(
+                    &self.config.erv,
+                    self.writer.as_ref(),
+                    speed,
+                    reason,
+                    co2_ppm,
+                )
+                .await;
+        }
+
+        self.apply_erv_speed(speed, reason, co2_ppm).await
+    }
+
+    pub fn latest_co2_ppm(&self) -> Option<i64> {
+        self.qingping.latest().and_then(|reading| reading.co2_ppm)
+    }
+
+    pub fn broadcast_status(&self) {
+        let _ = self.status_broadcast.send(());
+    }
+
+    fn should_refresh_unknown_erv_status(
+        &self,
+        snapshot: &crate::erv::ErvRuntimeSnapshot,
+        state_status: &crate::state::StateStatus,
+        qingping_reading: Option<&crate::qingping::QingpingReading>,
+        manual_override: Option<VentilationSpeed>,
+    ) -> bool {
+        if snapshot.status_known
+            || !self.config.erv.active_control_enabled
+            || !self.config.erv.is_configured()
+            || snapshot.local_key_invalid
+        {
+            return false;
+        }
+
+        if state_status.sensors.door_open || state_status.sensors.window_open {
+            return true;
+        }
+
+        if manual_override.is_some() {
+            return false;
+        }
+
+        let co2_ppm = qingping_reading
+            .and_then(|reading| reading.co2_ppm)
+            .or(Some(state_status.sensors.co2_ppm));
+        let tvoc = qingping_reading.and_then(|reading| reading.tvoc);
+
+        if state_status.is_present {
+            return !co2_ppm.is_some_and(|co2| co2 >= self.config.thresholds.co2_critical_ppm);
+        }
+
+        !co2_ppm.is_some_and(|co2| co2 > self.config.thresholds.co2_refresh_target_ppm)
+            && !tvoc.is_some_and(|tvoc| tvoc > self.config.thresholds.tvoc_away_threshold)
+    }
+
+    fn record_qingping_reading_once(
+        &self,
+        policy: &mut ErvPolicyState,
+        now: f64,
+        reading: &crate::qingping::QingpingReading,
+    ) {
+        let key = QingpingReadingKey::from(reading);
+        let should_record = {
+            let mut last_recorded = self
+                .last_recorded_qingping
+                .lock()
+                .expect("Qingping reading key lock poisoned");
+            if last_recorded.as_ref() == Some(&key) {
+                false
+            } else {
+                *last_recorded = Some(key);
+                true
+            }
+        };
+
+        if should_record {
+            policy.record_reading(
+                &self.config.thresholds,
+                now,
+                AirQualityReading {
+                    co2_ppm: reading.co2_ppm,
+                    tvoc: reading.tvoc,
+                    temp_c: reading.temp_c,
+                },
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QingpingReadingKey {
+    timestamp: String,
+    raw_data: String,
+}
+
+impl From<&crate::qingping::QingpingReading> for QingpingReadingKey {
+    fn from(reading: &crate::qingping::QingpingReading) -> Self {
+        Self {
+            timestamp: reading.timestamp.clone(),
+            raw_data: reading.raw_data.clone(),
+        }
+    }
+}
+
+fn ventilation_speed_from_erv(speed: ErvFanSpeed) -> VentilationSpeed {
+    match speed {
+        ErvFanSpeed::Off => VentilationSpeed::Off,
+        ErvFanSpeed::Quiet => VentilationSpeed::Quiet,
+        ErvFanSpeed::Medium => VentilationSpeed::Medium,
+        ErvFanSpeed::Turbo => VentilationSpeed::Turbo,
+    }
+}
+
+fn erv_speed_from_ventilation(speed: VentilationSpeed) -> ErvFanSpeed {
+    match speed {
+        VentilationSpeed::Off => ErvFanSpeed::Off,
+        VentilationSpeed::Quiet => ErvFanSpeed::Quiet,
+        VentilationSpeed::Medium => ErvFanSpeed::Medium,
+        VentilationSpeed::Turbo => ErvFanSpeed::Turbo,
+    }
+}
+
+fn unix_timestamp_now() -> f64 {
+    chrono::Local::now().timestamp_millis() as f64 / 1_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, path::PathBuf, sync::Mutex, time::Duration};
+
+    use anyhow::Result;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+
+    use super::*;
+    use crate::{
+        config::{
+            ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
+            YoLinkConfig,
+        },
+        db,
+        erv::BoxFutureResult,
+        qingping::QingpingReading,
+        state::StateMachine,
+    };
+
+    struct FakeErvWriter {
+        smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        writes: Mutex<Vec<ErvFanSpeed>>,
+        set_delay: Duration,
+    }
+
+    impl FakeErvWriter {
+        fn new(smoke_results: Vec<Result<ErvDeviceStatus>>) -> Self {
+            Self {
+                smoke_results: Mutex::new(smoke_results.into()),
+                writes: Mutex::new(Vec::new()),
+                set_delay: Duration::ZERO,
+            }
+        }
+
+        fn with_set_delay(mut self, set_delay: Duration) -> Self {
+            self.set_delay = set_delay;
+            self
+        }
+
+        fn writes(&self) -> Vec<ErvFanSpeed> {
+            self.writes.lock().expect("writes lock").clone()
+        }
+    }
+
+    impl ErvSpeedWriter for FakeErvWriter {
+        fn smoke_status<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            let result = self
+                .smoke_results
+                .lock()
+                .expect("smoke lock")
+                .pop_front()
+                .unwrap_or_else(|| Ok(erv_status(ErvFanSpeed::Off)));
+            Box::pin(async move { result })
+        }
+
+        fn set_speed<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+            speed: ErvFanSpeed,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.writes.lock().expect("writes lock").push(speed);
+            let set_delay = self.set_delay;
+            Box::pin(async move {
+                if !set_delay.is_zero() {
+                    tokio::time::sleep(set_delay).await;
+                }
+                Ok(erv_status(speed))
+            })
+        }
+    }
+
+    fn test_config(database_path: PathBuf) -> AppConfig {
+        let root = database_path
+            .parent()
+            .expect("database parent")
+            .to_path_buf();
+        AppConfig {
+            orchestrator: OrchestratorConfig::default(),
+            qingping: QingpingConfig::default(),
+            yolink: YoLinkConfig::default(),
+            erv: ErvConfig {
+                device_type: "tuya".to_string(),
+                ip: "192.0.2.10".to_string(),
+                device_id: "device-id".to_string(),
+                local_key: "local-key".to_string(),
+                active_control_enabled: true,
+                verify_delay_seconds: 0,
+                ..ErvConfig::default()
+            },
+            thresholds: ThresholdsConfig::default(),
+            runtime: RuntimeConfig {
+                root: root.clone(),
+                config_path: root.join("config.yaml"),
+                data_dir: root.clone(),
+                database_path,
+                frontend_dist: root.join("frontend/dist"),
+                artifacts_dir: root.join("apps"),
+                legacy_apk_path: root.join("app-debug.apk"),
+                base_url: None,
+                public_url: None,
+                mqtt_host: "127.0.0.1".to_string(),
+                mqtt_port: 1883,
+            },
+        }
+    }
+
+    fn qingping_reading(co2_ppm: i64) -> QingpingReading {
+        QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.0),
+            humidity: Some(45.0),
+            co2_ppm: Some(co2_ppm),
+            pm25: Some(2),
+            pm10: Some(3),
+            tvoc: Some(25),
+            noise_db: Some(35),
+            timestamp: "2026-06-05T12:30:00".to_string(),
+            raw_data: "{}".to_string(),
+        }
+    }
+
+    fn erv_status(speed: ErvFanSpeed) -> ErvDeviceStatus {
+        let (power, supply_speed, exhaust_speed) = match speed {
+            ErvFanSpeed::Off => (false, Some(1), Some(1)),
+            ErvFanSpeed::Quiet => (true, Some(1), Some(1)),
+            ErvFanSpeed::Medium => (true, Some(3), Some(2)),
+            ErvFanSpeed::Turbo => (true, Some(8), Some(8)),
+        };
+        ErvDeviceStatus {
+            power,
+            fan_speed: Some(speed),
+            supply_speed,
+            exhaust_speed,
+            raw_dps: json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn sensor_reading_can_drive_erv_policy_without_route_update() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Off))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy applies");
+
+        assert_eq!(writer.writes(), vec![ErvFanSpeed::Quiet]);
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.climate_actions[0]["system"], "erv");
+        assert_eq!(history.climate_actions[0]["action"], "quiet");
+        assert_eq!(
+            history.climate_actions[0]["reason"],
+            "present_co2_critical_2100ppm"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_cached_status_is_smoked_before_safety_off_decision() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            1_000.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state machine lock poisoned");
+            machine.set_manual_presence(true, 1_001.0);
+            machine.update_door(true, 1_002.0);
+        }
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(700));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(
+            ErvFanSpeed::Medium,
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy applies");
+
+        assert_eq!(writer.writes(), vec![ErvFanSpeed::Off]);
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.climate_actions[0]["system"], "erv");
+        assert_eq!(history.climate_actions[0]["action"], "off");
+        assert_eq!(history.climate_actions[0]["reason"], "safety_interlock");
+    }
+
+    #[tokio::test]
+    async fn locked_transition_update_applies_settle_before_policy_decision() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Off))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine.clone(),
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        let transition = coordinator
+            .update_state_and_maybe_evaluate(|| {
+                let transition = state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .set_manual_presence(false, now);
+                Ok((transition, transition, now, transition.is_some(), true))
+            })
+            .await
+            .expect("state update evaluates");
+
+        assert!(transition.is_some());
+        assert!(writer.writes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_sensor_policy_evaluations_issue_one_write() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path);
+        let writer = Arc::new(
+            FakeErvWriter::new(vec![
+                Ok(erv_status(ErvFanSpeed::Off)),
+                Ok(erv_status(ErvFanSpeed::Off)),
+            ])
+            .with_set_delay(Duration::from_millis(25)),
+        );
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy.clone(),
+            writer.clone(),
+            status_broadcast,
+        );
+
+        let (first, second) = tokio::join!(
+            coordinator.evaluate_erv_policy(false),
+            coordinator.evaluate_erv_policy(false)
+        );
+
+        first.expect("first policy applies");
+        second.expect("second policy applies");
+        assert_eq!(writer.writes(), vec![ErvFanSpeed::Quiet]);
+        assert_eq!(
+            policy
+                .read()
+                .expect("policy lock poisoned")
+                .air_quality_sample_counts(),
+            (1, 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_policy_evaluation_records_same_qingping_sample_once() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(700));
+        let erv = ErvState::new(database_path);
+        let writer = Arc::new(FakeErvWriter::new(Vec::new()));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy.clone(),
+            writer,
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("first policy applies");
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("second policy applies");
+
+        assert_eq!(
+            policy
+                .read()
+                .expect("policy lock poisoned")
+                .air_quality_sample_counts(),
+            (1, 1)
+        );
+    }
+}

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -170,7 +170,29 @@ impl ErvPolicyCoordinator {
             );
     }
 
-    pub async fn apply_erv_speed(
+    pub async fn apply_manual_erv_speed(
+        &self,
+        speed: ErvFanSpeed,
+        co2_ppm: Option<i64>,
+    ) -> Result<ErvDeviceStatus> {
+        let _apply_guard = self.apply_lock.lock().await;
+        let previous_override = self
+            .erv
+            .replace_manual_override(speed, unix_timestamp_now());
+
+        match self
+            .apply_erv_speed(speed, "manual_override", co2_ppm)
+            .await
+        {
+            Ok(status) => Ok(status),
+            Err(error) => {
+                self.erv.restore_manual_override(previous_override);
+                Err(error)
+            }
+        }
+    }
+
+    async fn apply_erv_speed(
         &self,
         speed: ErvFanSpeed,
         reason: &str,
@@ -655,6 +677,64 @@ mod tests {
                 .air_quality_sample_counts(),
             (1, 1)
         );
+    }
+
+    #[tokio::test]
+    async fn manual_erv_write_serializes_with_policy_evaluation() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let mut config = test_config(database_path.clone());
+        config.thresholds.erv_min_dwell_seconds = 0;
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(450));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(
+            FakeErvWriter::new(vec![
+                Ok(erv_status(ErvFanSpeed::Medium)),
+                Ok(erv_status(ErvFanSpeed::Medium)),
+            ])
+            .with_set_delay(Duration::from_millis(25)),
+        );
+        erv.smoke_status_with(&config.erv, writer.as_ref())
+            .await
+            .expect("initial ERV status");
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv.clone(),
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        let (manual, policy_eval) = tokio::join!(
+            coordinator.apply_manual_erv_speed(ErvFanSpeed::Turbo, Some(450)),
+            coordinator.evaluate_erv_policy(true)
+        );
+
+        manual.expect("manual write succeeds");
+        policy_eval.expect("policy evaluation succeeds");
+        assert_eq!(writer.writes(), vec![ErvFanSpeed::Turbo]);
+        assert_eq!(
+            erv.active_manual_override_speed(unix_timestamp_now()),
+            Some(ErvFanSpeed::Turbo)
+        );
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.climate_actions.len(), 1);
+        assert_eq!(history.climate_actions[0]["action"], "turbo");
+        assert_eq!(history.climate_actions[0]["reason"], "manual_override");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -122,9 +122,11 @@ pub struct ErvConfig {
     pub ip: String,
     pub device_id: String,
     pub local_key: String,
+    pub active_control_enabled: bool,
     pub version: String,
     pub port: u16,
     pub status_timeout_seconds: u64,
+    pub verify_delay_seconds: u64,
     pub poll_interval_seconds: u64,
 }
 
@@ -144,9 +146,11 @@ impl Default for ErvConfig {
             ip: String::new(),
             device_id: String::new(),
             local_key: String::new(),
+            active_control_enabled: false,
             version: "3.4".to_string(),
             port: 6668,
             status_timeout_seconds: 5,
+            verify_delay_seconds: 1,
             poll_interval_seconds: 60,
         }
     }
@@ -326,6 +330,11 @@ impl AppConfig {
             file_config.erv.local_key = local_key;
         }
 
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED") {
+            file_config.erv.active_control_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED", &enabled)?;
+        }
+
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
             root,
@@ -348,6 +357,14 @@ impl AppConfig {
             thresholds: file_config.thresholds,
             runtime,
         })
+    }
+}
+
+fn parse_bool_env(name: &str, value: &str) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => anyhow::bail!("invalid {name} value {value:?}; expected true/false"),
     }
 }
 
@@ -397,6 +414,7 @@ thresholds:
             "OFFICE_AUTOMATE_ERV_IP" => Some("192.0.2.11".to_string()),
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
+            "OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             _ => None,
         })
@@ -417,6 +435,7 @@ thresholds:
         assert_eq!(config.erv.ip, "192.0.2.11");
         assert_eq!(config.erv.device_id, "env-erv-device");
         assert_eq!(config.erv.local_key, "env-erv-key");
+        assert!(config.erv.active_control_enabled);
         assert_eq!(config.erv.version, "3.4");
         assert_eq!(config.erv.port, 6668);
         assert!(config.erv.is_configured());

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -315,6 +315,36 @@ pub fn log_device_event(
     Ok(())
 }
 
+pub fn log_climate_action(
+    database_path: &Path,
+    system: &str,
+    action: &str,
+    setpoint: Option<f64>,
+    co2_ppm: Option<i64>,
+    reason: Option<&str>,
+) -> Result<()> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+    connection
+        .execute(
+            r#"
+            INSERT INTO climate_actions (timestamp, system, action, setpoint, co2_ppm, reason)
+            VALUES (?, ?, ?, ?, ?, ?)
+            "#,
+            params![timestamp, system, action, setpoint, co2_ppm, reason],
+        )
+        .with_context(|| format!("failed to log {system} climate action"))?;
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct HistoryRows {
     pub sensor_readings: Vec<Value>,

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -340,14 +340,32 @@ impl ErvState {
     }
 
     pub fn set_manual_override(&self, speed: ErvFanSpeed, now: f64) {
+        self.replace_manual_override(speed, now);
+    }
+
+    pub(crate) fn replace_manual_override(
+        &self,
+        speed: ErvFanSpeed,
+        now: f64,
+    ) -> Option<(ErvFanSpeed, f64)> {
         let manual_override = ErvManualOverride {
             speed,
             expires_at: now + ERV_MANUAL_OVERRIDE_SECONDS as f64,
         };
+        let mut inner = self.inner.write().expect("ERV state lock poisoned");
+        let previous = inner
+            .manual_override
+            .map(|manual_override| (manual_override.speed, manual_override.expires_at));
+        inner.manual_override = Some(manual_override);
+        previous
+    }
+
+    pub(crate) fn restore_manual_override(&self, previous: Option<(ErvFanSpeed, f64)>) {
+        let restored = previous.map(|(speed, expires_at)| ErvManualOverride { speed, expires_at });
         self.inner
             .write()
             .expect("ERV state lock poisoned")
-            .manual_override = Some(manual_override);
+            .manual_override = restored;
     }
 
     pub fn active_manual_override_speed(&self, now: f64) -> Option<ErvFanSpeed> {

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -22,6 +22,7 @@ const DP_POWER: &str = "1";
 const DP_SUPPLY_SPEED: &str = "101";
 const DP_EXHAUST_SPEED: &str = "102";
 const LOCAL_KEY_ERROR_THRESHOLD: u64 = 5;
+pub const ERV_MANUAL_OVERRIDE_SECONDS: i64 = 30 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErvFanSpeed {
@@ -40,6 +41,25 @@ impl ErvFanSpeed {
             Self::Turbo => "turbo",
         }
     }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "off" => Some(Self::Off),
+            "quiet" => Some(Self::Quiet),
+            "medium" => Some(Self::Medium),
+            "turbo" => Some(Self::Turbo),
+            _ => None,
+        }
+    }
+
+    fn speed_preset(self) -> Option<(i64, i64)> {
+        match self {
+            Self::Off => None,
+            Self::Quiet => Some((1, 1)),
+            Self::Medium => Some((3, 2)),
+            Self::Turbo => Some((8, 8)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -51,10 +71,20 @@ pub struct ErvDeviceStatus {
     pub raw_dps: Value,
 }
 
-type BoxFutureResult<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+pub type BoxFutureResult<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
 
 pub trait ErvStatusReader: Send + Sync {
     fn read_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus>;
+}
+
+pub trait ErvSpeedWriter: Send + Sync {
+    fn smoke_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus>;
+
+    fn set_speed<'a>(
+        &'a self,
+        config: &'a ErvConfig,
+        speed: ErvFanSpeed,
+    ) -> BoxFutureResult<'a, ErvDeviceStatus>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -67,19 +97,7 @@ impl ErvStatusReader for RustuyaErvStatusReader {
                 bail!("ERV local Tuya config is incomplete");
             }
 
-            let version = rustuya::Version::from_str(&config.version)
-                .map_err(|error| anyhow!("invalid ERV Tuya protocol version: {error}"))?;
-            let device = rustuya::Device::builder(
-                config.device_id.clone(),
-                config.local_key.as_bytes().to_vec(),
-            )
-            .address(config.ip.clone())
-            .version(version)
-            .port(config.port)
-            .persist(false)
-            .timeout(Duration::from_secs(config.status_timeout_seconds.max(1)))
-            .build();
-
+            let device = build_rustuya_device(config)?;
             let result = device.status().await;
             device.close().await;
             let payload = result
@@ -88,6 +106,47 @@ impl ErvStatusReader for RustuyaErvStatusReader {
             parse_erv_status_payload(&payload)
         })
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RustuyaErvSpeedWriter;
+
+impl ErvSpeedWriter for RustuyaErvSpeedWriter {
+    fn smoke_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        RustuyaErvStatusReader.read_status(config)
+    }
+
+    fn set_speed<'a>(
+        &'a self,
+        config: &'a ErvConfig,
+        speed: ErvFanSpeed,
+    ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            if !config.is_configured() {
+                bail!("ERV local Tuya config is incomplete");
+            }
+
+            let device = build_rustuya_device(config)?;
+            let result = set_rustuya_speed(&device, config, speed).await;
+            device.close().await;
+            result
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ErvRuntimeSnapshot {
+    pub status_known: bool,
+    pub running: bool,
+    pub speed: ErvFanSpeed,
+    pub last_speed_changed_at: Option<f64>,
+    pub local_key_invalid: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ErvManualOverride {
+    speed: ErvFanSpeed,
+    expires_at: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +161,8 @@ struct ErvInner {
     latest_status: Option<ErvDeviceStatus>,
     control: ErvControlStatus,
     notification: Option<AppNotification>,
+    last_speed_changed_at: Option<f64>,
+    manual_override: Option<ErvManualOverride>,
 }
 
 impl ErvState {
@@ -141,21 +202,243 @@ impl ErvState {
         }
     }
 
-    pub fn overlay_status(&self, status: &mut Status) {
-        let inner = self.inner.read().expect("ERV state lock poisoned");
-        status.erv.control = inner.control.clone();
-
-        if let Some(device_status) = &inner.latest_status {
-            status.erv.running = device_status.power;
-            status.erv.speed = device_status
-                .fan_speed
-                .map(ErvFanSpeed::as_str)
-                .unwrap_or("unknown")
-                .to_string();
+    pub async fn set_speed_with<W>(
+        &self,
+        config: &ErvConfig,
+        writer: &W,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) -> Result<ErvDeviceStatus>
+    where
+        W: ErvSpeedWriter + ?Sized,
+    {
+        if !config.active_control_enabled {
+            bail!("ERV active control is disabled");
+        }
+        if !config.is_configured() {
+            bail!("ERV local Tuya config is incomplete");
+        }
+        if self.snapshot().local_key_invalid {
+            bail!("ERV local Tuya key is invalid");
         }
 
-        if let Some(notification) = &inner.notification {
-            status.notifications.push(notification.clone());
+        let smoked_status = self
+            .smoke_status_with(config, writer)
+            .await
+            .context("ERV smoke check failed before active write")?;
+
+        if device_status_matches_speed(&smoked_status, speed) {
+            return Ok(smoked_status);
+        }
+
+        self.write_speed_after_gate(config, writer, speed, reason, co2_ppm)
+            .await
+    }
+
+    pub(crate) async fn set_speed_after_smoke_with<W>(
+        &self,
+        config: &ErvConfig,
+        writer: &W,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) -> Result<ErvDeviceStatus>
+    where
+        W: ErvSpeedWriter + ?Sized,
+    {
+        if !config.active_control_enabled {
+            bail!("ERV active control is disabled");
+        }
+        if !config.is_configured() {
+            bail!("ERV local Tuya config is incomplete");
+        }
+        if self.snapshot().local_key_invalid {
+            bail!("ERV local Tuya key is invalid");
+        }
+
+        self.write_speed_after_gate(config, writer, speed, reason, co2_ppm)
+            .await
+    }
+
+    async fn write_speed_after_gate<W>(
+        &self,
+        config: &ErvConfig,
+        writer: &W,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) -> Result<ErvDeviceStatus>
+    where
+        W: ErvSpeedWriter + ?Sized,
+    {
+        match writer.set_speed(config, speed).await {
+            Ok(status) => {
+                self.record_speed_success(status.clone(), speed, reason, co2_ppm);
+                Ok(status)
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                self.record_local_failure(&message);
+                Err(error)
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> ErvRuntimeSnapshot {
+        let inner = self.inner.read().expect("ERV state lock poisoned");
+        let status_known = inner.latest_status.is_some();
+        let running = inner
+            .latest_status
+            .as_ref()
+            .is_some_and(|status| status.power);
+        let speed = inner
+            .latest_status
+            .as_ref()
+            .and_then(|status| status.fan_speed)
+            .unwrap_or(ErvFanSpeed::Off);
+
+        ErvRuntimeSnapshot {
+            status_known,
+            running,
+            speed,
+            last_speed_changed_at: inner.last_speed_changed_at,
+            local_key_invalid: inner.control.local_key_invalid,
+        }
+    }
+
+    pub async fn smoke_status_with<W>(
+        &self,
+        config: &ErvConfig,
+        writer: &W,
+    ) -> Result<ErvDeviceStatus>
+    where
+        W: ErvSpeedWriter + ?Sized,
+    {
+        if !config.is_configured() {
+            bail!("ERV local Tuya config is incomplete");
+        }
+        if self.snapshot().local_key_invalid {
+            bail!("ERV local Tuya key is invalid");
+        }
+
+        match writer.smoke_status(config).await {
+            Ok(status) => {
+                if self.record_local_success(status.clone()) {
+                    self.notify_status();
+                }
+                Ok(status)
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                if self.record_local_failure(&message) {
+                    self.notify_status();
+                }
+                Err(error)
+            }
+        }
+    }
+
+    pub fn set_manual_override(&self, speed: ErvFanSpeed, now: f64) {
+        let manual_override = ErvManualOverride {
+            speed,
+            expires_at: now + ERV_MANUAL_OVERRIDE_SECONDS as f64,
+        };
+        self.inner
+            .write()
+            .expect("ERV state lock poisoned")
+            .manual_override = Some(manual_override);
+    }
+
+    pub fn active_manual_override_speed(&self, now: f64) -> Option<ErvFanSpeed> {
+        let (manual_override, expired) = {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            match inner.manual_override {
+                Some(manual_override) if manual_override.expires_at > now => {
+                    (Some(manual_override), false)
+                }
+                Some(_) => {
+                    inner.manual_override = None;
+                    (None, true)
+                }
+                None => (None, false),
+            }
+        };
+
+        if expired {
+            self.notify_status();
+        }
+
+        manual_override.map(|manual_override| manual_override.speed)
+    }
+
+    pub fn overlay_status(&self, status: &mut Status) {
+        let now = unix_timestamp_now();
+        let (manual_override, expired) = {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            let (manual_override, expired) = match inner.manual_override {
+                Some(manual_override) if manual_override.expires_at > now => {
+                    (Some(manual_override), false)
+                }
+                Some(_) => {
+                    inner.manual_override = None;
+                    (None, true)
+                }
+                None => (None, false),
+            };
+
+            status.erv.control = inner.control.clone();
+
+            if let Some(device_status) = &inner.latest_status {
+                status.erv.running = device_status.power;
+                status.erv.speed = device_status
+                    .fan_speed
+                    .map(ErvFanSpeed::as_str)
+                    .unwrap_or("unknown")
+                    .to_string();
+            }
+
+            if let Some(notification) = &inner.notification {
+                status.notifications.push(notification.clone());
+            }
+
+            (manual_override, expired)
+        };
+
+        if let Some(manual_override) = manual_override {
+            status.manual_override.erv = true;
+            status.manual_override.erv_speed = Some(manual_override.speed.as_str().to_string());
+            status.manual_override.erv_expires_in =
+                Some((manual_override.expires_at - now).ceil().max(0.0) as i64);
+        }
+
+        if expired {
+            self.notify_status();
+        }
+    }
+
+    fn record_speed_success(
+        &self,
+        device_status: ErvDeviceStatus,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) {
+        self.record_local_success(device_status);
+        self.inner
+            .write()
+            .expect("ERV state lock poisoned")
+            .last_speed_changed_at = Some(unix_timestamp_now());
+
+        if let Err(error) = db::log_climate_action(
+            &self.database_path,
+            "erv",
+            speed.as_str(),
+            None,
+            co2_ppm,
+            Some(reason),
+        ) {
+            tracing::warn!("failed to log ERV climate action: {error:#}");
         }
     }
 
@@ -283,6 +566,95 @@ pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {
     reader.read_status(&config.erv).await
 }
 
+fn build_rustuya_device(config: &ErvConfig) -> Result<rustuya::Device> {
+    let version = rustuya::Version::from_str(&config.version)
+        .map_err(|error| anyhow!("invalid ERV Tuya protocol version: {error}"))?;
+    Ok(rustuya::Device::builder(
+        config.device_id.clone(),
+        config.local_key.as_bytes().to_vec(),
+    )
+    .address(config.ip.clone())
+    .version(version)
+    .port(config.port)
+    .persist(false)
+    .timeout(Duration::from_secs(config.status_timeout_seconds.max(1)))
+    .build())
+}
+
+async fn set_rustuya_speed(
+    device: &rustuya::Device,
+    config: &ErvConfig,
+    speed: ErvFanSpeed,
+) -> Result<ErvDeviceStatus> {
+    if speed == ErvFanSpeed::Off {
+        let result = device
+            .set_value(DP_POWER, false)
+            .await
+            .context("failed to set ERV power off")?;
+        ensure_tuya_command_ok("Local set power off failed", result.as_deref())?;
+    } else {
+        let (supply, exhaust) = speed.speed_preset().expect("non-off speed has preset");
+        let result = device
+            .set_value(DP_POWER, true)
+            .await
+            .context("failed to set ERV power on")?;
+        ensure_tuya_command_ok("Local set power on failed", result.as_deref())?;
+        let result = device
+            .set_value(DP_SUPPLY_SPEED, supply)
+            .await
+            .context("failed to set ERV supply speed")?;
+        ensure_tuya_command_ok("Local set supply speed failed", result.as_deref())?;
+        let result = device
+            .set_value(DP_EXHAUST_SPEED, exhaust)
+            .await
+            .context("failed to set ERV exhaust speed")?;
+        ensure_tuya_command_ok("Local set exhaust speed failed", result.as_deref())?;
+    }
+
+    time::sleep(Duration::from_secs(config.verify_delay_seconds)).await;
+    let payload = device
+        .status()
+        .await
+        .context("failed to verify ERV local Tuya status")?
+        .ok_or_else(|| anyhow!("ERV local Tuya verification returned no payload"))?;
+    let status = parse_erv_status_payload(&payload)?;
+    verify_speed(speed, &status)?;
+    Ok(status)
+}
+
+fn ensure_tuya_command_ok(context: &str, payload: Option<&str>) -> Result<()> {
+    if payload.is_some_and(is_local_key_error) || payload.is_some_and(looks_like_tuya_error) {
+        bail!("{context}: {}", payload.expect("payload checked"));
+    }
+    Ok(())
+}
+
+fn verify_speed(expected: ErvFanSpeed, actual: &ErvDeviceStatus) -> Result<()> {
+    if expected == ErvFanSpeed::Off {
+        if actual.power {
+            bail!("ERV verification failed: expected power OFF, got ON");
+        }
+        return Ok(());
+    }
+
+    if !actual.power {
+        bail!("ERV verification failed: expected power ON, got OFF");
+    }
+    let (expected_supply, expected_exhaust) =
+        expected.speed_preset().expect("non-off speed has preset");
+    if actual.supply_speed != Some(expected_supply)
+        || actual.exhaust_speed != Some(expected_exhaust)
+    {
+        bail!(
+            "ERV verification failed: expected SA={expected_supply}/EA={expected_exhaust}, got SA={:?}/EA={:?}",
+            actual.supply_speed,
+            actual.exhaust_speed
+        );
+    }
+
+    Ok(())
+}
+
 pub fn parse_erv_status_payload(payload: &str) -> Result<ErvDeviceStatus> {
     let value: Value = serde_json::from_str(payload).context("ERV status payload is not JSON")?;
     parse_erv_status_value(&value)
@@ -338,6 +710,13 @@ fn fan_speed(
     }
 }
 
+fn device_status_matches_speed(status: &ErvDeviceStatus, speed: ErvFanSpeed) -> bool {
+    match speed {
+        ErvFanSpeed::Off => !status.power,
+        _ => status.power && status.fan_speed == Some(speed),
+    }
+}
+
 fn value_as_bool(value: &Value) -> Option<bool> {
     value.as_bool().or_else(|| {
         value
@@ -359,6 +738,10 @@ fn value_as_i64(value: &Value) -> Option<i64> {
 fn is_local_key_error(message: &str) -> bool {
     message.contains("Check device key or version")
         || (message.contains("914") && message.to_ascii_lowercase().contains("err"))
+}
+
+fn looks_like_tuya_error(message: &str) -> bool {
+    message.contains("\"Error\"") || message.contains("\"Err\"") || message.contains("Error:")
 }
 
 fn invalid_key_notification(created_at: &str) -> AppNotification {
@@ -396,9 +779,19 @@ fn local_iso_now() -> String {
         .to_string()
 }
 
+fn unix_timestamp_now() -> f64 {
+    Local::now().timestamp_millis() as f64 / 1_000.0
+}
+
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, sync::Mutex};
+    use std::{
+        collections::VecDeque,
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use super::*;
     use crate::{
@@ -437,12 +830,86 @@ mod tests {
         }
     }
 
+    struct FakeErvWriter {
+        smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        write_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        smoke_calls: AtomicUsize,
+        write_speeds: Mutex<Vec<ErvFanSpeed>>,
+    }
+
+    impl FakeErvWriter {
+        fn new(
+            smoke_results: Vec<Result<ErvDeviceStatus>>,
+            write_results: Vec<Result<ErvDeviceStatus>>,
+        ) -> Self {
+            Self {
+                smoke_results: Mutex::new(smoke_results.into()),
+                write_results: Mutex::new(write_results.into()),
+                smoke_calls: AtomicUsize::new(0),
+                write_speeds: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn smoke_calls(&self) -> usize {
+            self.smoke_calls.load(Ordering::SeqCst)
+        }
+
+        fn write_speeds(&self) -> Vec<ErvFanSpeed> {
+            self.write_speeds
+                .lock()
+                .expect("fake writer speeds lock")
+                .clone()
+        }
+    }
+
+    impl ErvSpeedWriter for FakeErvWriter {
+        fn smoke_status<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.smoke_calls.fetch_add(1, Ordering::SeqCst);
+            let result = self
+                .smoke_results
+                .lock()
+                .expect("fake writer smoke lock")
+                .pop_front()
+                .unwrap_or_else(|| bail!("no fake ERV smoke result configured"));
+            Box::pin(async move { result })
+        }
+
+        fn set_speed<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+            speed: ErvFanSpeed,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.write_speeds
+                .lock()
+                .expect("fake writer speeds lock")
+                .push(speed);
+            let result = self
+                .write_results
+                .lock()
+                .expect("fake writer write lock")
+                .pop_front()
+                .unwrap_or_else(|| bail!("no fake ERV write result configured"));
+            Box::pin(async move { result })
+        }
+    }
+
     fn test_config() -> ErvConfig {
         ErvConfig {
             ip: "192.0.2.10".to_string(),
             device_id: "device-id".to_string(),
             local_key: "local-key".to_string(),
             ..ErvConfig::default()
+        }
+    }
+
+    fn active_config() -> ErvConfig {
+        ErvConfig {
+            active_control_enabled: true,
+            verify_delay_seconds: 0,
+            ..test_config()
         }
     }
 
@@ -471,6 +938,10 @@ mod tests {
 
     fn medium_status() -> ErvDeviceStatus {
         parse_erv_status_payload(r#"{"dps":{"1":true,"101":3,"102":2}}"#).expect("status")
+    }
+
+    fn turbo_status() -> ErvDeviceStatus {
+        parse_erv_status_payload(r#"{"dps":{"1":true,"101":8,"102":8}}"#).expect("status")
     }
 
     #[test]
@@ -602,5 +1073,144 @@ mod tests {
             status.notifications[0].notification_type,
             "erv_local_key_recovered"
         );
+    }
+
+    #[tokio::test]
+    async fn active_control_disabled_skips_smoke_and_write() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let writer = FakeErvWriter::new(vec![Ok(medium_status())], vec![Ok(turbo_status())]);
+
+        let error = state
+            .set_speed_with(
+                &test_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                "manual_override",
+                Some(2100),
+            )
+            .await
+            .expect_err("disabled write should fail");
+
+        assert!(error.to_string().contains("active control is disabled"));
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_speeds().is_empty());
+    }
+
+    #[tokio::test]
+    async fn active_write_smokes_before_write_and_logs_action() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path.clone());
+        let writer = FakeErvWriter::new(vec![Ok(medium_status())], vec![Ok(turbo_status())]);
+
+        let status = state
+            .set_speed_with(
+                &active_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                "away_refresh_CO2=2100ppm",
+                Some(2100),
+            )
+            .await
+            .expect("write succeeds");
+
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
+
+        let snapshot = state.snapshot();
+        assert!(snapshot.running);
+        assert_eq!(snapshot.speed, ErvFanSpeed::Turbo);
+        assert!(snapshot.last_speed_changed_at.is_some());
+
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.climate_actions[0]["system"], "erv");
+        assert_eq!(history.climate_actions[0]["action"], "turbo");
+        assert_eq!(
+            history.climate_actions[0]["reason"],
+            "away_refresh_CO2=2100ppm"
+        );
+        assert_eq!(history.climate_actions[0]["co2_ppm"], 2100);
+    }
+
+    #[tokio::test]
+    async fn active_write_skips_noop_after_smoke_status_matches_target() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path.clone());
+        let writer = FakeErvWriter::new(vec![Ok(turbo_status())], vec![Ok(turbo_status())]);
+
+        let status = state
+            .set_speed_with(
+                &active_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                "away_refresh_CO2=2100ppm",
+                Some(2100),
+            )
+            .await
+            .expect("smoke succeeds");
+
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+        assert_eq!(writer.smoke_calls(), 1);
+        assert!(writer.write_speeds().is_empty());
+        assert!(state.snapshot().last_speed_changed_at.is_none());
+
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert!(history.climate_actions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn smoke_local_key_failures_close_active_write_gate() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let writer = FakeErvWriter::new(
+            (0..LOCAL_KEY_ERROR_THRESHOLD)
+                .map(|_| bail!("Check device key or version (Error 914)"))
+                .collect(),
+            vec![Ok(turbo_status())],
+        );
+
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            assert!(
+                state
+                    .set_speed_with(
+                        &active_config(),
+                        &writer,
+                        ErvFanSpeed::Turbo,
+                        "manual_override",
+                        None,
+                    )
+                    .await
+                    .is_err()
+            );
+        }
+
+        let mut status = Status::read_only_default(&app_config(active_config()));
+        state.overlay_status(&mut status);
+        assert!(status.erv.control.local_key_invalid);
+        assert_eq!(writer.smoke_calls(), LOCAL_KEY_ERROR_THRESHOLD as usize);
+        assert!(writer.write_speeds().is_empty());
+
+        let error = state
+            .set_speed_with(
+                &active_config(),
+                &writer,
+                ErvFanSpeed::Quiet,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("invalid local key should fail before smoke");
+        assert!(error.to_string().contains("local Tuya key is invalid"));
+        assert_eq!(writer.smoke_calls(), LOCAL_KEY_ERROR_THRESHOLD as usize);
+        assert!(writer.write_speeds().is_empty());
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -695,18 +695,12 @@ async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> 
             .into_response();
     };
 
-    let now = unix_timestamp_now();
     match state
         .erv_automation
-        .apply_erv_speed(
-            speed,
-            "manual_override",
-            state.erv_automation.latest_co2_ppm(),
-        )
+        .apply_manual_erv_speed(speed, state.erv_automation.latest_co2_ppm())
         .await
     {
         Ok(status) => {
-            state.erv.set_manual_override(speed, now);
             broadcast_status(&state);
             Json(json!({
                 "ok": true,

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -33,10 +33,14 @@ use crate::{
     artifacts::ARTIFACT_MAX_SIZE_BYTES,
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
+    automation::ErvPolicyCoordinator,
     config::AppConfig,
     db,
-    erv::ErvState,
+    erv::{
+        ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
+    },
     mqtt,
+    policy::ErvPolicyState,
     qingping::QingpingState,
     state::{StateMachine, StateTransition},
     status::{Status, TemperatureBands},
@@ -56,6 +60,7 @@ struct AppState {
     status_broadcast: broadcast::Sender<()>,
     qingping: QingpingState,
     erv: ErvState,
+    erv_automation: ErvPolicyCoordinator,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -83,6 +88,43 @@ fn try_app_with_state(
     yolink: YoLinkState,
     erv_state: ErvState,
 ) -> Result<Router> {
+    try_app_with_erv_writer(
+        config,
+        qingping,
+        state_machine,
+        yolink,
+        erv_state,
+        Arc::new(RustuyaErvSpeedWriter),
+    )
+}
+
+fn try_app_with_erv_writer(
+    config: AppConfig,
+    qingping: QingpingState,
+    state_machine: Arc<RwLock<StateMachine>>,
+    yolink: YoLinkState,
+    erv_state: ErvState,
+    erv_writer: Arc<dyn ErvSpeedWriter>,
+) -> Result<Router> {
+    try_app_with_erv_writer_and_coordinator(
+        config,
+        qingping,
+        state_machine,
+        yolink,
+        erv_state,
+        erv_writer,
+    )
+    .map(|(router, _)| router)
+}
+
+fn try_app_with_erv_writer_and_coordinator(
+    config: AppConfig,
+    qingping: QingpingState,
+    state_machine: Arc<RwLock<StateMachine>>,
+    yolink: YoLinkState,
+    erv_state: ErvState,
+    erv_writer: Arc<dyn ErvSpeedWriter>,
+) -> Result<(Router, ErvPolicyCoordinator)> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
@@ -95,6 +137,16 @@ fn try_app_with_state(
     yolink.set_status_broadcast(status_broadcast.clone());
     erv_state.set_status_broadcast(status_broadcast.clone());
     yolink.restore_from_database(unix_timestamp_now())?;
+    let erv_policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+    let erv_automation = ErvPolicyCoordinator::new(
+        config.clone(),
+        state_machine.clone(),
+        qingping.clone(),
+        erv_state.clone(),
+        erv_policy,
+        erv_writer,
+        status_broadcast.clone(),
+    );
     let state = AppState {
         config,
         auth,
@@ -105,6 +157,7 @@ fn try_app_with_state(
         status_broadcast,
         qingping,
         erv: erv_state,
+        erv_automation: erv_automation.clone(),
     };
 
     let cors = CorsLayer::new()
@@ -115,7 +168,7 @@ fn try_app_with_state(
     let frontend_dist = state.config.runtime.frontend_dist.clone();
     let assets_dir = frontend_dist.join("assets");
 
-    Ok(Router::new()
+    let router = Router::new()
         .route("/status", get(status))
         .route("/ws", get(websocket))
         .route("/occupancy", post(occupancy))
@@ -160,7 +213,9 @@ fn try_app_with_state(
         ))
         .with_state(state)
         .layer(cors)
-        .layer(TraceLayer::new_for_http()))
+        .layer(TraceLayer::new_for_http());
+
+    Ok((router, erv_automation))
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
@@ -175,17 +230,34 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
-    let app = try_app_with_state(
+    let (app, erv_automation) = try_app_with_erv_writer_and_coordinator(
         config.clone(),
         qingping.clone(),
         state_machine,
         yolink.clone(),
         erv_state.clone(),
+        Arc::new(RustuyaErvSpeedWriter),
     )
     .context("failed to build HTTP app")?;
+    let runtime_handle = tokio::runtime::Handle::current();
+    let qingping_policy_trigger: mqtt::SensorIngressHook = Arc::new({
+        let erv_automation = erv_automation.clone();
+        move || {
+            let erv_automation = erv_automation.clone();
+            runtime_handle.spawn(async move {
+                if let Err(error) = erv_automation.evaluate_erv_policy(false).await {
+                    tracing::warn!(
+                        "ERV automated policy apply failed after Qingping update: {error:#}"
+                    );
+                }
+                erv_automation.broadcast_status();
+            });
+        }
+    });
     let _mqtt_runtime =
-        mqtt::start_qingping_ingress(&config, qingping).context("failed to start MQTT ingress")?;
-    let _yolink_task = yolink::start_yolink_client(&config, yolink);
+        mqtt::start_qingping_ingress(&config, qingping, Some(qingping_policy_trigger))
+            .context("failed to start MQTT ingress")?;
+    let _yolink_task = yolink::start_yolink_client(&config, yolink, Some(erv_automation.clone()));
     let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
 
     tracing::info!("office-automate-server listening on {}", bind_address);
@@ -449,29 +521,58 @@ async fn occupancy(
     Json(payload): Json<OccupancyRequest>,
 ) -> Response {
     let now = unix_timestamp_now();
-    let (transition, state_name, erv_should_run) = {
-        let mut machine = state
-            .state_machine
-            .write()
-            .expect("state machine lock poisoned");
-        let transition = machine.update_mac_occupancy(
-            payload.last_active_timestamp,
-            payload.external_monitor,
-            now,
-        );
-        let status = machine.status_at(now);
-        (transition, status.state, status.erv_should_run)
+    let policy_result = state
+        .erv_automation
+        .update_state_and_maybe_evaluate(|| {
+            let (transition, state_name, erv_should_run) = {
+                let mut machine = state
+                    .state_machine
+                    .write()
+                    .expect("state machine lock poisoned");
+                let transition = machine.update_mac_occupancy(
+                    payload.last_active_timestamp,
+                    payload.external_monitor,
+                    now,
+                );
+                let status = machine.status_at(now);
+                (transition, status.state, status.erv_should_run)
+            };
+            log_state_transition(&state, transition, "mac_activity")
+                .context("failed to persist occupancy update")?;
+            Ok((
+                (state_name, erv_should_run),
+                transition,
+                now,
+                transition.is_some(),
+                true,
+            ))
+        })
+        .await;
+
+    let (state_name, erv_should_run) = match policy_result {
+        Ok(result) => result,
+        Err(error)
+            if error
+                .to_string()
+                .contains("failed to persist occupancy update") =>
+        {
+            tracing::error!("failed to log occupancy transition: {error:#}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"ok": false, "error": "Failed to persist occupancy update"})),
+            )
+                .into_response();
+        }
+        Err(error) => {
+            tracing::warn!("ERV automated policy apply failed after occupancy update: {error:#}");
+            let status = state
+                .state_machine
+                .read()
+                .expect("state machine lock poisoned")
+                .status_at(now);
+            (status.state, status.erv_should_run)
+        }
     };
-
-    if let Err(error) = log_state_transition(&state, transition, "mac_activity") {
-        tracing::error!("failed to log occupancy transition: {error:#}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"ok": false, "error": "Failed to persist occupancy update"})),
-        )
-            .into_response();
-    }
-
     broadcast_status(&state);
     Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run})).into_response()
 }
@@ -487,33 +588,63 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
             let requested_state = payload.state.as_str();
             let now = unix_timestamp_now();
             let present = requested_state == "present";
-            let (transition, state_name, is_present) = {
-                let mut machine = state
-                    .state_machine
-                    .write()
-                    .expect("state machine lock poisoned");
-                let transition = machine.set_manual_presence(present, now);
-                let status = machine.status_at(now);
-                (transition, status.state, status.is_present)
+            let policy_result = state
+                .erv_automation
+                .update_state_and_maybe_evaluate(|| {
+                    let (transition, state_name, is_present) = {
+                        let mut machine = state
+                            .state_machine
+                            .write()
+                            .expect("state machine lock poisoned");
+                        let transition = machine.set_manual_presence(present, now);
+                        let status = machine.status_at(now);
+                        (transition, status.state, status.is_present)
+                    };
+                    db::log_device_event(
+                        &state.config.runtime.database_path,
+                        "presence",
+                        &format!("manual_{requested_state}"),
+                        Some("Dashboard"),
+                        None,
+                    )
+                    .and_then(|_| log_state_transition(&state, transition, "manual"))
+                    .context("failed to persist presence update")?;
+                    Ok((
+                        (state_name, is_present),
+                        transition,
+                        now,
+                        transition.is_some(),
+                        true,
+                    ))
+                })
+                .await;
+
+            let (state_name, is_present) = match policy_result {
+                Ok(result) => result,
+                Err(error)
+                    if error
+                        .to_string()
+                        .contains("failed to persist presence update") =>
+                {
+                    tracing::error!("failed to persist manual presence update: {error:#}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"ok": false, "error": "Failed to persist presence update"})),
+                    )
+                        .into_response();
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        "ERV automated policy apply failed after presence update: {error:#}"
+                    );
+                    let status = state
+                        .state_machine
+                        .read()
+                        .expect("state machine lock poisoned")
+                        .status_at(now);
+                    (status.state, status.is_present)
+                }
             };
-
-            if let Err(error) = db::log_device_event(
-                &state.config.runtime.database_path,
-                "presence",
-                &format!("manual_{requested_state}"),
-                Some("Dashboard"),
-                None,
-            )
-            .and_then(|_| log_state_transition(&state, transition, "manual"))
-            {
-                tracing::error!("failed to persist manual presence update: {error:#}");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"ok": false, "error": "Failed to persist presence update"})),
-                )
-                    .into_response();
-            }
-
             broadcast_status(&state);
             Json(json!({"ok": true, "state": state_name, "is_present": is_present})).into_response()
         }
@@ -554,22 +685,46 @@ struct ErvRequest {
     speed: String,
 }
 
-async fn erv(Json(payload): Json<ErvRequest>) -> Response {
-    if !matches!(payload.speed.as_str(), "off" | "quiet" | "medium" | "turbo") {
+async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> Response {
+    let speed = payload.speed.to_ascii_lowercase();
+    let Some(speed) = ErvFanSpeed::parse(&speed) else {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"ok": false, "error": "Invalid ERV speed"})),
         )
             .into_response();
-    }
+    };
 
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(
-            json!({"ok": false, "error": "ERV control is not enabled in Rust compatibility mode"}),
-        ),
-    )
-        .into_response()
+    let now = unix_timestamp_now();
+    match state
+        .erv_automation
+        .apply_erv_speed(
+            speed,
+            "manual_override",
+            state.erv_automation.latest_co2_ppm(),
+        )
+        .await
+    {
+        Ok(status) => {
+            state.erv.set_manual_override(speed, now);
+            broadcast_status(&state);
+            Json(json!({
+                "ok": true,
+                "erv": {
+                    "speed": status.fan_speed.map(ErvFanSpeed::as_str).unwrap_or("unknown"),
+                    "running": status.power,
+                    "manual_override": true,
+                    "expires_in": ERV_MANUAL_OVERRIDE_SECONDS,
+                }
+            }))
+            .into_response()
+        }
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response(),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1285,6 +1440,14 @@ fn is_safe_spa_path(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
     use axum::{
         body::{Body, to_bytes},
         http::Request as HttpRequest,
@@ -1297,10 +1460,79 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::config::{
-        ErvConfig, GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-        ThresholdsConfig, YoLinkConfig,
+    use crate::{
+        config::{
+            ErvConfig, GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+            ThresholdsConfig, YoLinkConfig,
+        },
+        erv::{BoxFutureResult, ErvDeviceStatus, parse_erv_status_payload},
     };
+
+    struct FakeErvWriter {
+        smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        write_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        smoke_calls: AtomicUsize,
+        write_speeds: Mutex<Vec<ErvFanSpeed>>,
+    }
+
+    impl FakeErvWriter {
+        fn new(
+            smoke_results: Vec<Result<ErvDeviceStatus>>,
+            write_results: Vec<Result<ErvDeviceStatus>>,
+        ) -> Self {
+            Self {
+                smoke_results: Mutex::new(smoke_results.into()),
+                write_results: Mutex::new(write_results.into()),
+                smoke_calls: AtomicUsize::new(0),
+                write_speeds: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn smoke_calls(&self) -> usize {
+            self.smoke_calls.load(Ordering::SeqCst)
+        }
+
+        fn write_speeds(&self) -> Vec<ErvFanSpeed> {
+            self.write_speeds
+                .lock()
+                .expect("fake writer speeds lock")
+                .clone()
+        }
+    }
+
+    impl ErvSpeedWriter for FakeErvWriter {
+        fn smoke_status<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.smoke_calls.fetch_add(1, Ordering::SeqCst);
+            let result = self
+                .smoke_results
+                .lock()
+                .expect("fake writer smoke lock")
+                .pop_front()
+                .unwrap_or_else(|| anyhow::bail!("no fake ERV smoke result configured"));
+            Box::pin(async move { result })
+        }
+
+        fn set_speed<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+            speed: ErvFanSpeed,
+        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.write_speeds
+                .lock()
+                .expect("fake writer speeds lock")
+                .push(speed);
+            let result = self
+                .write_results
+                .lock()
+                .expect("fake writer write lock")
+                .pop_front()
+                .unwrap_or_else(|| anyhow::bail!("no fake ERV write result configured"));
+            Box::pin(async move { result })
+        }
+    }
 
     fn test_config() -> AppConfig {
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -1353,6 +1585,67 @@ mod tests {
             },
             ..test_config()
         }
+    }
+
+    fn configured_erv_config(active_control_enabled: bool) -> AppConfig {
+        let mut config = test_config();
+        config.erv = ErvConfig {
+            device_type: "tuya".to_string(),
+            ip: "192.0.2.10".to_string(),
+            device_id: "device-id".to_string(),
+            local_key: "local-key".to_string(),
+            active_control_enabled,
+            verify_delay_seconds: 0,
+            ..ErvConfig::default()
+        };
+        config
+    }
+
+    fn qingping_with_co2(co2_ppm: i64) -> QingpingState {
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(co2_ppm));
+        qingping
+    }
+
+    fn qingping_reading(co2_ppm: i64) -> crate::qingping::QingpingReading {
+        crate::qingping::QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.0),
+            humidity: Some(45.0),
+            co2_ppm: Some(co2_ppm),
+            pm25: Some(2),
+            pm10: Some(3),
+            tvoc: Some(25),
+            noise_db: Some(35),
+            timestamp: "2026-06-05T12:30:00".to_string(),
+            raw_data: "{}".to_string(),
+        }
+    }
+
+    fn app_with_erv_writer(
+        config: AppConfig,
+        qingping: QingpingState,
+        writer: Arc<dyn ErvSpeedWriter>,
+    ) -> Router {
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        try_app_with_erv_writer(config, qingping, state_machine, yolink, erv_state, writer)
+            .expect("app")
+    }
+
+    fn erv_status(speed: ErvFanSpeed) -> ErvDeviceStatus {
+        let payload = match speed {
+            ErvFanSpeed::Off => r#"{"dps":{"1":false,"101":1,"102":1}}"#,
+            ErvFanSpeed::Quiet => r#"{"dps":{"1":true,"101":1,"102":1}}"#,
+            ErvFanSpeed::Medium => r#"{"dps":{"1":true,"101":3,"102":2}}"#,
+            ErvFanSpeed::Turbo => r#"{"dps":{"1":true,"101":8,"102":8}}"#,
+        };
+        parse_erv_status_payload(payload).expect("ERV status")
     }
 
     fn multipart_body(boundary: &str, bytes: &[u8]) -> Vec<u8> {
@@ -1857,6 +2150,347 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn manual_erv_write_requires_active_control_gate() {
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let service = app_with_erv_writer(
+            configured_erv_config(false),
+            QingpingState::default(),
+            writer.clone(),
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/erv")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"speed":"turbo"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            value["error"]
+                .as_str()
+                .expect("error")
+                .contains("active control is disabled")
+        );
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_speeds().is_empty());
+    }
+
+    #[tokio::test]
+    async fn manual_erv_write_smokes_writes_logs_and_broadcasts_status() {
+        let config = configured_erv_config(true);
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let service = app_with_erv_writer(config.clone(), qingping_with_co2(2100), writer.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server_service = service.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                server_service.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
+            .await
+            .expect("connect");
+        timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("initial timeout")
+            .expect("initial message")
+            .expect("initial ok");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/erv")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"speed":"turbo"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["erv"]["speed"], "turbo");
+        assert_eq!(value["erv"]["running"], true);
+        assert_eq!(value["erv"]["manual_override"], true);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
+
+        let update = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("update timeout")
+            .expect("update message")
+            .expect("update ok");
+        assert!(
+            update
+                .into_text()
+                .expect("text")
+                .contains("\"speed\":\"turbo\"")
+        );
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["erv"]["speed"], "turbo");
+        assert_eq!(value["erv"]["running"], true);
+        assert_eq!(value["manual_override"]["erv"], true);
+        assert_eq!(value["manual_override"]["erv_speed"], "turbo");
+        let expires_in = value["manual_override"]["erv_expires_in"]
+            .as_i64()
+            .expect("expires");
+        assert!(expires_in > 0);
+        assert!(expires_in <= ERV_MANUAL_OVERRIDE_SECONDS);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "erv");
+        assert_eq!(value["climate_actions"][0]["action"], "turbo");
+        assert_eq!(value["climate_actions"][0]["reason"], "manual_override");
+        assert_eq!(value["climate_actions"][0]["co2_ppm"], 2100);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn manual_erv_override_prevents_next_policy_update_from_rewriting_speed() {
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let service = app_with_erv_writer(
+            configured_erv_config(true),
+            qingping_with_co2(450),
+            writer.clone(),
+        );
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/erv")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"speed":"turbo"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        let actions = value["climate_actions"].as_array().expect("actions");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0]["action"], "turbo");
+        assert_eq!(actions[0]["reason"], "manual_override");
+    }
+
+    #[tokio::test]
+    async fn automated_erv_policy_respects_disabled_active_control_gate() {
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Quiet))],
+        ));
+        let service = app_with_erv_writer(
+            configured_erv_config(false),
+            qingping_with_co2(2100),
+            writer.clone(),
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_speeds().is_empty());
+    }
+
+    #[tokio::test]
+    async fn automated_erv_policy_uses_gated_writer_after_presence_update() {
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Quiet))],
+        ));
+        let service = app_with_erv_writer(
+            configured_erv_config(true),
+            qingping_with_co2(2100),
+            writer.clone(),
+        );
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Quiet]);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "erv");
+        assert_eq!(value["climate_actions"][0]["action"], "quiet");
+        assert_eq!(
+            value["climate_actions"][0]["reason"],
+            "present_co2_critical_2100ppm"
+        );
+        assert_eq!(value["climate_actions"][0]["co2_ppm"], 2100);
+    }
+
+    #[tokio::test]
+    async fn automated_erv_policy_records_away_transition_before_deciding() {
+        let qingping = qingping_with_co2(400);
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let service = app_with_erv_writer(
+            configured_erv_config(true),
+            qingping.clone(),
+            writer.clone(),
+        );
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 1);
+
+        qingping.apply_reading(qingping_reading(2100));
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"away"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert!(writer.write_speeds().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod artifacts;
 pub mod auth;
+pub mod automation;
 pub mod cli;
 pub mod config;
 pub mod db;

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::HashMap,
     net::{SocketAddr, ToSocketAddrs},
-    path::PathBuf,
+    path::{Path, PathBuf},
+    sync::Arc,
     thread::{self, JoinHandle},
 };
 
@@ -21,9 +22,12 @@ pub struct MqttRuntime {
     _ingest_thread: JoinHandle<()>,
 }
 
+pub type SensorIngressHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
 pub fn start_qingping_ingress(
     config: &AppConfig,
     qingping: QingpingState,
+    reading_hook: Option<SensorIngressHook>,
 ) -> Result<Option<MqttRuntime>> {
     let Some(device_mac) = config.qingping.device_mac.as_deref() else {
         tracing::warn!("Qingping device_mac is not configured; MQTT broker not started");
@@ -53,6 +57,7 @@ pub fn start_qingping_ingress(
                 &configured_mac,
                 database_path,
                 qingping,
+                reading_hook,
             );
         })
         .context("failed to spawn Qingping MQTT ingest thread")?;
@@ -78,6 +83,7 @@ fn ingest_loop(
     configured_mac: &str,
     database_path: PathBuf,
     qingping: QingpingState,
+    reading_hook: Option<SensorIngressHook>,
 ) {
     loop {
         match link_rx.recv() {
@@ -85,26 +91,45 @@ fn ingest_loop(
                 if forward.publish.topic.as_ref() != topic.as_bytes() {
                     continue;
                 }
-                match parse_qingping_payload(&forward.publish.payload, configured_mac) {
-                    Ok(Some(reading)) => {
-                        if let Err(error) = db::insert_sensor_reading(&database_path, &reading) {
-                            tracing::warn!("failed to store Qingping reading: {error:#}");
-                        }
-                        qingping.apply_reading(reading);
-                    }
-                    Ok(None) => {
-                        tracing::debug!("ignoring Qingping MQTT message without sensor data");
-                    }
-                    Err(error) => {
-                        tracing::warn!("failed to parse Qingping MQTT payload: {error}");
-                    }
-                }
+                handle_qingping_publish(
+                    &forward.publish.payload,
+                    configured_mac,
+                    &database_path,
+                    &qingping,
+                    reading_hook.as_ref(),
+                );
             }
             Ok(Some(_)) | Ok(None) => {}
             Err(error) => {
                 tracing::warn!("Qingping MQTT internal link stopped: {error}");
                 break;
             }
+        }
+    }
+}
+
+fn handle_qingping_publish(
+    payload: &[u8],
+    configured_mac: &str,
+    database_path: &Path,
+    qingping: &QingpingState,
+    reading_hook: Option<&SensorIngressHook>,
+) {
+    match parse_qingping_payload(payload, configured_mac) {
+        Ok(Some(reading)) => {
+            if let Err(error) = db::insert_sensor_reading(database_path, &reading) {
+                tracing::warn!("failed to store Qingping reading: {error:#}");
+            }
+            qingping.apply_reading(reading);
+            if let Some(hook) = reading_hook {
+                hook();
+            }
+        }
+        Ok(None) => {
+            tracing::debug!("ignoring Qingping MQTT message without sensor data");
+        }
+        Err(error) => {
+            tracing::warn!("failed to parse Qingping MQTT payload: {error}");
         }
     }
 }
@@ -163,6 +188,9 @@ fn resolve_listen_address(host: &str, port: u16) -> Result<SocketAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::db::migrate_database;
     use crate::qingping::{normalize_device_mac, qingping_up_topic};
 
     #[test]
@@ -183,5 +211,31 @@ mod tests {
             qingping_up_topic("aa:bb:cc:dd:ee:ff"),
             "qingping/AABBCCDDEEFF/up"
         );
+    }
+
+    #[test]
+    fn qingping_publish_hook_runs_after_valid_sensor_reading() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&database_path).expect("migration");
+        let qingping = QingpingState::default();
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let hook: SensorIngressHook = Arc::new({
+            let hook_calls = hook_calls.clone();
+            move || {
+                hook_calls.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        handle_qingping_publish(
+            br#"{"sensorData":[{"co2":{"value":2100},"temperature":{"value":22.5},"tvoc":{"value":25}}]}"#,
+            "aa:bb:cc:dd:ee:ff",
+            &database_path,
+            &qingping,
+            Some(&hook),
+        );
+
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(qingping.latest().expect("reading").co2_ppm, Some(2100));
     }
 }

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -150,6 +150,11 @@ impl ErvPolicyState {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn air_quality_sample_counts(&self) -> (usize, usize) {
+        (self.co2_history.len(), self.tvoc_history.len())
+    }
+
     pub fn on_occupancy_transition(
         &mut self,
         thresholds: &ThresholdsConfig,

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -14,6 +14,7 @@ use serde_json::{Value, json};
 use tokio::{sync::broadcast, task::JoinHandle};
 
 use crate::{
+    automation::ErvPolicyCoordinator,
     config::{AppConfig, YoLinkConfig},
     db,
     state::{StateMachine, StateTransition},
@@ -520,7 +521,11 @@ pub fn reconnect_delay(config: &YoLinkConfig) -> Duration {
     Duration::from_secs(config.reconnect_delay_seconds.max(1))
 }
 
-pub fn start_yolink_client(config: &AppConfig, yolink: YoLinkState) -> Option<JoinHandle<()>> {
+pub fn start_yolink_client(
+    config: &AppConfig,
+    yolink: YoLinkState,
+    erv_automation: Option<ErvPolicyCoordinator>,
+) -> Option<JoinHandle<()>> {
     if !config.yolink.is_configured() {
         tracing::warn!("YoLink credentials are not configured; client not started");
         return None;
@@ -529,7 +534,9 @@ pub fn start_yolink_client(config: &AppConfig, yolink: YoLinkState) -> Option<Jo
     let config = config.clone();
     Some(tokio::spawn(async move {
         loop {
-            if let Err(error) = run_yolink_client_once(&config, yolink.clone()).await {
+            if let Err(error) =
+                run_yolink_client_once(&config, yolink.clone(), erv_automation.clone()).await
+            {
                 tracing::warn!("YoLink client stopped: {error:#}");
             }
             tokio::time::sleep(reconnect_delay(&config.yolink)).await;
@@ -537,11 +544,22 @@ pub fn start_yolink_client(config: &AppConfig, yolink: YoLinkState) -> Option<Jo
     }))
 }
 
-async fn run_yolink_client_once(config: &AppConfig, yolink: YoLinkState) -> Result<()> {
+async fn run_yolink_client_once(
+    config: &AppConfig,
+    yolink: YoLinkState,
+    erv_automation: Option<ErvPolicyCoordinator>,
+) -> Result<()> {
     let cloud = YoLinkCloudClient::new(config.yolink.clone());
     let (access_token, home_id) = initialize_yolink_inventory(&cloud, &yolink).await?;
     yolink.restore_from_database(chrono::Local::now().timestamp_millis() as f64 / 1_000.0)?;
-    listen_yolink_mqtt(&config.yolink, &access_token, &home_id, yolink).await
+    listen_yolink_mqtt(
+        &config.yolink,
+        &access_token,
+        &home_id,
+        yolink,
+        erv_automation,
+    )
+    .await
 }
 
 async fn listen_yolink_mqtt(
@@ -549,6 +567,7 @@ async fn listen_yolink_mqtt(
     access_token: &str,
     home_id: &str,
     yolink: YoLinkState,
+    erv_automation: Option<ErvPolicyCoordinator>,
 ) -> Result<()> {
     let mut options = MqttOptions::new(
         "office-automate-yolink",
@@ -571,8 +590,47 @@ async fn listen_yolink_mqtt(
                 match parse_mqtt_report_payload(&publish.payload) {
                     Ok(Some(report)) => {
                         let now = chrono::Local::now().timestamp_millis() as f64 / 1_000.0;
-                        if let Err(error) = yolink.apply_report(report, now) {
-                            tracing::warn!("failed to apply YoLink report: {error:#}");
+                        if let Some(erv_automation) = &erv_automation {
+                            match erv_automation
+                                .update_state_and_maybe_evaluate(|| {
+                                    let applied = yolink
+                                        .apply_report(report, now)
+                                        .context("failed to apply YoLink report")?;
+                                    let Some(applied) = applied else {
+                                        return Ok((None, None, now, false, false));
+                                    };
+                                    let bypass_dwell = applied.transition.is_some();
+                                    Ok((
+                                        Some(applied.device_type),
+                                        applied.transition,
+                                        now,
+                                        bypass_dwell,
+                                        true,
+                                    ))
+                                })
+                                .await
+                            {
+                                Ok(Some(_)) | Ok(None) => {}
+                                Err(error)
+                                    if error
+                                        .to_string()
+                                        .contains("failed to apply YoLink report") =>
+                                {
+                                    tracing::warn!("failed to apply YoLink report: {error:#}")
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        "ERV automated policy apply failed after YoLink update: {error:#}"
+                                    );
+                                }
+                            }
+                        } else {
+                            match yolink.apply_report(report, now) {
+                                Ok(Some(_)) | Ok(None) => {}
+                                Err(error) => {
+                                    tracing::warn!("failed to apply YoLink report: {error:#}")
+                                }
+                            }
                         }
                     }
                     Ok(None) => {}

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -246,13 +246,17 @@ impl YoLinkState {
             }
         };
 
-        db::log_device_event(
+        if let Err(error) = db::log_device_event(
             &self.database_path,
             device_type,
             event,
             Some(&device_name),
             Some(&event_data),
-        )?;
+        ) {
+            tracing::warn!(
+                "failed to persist YoLink {device_type} event after state update: {error:#}"
+            );
+        }
         self.notify_status();
 
         Ok(Some(YoLinkAppliedEvent {
@@ -894,6 +898,29 @@ mod tests {
         assert_eq!(
             db::get_latest_device_state(&db_path, "motion").expect("motion state"),
             Some("detected".to_string())
+        );
+    }
+
+    #[test]
+    fn event_logging_failure_still_returns_applied_event() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let yolink = test_state(temp_dir.path().to_path_buf());
+        yolink.apply_devices(sample_devices());
+
+        let applied = yolink
+            .apply_event("door-1", json!({"state": "open"}), 1_010.0)
+            .expect("state update survives logging failure")
+            .expect("applied");
+
+        assert_eq!(applied.device_type, "door");
+        assert_eq!(applied.event, "open");
+        assert!(
+            yolink
+                .state_machine
+                .read()
+                .expect("state machine lock poisoned")
+                .sensors
+                .door_open
         );
     }
 


### PR DESCRIPTION
## Summary
- Add Rust ERV active write support behind explicit `erv.active_control_enabled` and local smoke checks.
- Wire manual `/erv` and automated policy writes through the gated ERV writer with device-action logging.
- Preserve ERV read-only health behavior, including WebSocket broadcasts for read-poll status and local-key notification transitions.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `/Users/rajesh/projects/office-automate/venv/bin/python -m pytest tests/ -v`

Fixes #70