### PR TITLE
Port HVAC status/read and temperature-band persistence

### DIFF
--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -358,8 +358,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
-            YoLinkConfig,
+            ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+            ThresholdsConfig, YoLinkConfig,
         },
         db,
         erv::BoxFutureResult,
@@ -440,6 +440,7 @@ mod tests {
                 verify_delay_seconds: 0,
                 ..ErvConfig::default()
             },
+            mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -75,28 +75,38 @@ pub async fn run(cli: Cli) -> Result<()> {
 }
 
 async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()> {
-    match target {
-        Some(SmokeTarget::Erv) | None => {
-            let status = erv::smoke_erv(config).await?;
-            println!(
-                "ERV local status OK: running={} speed={}",
-                status.power,
-                status
-                    .fan_speed
-                    .map(|speed| speed.as_str())
-                    .unwrap_or("unknown")
-            );
-        }
-        Some(SmokeTarget::Hvac) => {
-            let status = hvac::smoke_hvac(config).await?;
-            println!(
-                "HVAC Kumo status OK: mode={} setpoint_c={:.1}",
-                status.mode, status.setpoint_c
-            );
+    for smoke_target in smoke_targets(target) {
+        match smoke_target {
+            SmokeTarget::Erv => {
+                let status = erv::smoke_erv(config).await?;
+                println!(
+                    "ERV local status OK: running={} speed={}",
+                    status.power,
+                    status
+                        .fan_speed
+                        .map(|speed| speed.as_str())
+                        .unwrap_or("unknown")
+                );
+            }
+            SmokeTarget::Hvac => {
+                let status = hvac::smoke_hvac(config).await?;
+                println!(
+                    "HVAC Kumo status OK: mode={} setpoint_c={:.1}",
+                    status.mode, status.setpoint_c
+                );
+            }
         }
     }
 
     Ok(())
+}
+
+fn smoke_targets(target: Option<SmokeTarget>) -> &'static [SmokeTarget] {
+    match target {
+        Some(SmokeTarget::Erv) => &[SmokeTarget::Erv],
+        Some(SmokeTarget::Hvac) => &[SmokeTarget::Hvac],
+        None => &[SmokeTarget::Erv, SmokeTarget::Hvac],
+    }
 }
 
 #[cfg(test)]
@@ -171,6 +181,28 @@ mod tests {
             Command::Smoke(args) => {
                 assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
                 assert_eq!(args.target, Some(SmokeTarget::Hvac));
+            }
+            other => panic!("expected smoke command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bare_smoke_runs_all_dependency_checks() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "smoke",
+            "--config",
+            "/tmp/office.yaml",
+        ])
+        .expect("smoke command should parse");
+
+        match cli.command {
+            Command::Smoke(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(
+                    smoke_targets(args.target),
+                    &[SmokeTarget::Erv, SmokeTarget::Hvac]
+                );
             }
             other => panic!("expected smoke command, got {other:?}"),
         }

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-use crate::{config::AppConfig, db, erv, http};
+use crate::{config::AppConfig, db, erv, http, hvac};
 
 #[derive(Debug, Parser)]
 #[command(name = "office-automate-server")]
@@ -41,6 +41,8 @@ pub struct SmokeArgs {
 pub enum SmokeTarget {
     /// Verify local ERV read credential and connectivity.
     Erv,
+    /// Verify Mitsubishi Kumo HVAC status read.
+    Hvac,
 }
 
 pub async fn run_cli() -> Result<()> {
@@ -83,6 +85,13 @@ async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()
                     .fan_speed
                     .map(|speed| speed.as_str())
                     .unwrap_or("unknown")
+            );
+        }
+        Some(SmokeTarget::Hvac) => {
+            let status = hvac::smoke_hvac(config).await?;
+            println!(
+                "HVAC Kumo status OK: mode={} setpoint_c={:.1}",
+                status.mode, status.setpoint_c
             );
         }
     }
@@ -142,6 +151,26 @@ mod tests {
             Command::Smoke(args) => {
                 assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
                 assert_eq!(args.target, Some(SmokeTarget::Erv));
+            }
+            other => panic!("expected smoke command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_smoke_hvac_command_with_config() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "smoke",
+            "--config",
+            "/tmp/office.yaml",
+            "hvac",
+        ])
+        .expect("smoke command should parse");
+
+        match cli.command {
+            Command::Smoke(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.target, Some(SmokeTarget::Hvac));
             }
             other => panic!("expected smoke command, got {other:?}"),
         }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -12,6 +12,7 @@ pub struct AppConfig {
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
     pub erv: ErvConfig,
+    pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
     pub runtime: RuntimeConfig,
 }
@@ -110,6 +111,53 @@ impl Default for YoLinkConfig {
             mqtt_host: "api.yosmart.com".to_string(),
             mqtt_port: 8003,
             reconnect_delay_seconds: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct MitsubishiConfig {
+    #[serde(rename = "type")]
+    pub device_type: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub device_serial: Option<String>,
+    pub ip: Option<String>,
+    pub base_url: String,
+    pub poll_interval_seconds: u64,
+    pub status_timeout_seconds: u64,
+}
+
+impl MitsubishiConfig {
+    pub fn is_configured(&self) -> bool {
+        self.device_type == "kumo"
+            && self
+                .username
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .password
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .device_serial
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+impl Default for MitsubishiConfig {
+    fn default() -> Self {
+        Self {
+            device_type: "kumo".to_string(),
+            username: None,
+            password: None,
+            device_serial: None,
+            ip: None,
+            base_url: "https://app-prod.kumocloud.com".to_string(),
+            poll_interval_seconds: 600,
+            status_timeout_seconds: 10,
         }
     }
 }
@@ -266,6 +314,7 @@ struct FileConfig {
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
     erv: ErvConfig,
+    mitsubishi: MitsubishiConfig,
     thresholds: ThresholdsConfig,
 }
 
@@ -318,6 +367,22 @@ impl AppConfig {
             file_config.yolink.secret_key = secret_key;
         }
 
+        if let Some(username) = env_lookup("OFFICE_AUTOMATE_KUMO_USERNAME") {
+            file_config.mitsubishi.username = Some(username);
+        }
+
+        if let Some(password) = env_lookup("OFFICE_AUTOMATE_KUMO_PASSWORD") {
+            file_config.mitsubishi.password = Some(password);
+        }
+
+        if let Some(serial) = env_lookup("OFFICE_AUTOMATE_KUMO_DEVICE_SERIAL") {
+            file_config.mitsubishi.device_serial = Some(serial);
+        }
+
+        if let Some(base_url) = env_lookup("OFFICE_AUTOMATE_KUMO_BASE_URL") {
+            file_config.mitsubishi.base_url = base_url;
+        }
+
         if let Some(ip) = env_lookup("OFFICE_AUTOMATE_ERV_IP") {
             file_config.erv.ip = ip;
         }
@@ -354,6 +419,7 @@ impl AppConfig {
             qingping: file_config.qingping,
             yolink: file_config.yolink,
             erv: file_config.erv,
+            mitsubishi: file_config.mitsubishi,
             thresholds: file_config.thresholds,
             runtime,
         })
@@ -390,6 +456,10 @@ qingping:
 yolink:
   uaid: "yaml-uaid"
   secret_key: "yaml-secret"
+mitsubishi:
+  username: "yaml-kumo-user"
+  password: "yaml-kumo-pass"
+  device_serial: "yaml-kumo-serial"
 erv:
   type: "tuya"
   ip: "192.0.2.10"
@@ -411,6 +481,10 @@ thresholds:
             "OFFICE_AUTOMATE_MQTT_PORT" => Some("2883".to_string()),
             "OFFICE_AUTOMATE_YOLINK_UAID" => Some("env-uaid".to_string()),
             "OFFICE_AUTOMATE_YOLINK_SECRET_KEY" => Some("env-secret".to_string()),
+            "OFFICE_AUTOMATE_KUMO_USERNAME" => Some("env-kumo-user".to_string()),
+            "OFFICE_AUTOMATE_KUMO_PASSWORD" => Some("env-kumo-pass".to_string()),
+            "OFFICE_AUTOMATE_KUMO_DEVICE_SERIAL" => Some("env-kumo-serial".to_string()),
+            "OFFICE_AUTOMATE_KUMO_BASE_URL" => Some("https://kumo.example.test".to_string()),
             "OFFICE_AUTOMATE_ERV_IP" => Some("192.0.2.11".to_string()),
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
@@ -431,6 +505,16 @@ thresholds:
         assert_eq!(config.yolink.mqtt_port, 8003);
         assert_eq!(config.yolink.reconnect_delay_seconds, 5);
         assert!(config.yolink.is_configured());
+        assert_eq!(config.mitsubishi.device_type, "kumo");
+        assert_eq!(config.mitsubishi.username.as_deref(), Some("env-kumo-user"));
+        assert_eq!(config.mitsubishi.password.as_deref(), Some("env-kumo-pass"));
+        assert_eq!(
+            config.mitsubishi.device_serial.as_deref(),
+            Some("env-kumo-serial")
+        );
+        assert_eq!(config.mitsubishi.base_url, "https://kumo.example.test");
+        assert_eq!(config.mitsubishi.poll_interval_seconds, 600);
+        assert!(config.mitsubishi.is_configured());
         assert_eq!(config.erv.device_type, "tuya");
         assert_eq!(config.erv.ip, "192.0.2.11");
         assert_eq!(config.erv.device_id, "env-erv-device");

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -814,8 +814,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            AppConfig, ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-            ThresholdsConfig, YoLinkConfig,
+            AppConfig, ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig,
+            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
         },
         db,
         status::Status,
@@ -937,6 +937,7 @@ mod tests {
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv,
+            mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
                 root: PathBuf::from("/tmp/office"),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -151,6 +151,7 @@ fn try_app_with_erv_writer_and_coordinator(
     let (status_broadcast, _) = broadcast::channel(32);
     yolink.set_status_broadcast(status_broadcast.clone());
     erv_state.set_status_broadcast(status_broadcast.clone());
+    hvac_state.set_status_broadcast(status_broadcast.clone());
     yolink.restore_from_database(unix_timestamp_now())?;
     let erv_policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
     let erv_automation = ErvPolicyCoordinator::new(

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -39,6 +39,7 @@ use crate::{
     erv::{
         ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
     },
+    hvac::HvacState,
     mqtt,
     policy::ErvPolicyState,
     qingping::QingpingState,
@@ -60,6 +61,7 @@ struct AppState {
     status_broadcast: broadcast::Sender<()>,
     qingping: QingpingState,
     erv: ErvState,
+    hvac: HvacState,
     erv_automation: ErvPolicyCoordinator,
 }
 
@@ -78,7 +80,15 @@ fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<R
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
-    try_app_with_state(config, qingping, state_machine, yolink, erv_state)
+    let hvac_state = HvacState::default();
+    try_app_with_state(
+        config,
+        qingping,
+        state_machine,
+        yolink,
+        erv_state,
+        hvac_state,
+    )
 }
 
 fn try_app_with_state(
@@ -87,6 +97,7 @@ fn try_app_with_state(
     state_machine: Arc<RwLock<StateMachine>>,
     yolink: YoLinkState,
     erv_state: ErvState,
+    hvac_state: HvacState,
 ) -> Result<Router> {
     try_app_with_erv_writer(
         config,
@@ -94,6 +105,7 @@ fn try_app_with_state(
         state_machine,
         yolink,
         erv_state,
+        hvac_state,
         Arc::new(RustuyaErvSpeedWriter),
     )
 }
@@ -104,6 +116,7 @@ fn try_app_with_erv_writer(
     state_machine: Arc<RwLock<StateMachine>>,
     yolink: YoLinkState,
     erv_state: ErvState,
+    hvac_state: HvacState,
     erv_writer: Arc<dyn ErvSpeedWriter>,
 ) -> Result<Router> {
     try_app_with_erv_writer_and_coordinator(
@@ -112,6 +125,7 @@ fn try_app_with_erv_writer(
         state_machine,
         yolink,
         erv_state,
+        hvac_state,
         erv_writer,
     )
     .map(|(router, _)| router)
@@ -123,6 +137,7 @@ fn try_app_with_erv_writer_and_coordinator(
     state_machine: Arc<RwLock<StateMachine>>,
     yolink: YoLinkState,
     erv_state: ErvState,
+    hvac_state: HvacState,
     erv_writer: Arc<dyn ErvSpeedWriter>,
 ) -> Result<(Router, ErvPolicyCoordinator)> {
     db::migrate_database(&config.runtime.database_path)?;
@@ -157,6 +172,7 @@ fn try_app_with_erv_writer_and_coordinator(
         status_broadcast,
         qingping,
         erv: erv_state,
+        hvac: hvac_state,
         erv_automation: erv_automation.clone(),
     };
 
@@ -230,12 +246,14 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
+    let hvac_state = HvacState::default();
     let (app, erv_automation) = try_app_with_erv_writer_and_coordinator(
         config.clone(),
         qingping.clone(),
         state_machine,
         yolink.clone(),
         erv_state.clone(),
+        hvac_state.clone(),
         Arc::new(RustuyaErvSpeedWriter),
     )
     .context("failed to build HTTP app")?;
@@ -259,6 +277,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
             .context("failed to start MQTT ingress")?;
     let _yolink_task = yolink::start_yolink_client(&config, yolink, Some(erv_automation.clone()));
     let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
+    let _hvac_task = crate::hvac::start_hvac_status_poll(&config, hvac_state);
 
     tracing::info!("office-automate-server listening on {}", bind_address);
     axum::serve(
@@ -863,6 +882,7 @@ fn status_for_state(state: &AppState) -> Status {
     status.sensors.co2_ppm = state_status.sensors.co2_ppm;
     state.qingping.overlay_status(&mut status);
     state.erv.overlay_status(&mut status);
+    state.hvac.overlay_status(&mut status);
     status
 }
 
@@ -1456,12 +1476,14 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            ErvConfig, GoogleOAuthConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-            ThresholdsConfig, YoLinkConfig,
+            ErvConfig, GoogleOAuthConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig,
+            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
         },
         erv::{BoxFutureResult, ErvDeviceStatus, parse_erv_status_payload},
+        hvac::parse_kumo_adapter_status,
     };
 
+    #[derive(Default)]
     struct FakeErvWriter {
         smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
         write_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
@@ -1536,6 +1558,7 @@ mod tests {
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv: ErvConfig::default(),
+            mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),
@@ -1628,8 +1651,36 @@ mod tests {
         )));
         let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
         let erv_state = ErvState::new(config.runtime.database_path.clone());
-        try_app_with_erv_writer(config, qingping, state_machine, yolink, erv_state, writer)
-            .expect("app")
+        try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            HvacState::default(),
+            writer,
+        )
+        .expect("app")
+    }
+
+    fn app_with_hvac_state(config: AppConfig, hvac_state: HvacState) -> Router {
+        let qingping = QingpingState::default();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+        )
+        .expect("app")
     }
 
     fn erv_status(speed: ErvFanSpeed) -> ErvDeviceStatus {
@@ -1726,6 +1777,40 @@ mod tests {
         assert_eq!(value["air_quality"]["tvoc"], 25);
         assert_eq!(value["air_quality"]["noise_db"], 37.0);
         assert_eq!(value["air_quality"]["last_update"], "2026-06-05T12:30:00");
+    }
+
+    #[tokio::test]
+    async fn status_route_reflects_latest_hvac_reading() {
+        let hvac_state = HvacState::default();
+        hvac_state.record_status(
+            parse_kumo_adapter_status(&json!({
+                "power": 1,
+                "operationMode": "cool",
+                "spHeat": 21.0,
+                "spCool": 25.5
+            }))
+            .expect("HVAC status"),
+        );
+
+        let response = app_with_hvac_state(test_config(), hvac_state)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["hvac"]["mode"], "cool");
+        assert_eq!(value["hvac"]["setpoint_c"], 25.5);
+        assert_eq!(value["hvac"]["temperature_bands"]["heat_on_temp_f"], 71);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -329,14 +329,16 @@ pub fn start_hvac_status_poll(config: &AppConfig, hvac: HvacState) -> Option<Joi
         let reader = KumoHvacStatusReader;
         let mut interval =
             time::interval(Duration::from_secs(config.poll_interval_seconds.max(60)));
+        let mut initial_status_loaded = false;
         loop {
             interval.tick().await;
-            if hvac_poll_paused_now() {
+            if should_skip_hvac_poll(initial_status_loaded, Local::now().hour()) {
                 tracing::debug!("HVAC polling paused during night hours");
                 continue;
             }
-            if let Err(error) = hvac.refresh_with(&config, &reader).await {
-                tracing::warn!("HVAC read-only status poll failed: {error:#}");
+            match hvac.refresh_with(&config, &reader).await {
+                Ok(_) => initial_status_loaded = true,
+                Err(error) => tracing::warn!("HVAC read-only status poll failed: {error:#}"),
             }
         }
     }))
@@ -347,9 +349,8 @@ pub async fn smoke_hvac(config: &AppConfig) -> Result<HvacDeviceStatus> {
     reader.read_status(&config.mitsubishi).await
 }
 
-fn hvac_poll_paused_now() -> bool {
-    let hour = Local::now().hour();
-    hour >= 23 || hour < 6
+fn should_skip_hvac_poll(initial_status_loaded: bool, hour: u32) -> bool {
+    initial_status_loaded && (hour >= 23 || hour < 6)
 }
 
 #[cfg(test)]
@@ -484,5 +485,15 @@ mod tests {
             .expect("refresh succeeds");
 
         assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn hvac_night_pause_does_not_skip_initial_status_load() {
+        assert!(!should_skip_hvac_poll(false, 23));
+        assert!(!should_skip_hvac_poll(false, 5));
+        assert!(should_skip_hvac_poll(true, 23));
+        assert!(should_skip_hvac_poll(true, 5));
+        assert!(!should_skip_hvac_poll(true, 6));
+        assert!(!should_skip_hvac_poll(true, 22));
     }
 }

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -1,0 +1,415 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::{Local, Timelike};
+use reqwest::{Client, header};
+use serde_json::{Value, json};
+use tokio::{task::JoinHandle, time};
+
+use crate::{
+    config::{AppConfig, MitsubishiConfig},
+    status::Status,
+};
+
+const KUMO_APP_VERSION: &str = "1297";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HvacDeviceStatus {
+    pub power: bool,
+    pub mode: String,
+    pub setpoint_c: f64,
+    pub heat_setpoint_c: Option<f64>,
+    pub cool_setpoint_c: Option<f64>,
+    pub raw_adapter: Value,
+}
+
+pub type BoxFutureResult<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+pub trait HvacStatusReader: Send + Sync {
+    fn read_status<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct KumoHvacStatusReader;
+
+impl HvacStatusReader for KumoHvacStatusReader {
+    fn read_status<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+        Box::pin(async move {
+            let client = KumoClient::new(config)?;
+            client.get_full_status().await
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HvacState {
+    inner: Arc<RwLock<Option<HvacDeviceStatus>>>,
+}
+
+impl HvacState {
+    pub async fn refresh_with<R>(
+        &self,
+        config: &MitsubishiConfig,
+        reader: &R,
+    ) -> Result<HvacDeviceStatus>
+    where
+        R: HvacStatusReader + ?Sized,
+    {
+        let status = reader.read_status(config).await?;
+        self.record_status(status.clone());
+        Ok(status)
+    }
+
+    pub fn record_status(&self, status: HvacDeviceStatus) {
+        *self.inner.write().expect("HVAC state lock poisoned") = Some(status);
+    }
+
+    pub fn latest(&self) -> Option<HvacDeviceStatus> {
+        self.inner.read().expect("HVAC state lock poisoned").clone()
+    }
+
+    pub fn overlay_status(&self, status: &mut Status) {
+        let Some(device_status) = self.latest() else {
+            return;
+        };
+
+        status.hvac.mode = device_status.mode;
+        status.hvac.setpoint_c = device_status.setpoint_c;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct KumoClient {
+    http: Client,
+    base_url: String,
+    username: String,
+    password: String,
+    device_serial: String,
+}
+
+impl KumoClient {
+    fn new(config: &MitsubishiConfig) -> Result<Self> {
+        if !config.is_configured() {
+            bail!("Mitsubishi Kumo config is incomplete");
+        }
+
+        let http = Client::builder()
+            .timeout(Duration::from_secs(config.status_timeout_seconds.max(1)))
+            .build()
+            .context("failed to build Kumo HTTP client")?;
+
+        Ok(Self {
+            http,
+            base_url: config.base_url.trim_end_matches('/').to_string(),
+            username: config
+                .username
+                .as_ref()
+                .expect("checked configured username")
+                .clone(),
+            password: config
+                .password
+                .as_ref()
+                .expect("checked configured password")
+                .clone(),
+            device_serial: config
+                .device_serial
+                .as_ref()
+                .expect("checked configured serial")
+                .clone(),
+        })
+    }
+
+    async fn get_full_status(&self) -> Result<HvacDeviceStatus> {
+        let token = self.login().await?;
+        let sites = self.get_json("/v3/sites", &token).await?;
+        let Some(sites) = sites.as_array() else {
+            bail!("Kumo sites response is not an array");
+        };
+
+        for site in sites {
+            let Some(site_id) = site.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let zones = self
+                .get_json(&format!("/v3/sites/{site_id}/zones"), &token)
+                .await?;
+            let Some(zones) = zones.as_array() else {
+                bail!("Kumo zones response for site {site_id} is not an array");
+            };
+
+            for zone in zones {
+                let Some(adapter) = zone.get("adapter") else {
+                    continue;
+                };
+                if adapter.get("deviceSerial").and_then(Value::as_str)
+                    == Some(self.device_serial.as_str())
+                {
+                    return parse_kumo_adapter_status(adapter);
+                }
+            }
+        }
+
+        bail!("Kumo device {} not found in any zone", self.device_serial)
+    }
+
+    async fn login(&self) -> Result<String> {
+        let response = self
+            .http
+            .post(self.url("/v3/login"))
+            .headers(kumo_headers())
+            .json(&json!({
+                "username": self.username,
+                "password": self.password,
+                "appVersion": KUMO_APP_VERSION,
+            }))
+            .send()
+            .await
+            .context("failed to send Kumo login request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            bail!("Kumo login failed: {status} - {text}");
+        }
+
+        let payload: Value = response
+            .json()
+            .await
+            .context("Kumo login response is not JSON")?;
+        payload
+            .get("token")
+            .and_then(|token| token.get("access"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("Kumo login response missing token.access"))
+    }
+
+    async fn get_json(&self, path: &str, token: &str) -> Result<Value> {
+        let response = self
+            .http
+            .get(self.url(path))
+            .headers(kumo_headers())
+            .bearer_auth(token)
+            .send()
+            .await
+            .with_context(|| format!("failed to send Kumo GET {path}"))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            bail!("Kumo GET {path} failed: {status} - {text}");
+        }
+
+        response
+            .json()
+            .await
+            .with_context(|| format!("Kumo GET {path} response is not JSON"))
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+}
+
+fn kumo_headers() -> header::HeaderMap {
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        header::USER_AGENT,
+        header::HeaderValue::from_static("kumocloud/1297 CFNetwork/3826.600.41 Darwin/24.6.0"),
+    );
+    headers.insert(
+        "X-App-Version",
+        header::HeaderValue::from_static(KUMO_APP_VERSION),
+    );
+    headers.insert("X-App-Platform", header::HeaderValue::from_static("ios"));
+    headers
+}
+
+pub fn parse_kumo_adapter_status(adapter: &Value) -> Result<HvacDeviceStatus> {
+    let power = adapter.get("power").and_then(value_as_i64).unwrap_or(0) == 1;
+    let raw_mode = adapter
+        .get("operationMode")
+        .and_then(Value::as_str)
+        .unwrap_or("off");
+    let mode = if power {
+        normalize_mode(raw_mode)
+    } else {
+        "off".to_string()
+    };
+    let heat_setpoint_c = adapter.get("spHeat").and_then(value_as_f64);
+    let cool_setpoint_c = adapter.get("spCool").and_then(value_as_f64);
+    let setpoint_c = match mode.as_str() {
+        "heat" => heat_setpoint_c.unwrap_or(22.0),
+        "cool" => cool_setpoint_c.unwrap_or(22.0),
+        "auto" => heat_setpoint_c.or(cool_setpoint_c).unwrap_or(22.0),
+        _ => 22.0,
+    };
+
+    Ok(HvacDeviceStatus {
+        power,
+        mode,
+        setpoint_c,
+        heat_setpoint_c,
+        cool_setpoint_c,
+        raw_adapter: adapter.clone(),
+    })
+}
+
+fn normalize_mode(value: &str) -> String {
+    match value {
+        "off" | "heat" | "cool" | "auto" | "dry" | "vent" => value.to_string(),
+        _ => "off".to_string(),
+    }
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+}
+
+fn value_as_f64(value: &Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+}
+
+pub fn start_hvac_status_poll(config: &AppConfig, hvac: HvacState) -> Option<JoinHandle<()>> {
+    if !config.mitsubishi.is_configured() {
+        tracing::info!("Mitsubishi Kumo config is incomplete; read-only HVAC polling disabled");
+        return None;
+    }
+
+    let config = config.mitsubishi.clone();
+    Some(tokio::spawn(async move {
+        let reader = KumoHvacStatusReader;
+        let mut interval =
+            time::interval(Duration::from_secs(config.poll_interval_seconds.max(60)));
+        loop {
+            interval.tick().await;
+            if hvac_poll_paused_now() {
+                tracing::debug!("HVAC polling paused during night hours");
+                continue;
+            }
+            if let Err(error) = hvac.refresh_with(&config, &reader).await {
+                tracing::warn!("HVAC read-only status poll failed: {error:#}");
+            }
+        }
+    }))
+}
+
+pub async fn smoke_hvac(config: &AppConfig) -> Result<HvacDeviceStatus> {
+    let reader = KumoHvacStatusReader;
+    reader.read_status(&config.mitsubishi).await
+}
+
+fn hvac_poll_paused_now() -> bool {
+    let hour = Local::now().hour();
+    hour >= 23 || hour < 6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::ThresholdsConfig, status::Status};
+
+    #[test]
+    fn parses_kumo_adapter_status_for_active_heat_and_cool() {
+        let heat = parse_kumo_adapter_status(&json!({
+            "deviceSerial": "serial",
+            "power": 1,
+            "operationMode": "heat",
+            "spHeat": 21.5,
+            "spCool": 25.0
+        }))
+        .expect("heat status");
+        assert!(heat.power);
+        assert_eq!(heat.mode, "heat");
+        assert_eq!(heat.setpoint_c, 21.5);
+        assert_eq!(heat.heat_setpoint_c, Some(21.5));
+        assert_eq!(heat.cool_setpoint_c, Some(25.0));
+
+        let cool = parse_kumo_adapter_status(&json!({
+            "power": "1",
+            "operationMode": "cool",
+            "spHeat": "21.0",
+            "spCool": "25.5"
+        }))
+        .expect("cool status");
+        assert_eq!(cool.mode, "cool");
+        assert_eq!(cool.setpoint_c, 25.5);
+    }
+
+    #[test]
+    fn treats_powered_off_kumo_adapter_as_off() {
+        let status = parse_kumo_adapter_status(&json!({
+            "power": 0,
+            "operationMode": "heat",
+            "spHeat": 21.0,
+            "spCool": 25.0
+        }))
+        .expect("status");
+
+        assert!(!status.power);
+        assert_eq!(status.mode, "off");
+        assert_eq!(status.setpoint_c, 22.0);
+    }
+
+    #[test]
+    fn hvac_state_overlays_cached_status() {
+        let hvac = HvacState::default();
+        hvac.record_status(
+            parse_kumo_adapter_status(&json!({
+                "power": 1,
+                "operationMode": "cool",
+                "spCool": 24.5
+            }))
+            .expect("status"),
+        );
+
+        let mut status = Status::read_only_default(&crate::config::AppConfig {
+            orchestrator: crate::config::OrchestratorConfig::default(),
+            qingping: crate::config::QingpingConfig::default(),
+            yolink: crate::config::YoLinkConfig::default(),
+            erv: crate::config::ErvConfig::default(),
+            mitsubishi: crate::config::MitsubishiConfig::default(),
+            thresholds: ThresholdsConfig::default(),
+            runtime: crate::config::RuntimeConfig {
+                root: "/tmp/office".into(),
+                config_path: "/tmp/office/config.yaml".into(),
+                data_dir: "/tmp/office/data".into(),
+                database_path: "/tmp/office/data/office_climate.db".into(),
+                frontend_dist: "/tmp/office/frontend/dist".into(),
+                artifacts_dir: "/tmp/office/data/apps".into(),
+                legacy_apk_path: "/tmp/office/data/app-debug.apk".into(),
+                base_url: None,
+                public_url: None,
+                mqtt_host: "127.0.0.1".to_string(),
+                mqtt_port: 1883,
+            },
+        });
+        hvac.overlay_status(&mut status);
+
+        assert_eq!(status.hvac.mode, "cool");
+        assert_eq!(status.hvac.setpoint_c, 24.5);
+    }
+}

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use chrono::{Local, Timelike};
 use reqwest::{Client, header};
 use serde_json::{Value, json};
-use tokio::{task::JoinHandle, time};
+use tokio::{sync::broadcast, task::JoinHandle, time};
 
 use crate::{
     config::{AppConfig, MitsubishiConfig},
@@ -55,9 +55,17 @@ impl HvacStatusReader for KumoHvacStatusReader {
 #[derive(Debug, Clone, Default)]
 pub struct HvacState {
     inner: Arc<RwLock<Option<HvacDeviceStatus>>>,
+    status_broadcast: Arc<RwLock<Option<broadcast::Sender<()>>>>,
 }
 
 impl HvacState {
+    pub fn set_status_broadcast(&self, sender: broadcast::Sender<()>) {
+        *self
+            .status_broadcast
+            .write()
+            .expect("HVAC broadcast lock poisoned") = Some(sender);
+    }
+
     pub async fn refresh_with<R>(
         &self,
         config: &MitsubishiConfig,
@@ -67,12 +75,17 @@ impl HvacState {
         R: HvacStatusReader + ?Sized,
     {
         let status = reader.read_status(config).await?;
-        self.record_status(status.clone());
+        if self.record_status(status.clone()) {
+            self.notify_status();
+        }
         Ok(status)
     }
 
-    pub fn record_status(&self, status: HvacDeviceStatus) {
-        *self.inner.write().expect("HVAC state lock poisoned") = Some(status);
+    pub fn record_status(&self, status: HvacDeviceStatus) -> bool {
+        let mut inner = self.inner.write().expect("HVAC state lock poisoned");
+        let changed = inner.as_ref() != Some(&status);
+        *inner = Some(status);
+        changed
     }
 
     pub fn latest(&self) -> Option<HvacDeviceStatus> {
@@ -86,6 +99,18 @@ impl HvacState {
 
         status.hvac.mode = device_status.mode;
         status.hvac.setpoint_c = device_status.setpoint_c;
+    }
+
+    fn notify_status(&self) {
+        let Some(sender) = self
+            .status_broadcast
+            .read()
+            .expect("HVAC broadcast lock poisoned")
+            .clone()
+        else {
+            return;
+        };
+        let _ = sender.send(());
     }
 }
 
@@ -332,6 +357,20 @@ mod tests {
     use super::*;
     use crate::{config::ThresholdsConfig, status::Status};
 
+    struct FakeHvacReader {
+        status: HvacDeviceStatus,
+    }
+
+    impl HvacStatusReader for FakeHvacReader {
+        fn read_status<'a>(
+            &'a self,
+            _config: &'a MitsubishiConfig,
+        ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+            let status = self.status.clone();
+            Box::pin(async move { Ok(status) })
+        }
+    }
+
     #[test]
     fn parses_kumo_adapter_status_for_active_heat_and_cool() {
         let heat = parse_kumo_adapter_status(&json!({
@@ -411,5 +450,39 @@ mod tests {
 
         assert_eq!(status.hvac.mode, "cool");
         assert_eq!(status.hvac.setpoint_c, 24.5);
+    }
+
+    #[tokio::test]
+    async fn hvac_status_change_notifies_status_broadcast() {
+        let hvac = HvacState::default();
+        let (sender, mut receiver) = broadcast::channel(4);
+        hvac.set_status_broadcast(sender);
+        let config = MitsubishiConfig::default();
+
+        let cool = parse_kumo_adapter_status(&json!({
+            "power": 1,
+            "operationMode": "cool",
+            "spCool": 24.5
+        }))
+        .expect("cool status");
+        hvac.refresh_with(
+            &config,
+            &FakeHvacReader {
+                status: cool.clone(),
+            },
+        )
+        .await
+        .expect("refresh succeeds");
+
+        time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast message");
+
+        hvac.refresh_with(&config, &FakeHvacReader { status: cool })
+            .await
+            .expect("refresh succeeds");
+
+        assert!(receiver.try_recv().is_err());
     }
 }

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod db;
 pub mod erv;
 pub mod http;
+pub mod hvac;
 pub mod mqtt;
 pub mod policy;
 pub mod qingping;

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -240,8 +240,8 @@ mod tests {
 
     use super::*;
     use crate::config::{
-        ErvConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig, ThresholdsConfig,
-        YoLinkConfig,
+        ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+        ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -253,6 +253,7 @@ mod tests {
             },
             yolink: YoLinkConfig::default(),
             erv: ErvConfig::default(),
+            mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig {
                 hvac_heat_on_temp_f: 70,
                 hvac_heat_off_temp_f: 74,


### PR DESCRIPTION
## Summary
- Add read-only Kumo/HVAC status loading and expose it through the Rust `/status` compatibility payload.
- Add persisted HVAC temperature-band GET/POST support with validation matching the Python behavior.
- Keep active HVAC writes disabled for this ticket while adding smoke/status CLI support.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `/Users/rajesh/projects/office-automate/venv/bin/python -m pytest tests/ -v`

Fixes #71