### PR TITLE
Gate active HVAC write control

### DIFF
--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -124,6 +124,7 @@ pub struct MitsubishiConfig {
     pub password: Option<String>,
     pub device_serial: Option<String>,
     pub ip: Option<String>,
+    pub active_control_enabled: bool,
     pub base_url: String,
     pub poll_interval_seconds: u64,
     pub status_timeout_seconds: u64,
@@ -155,6 +156,7 @@ impl Default for MitsubishiConfig {
             password: None,
             device_serial: None,
             ip: None,
+            active_control_enabled: false,
             base_url: "https://app-prod.kumocloud.com".to_string(),
             poll_interval_seconds: 600,
             status_timeout_seconds: 10,
@@ -239,6 +241,7 @@ pub struct ThresholdsConfig {
     pub hvac_critical_temp_f: i64,
     pub hvac_heat_on_temp_f: i64,
     pub hvac_heat_off_temp_f: i64,
+    pub hvac_cool_setpoint_f: i64,
     pub hvac_cool_off_temp_f: i64,
     pub hvac_cool_on_temp_f: i64,
     pub away_stale_flush_enabled: bool,
@@ -282,6 +285,7 @@ impl Default for ThresholdsConfig {
             hvac_critical_temp_f: 55,
             hvac_heat_on_temp_f: 71,
             hvac_heat_off_temp_f: 75,
+            hvac_cool_setpoint_f: 78,
             hvac_cool_off_temp_f: 78,
             hvac_cool_on_temp_f: 81,
             away_stale_flush_enabled: true,
@@ -383,6 +387,11 @@ impl AppConfig {
             file_config.mitsubishi.base_url = base_url;
         }
 
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_KUMO_ACTIVE_CONTROL_ENABLED") {
+            file_config.mitsubishi.active_control_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_KUMO_ACTIVE_CONTROL_ENABLED", &enabled)?;
+        }
+
         if let Some(ip) = env_lookup("OFFICE_AUTOMATE_ERV_IP") {
             file_config.erv.ip = ip;
         }
@@ -468,6 +477,7 @@ erv:
 thresholds:
   hvac_heat_on_temp_f: 70
   hvac_heat_off_temp_f: 74
+  hvac_cool_setpoint_f: 77
   hvac_cool_off_temp_f: 79
   hvac_cool_on_temp_f: 82
 "#,
@@ -485,6 +495,7 @@ thresholds:
             "OFFICE_AUTOMATE_KUMO_PASSWORD" => Some("env-kumo-pass".to_string()),
             "OFFICE_AUTOMATE_KUMO_DEVICE_SERIAL" => Some("env-kumo-serial".to_string()),
             "OFFICE_AUTOMATE_KUMO_BASE_URL" => Some("https://kumo.example.test".to_string()),
+            "OFFICE_AUTOMATE_KUMO_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_ERV_IP" => Some("192.0.2.11".to_string()),
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
@@ -513,6 +524,7 @@ thresholds:
             Some("env-kumo-serial")
         );
         assert_eq!(config.mitsubishi.base_url, "https://kumo.example.test");
+        assert!(config.mitsubishi.active_control_enabled);
         assert_eq!(config.mitsubishi.poll_interval_seconds, 600);
         assert!(config.mitsubishi.is_configured());
         assert_eq!(config.erv.device_type, "tuya");
@@ -547,6 +559,7 @@ thresholds:
             Some("https://office.example.com")
         );
         assert_eq!(config.thresholds.hvac_heat_on_temp_f, 70);
+        assert_eq!(config.thresholds.hvac_cool_setpoint_f, 77);
         assert_eq!(config.thresholds.hvac_cool_on_temp_f, 82);
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -244,6 +244,8 @@ pub struct ThresholdsConfig {
     pub hvac_cool_setpoint_f: i64,
     pub hvac_cool_off_temp_f: i64,
     pub hvac_cool_on_temp_f: i64,
+    pub expected_occupancy_start: String,
+    pub expected_occupancy_end: String,
     pub away_stale_flush_enabled: bool,
     pub away_stale_flush_interval_hours: u64,
     pub away_stale_flush_duration_minutes: u64,
@@ -288,6 +290,8 @@ impl Default for ThresholdsConfig {
             hvac_cool_setpoint_f: 78,
             hvac_cool_off_temp_f: 78,
             hvac_cool_on_temp_f: 81,
+            expected_occupancy_start: "07:00".to_string(),
+            expected_occupancy_end: "22:00".to_string(),
             away_stale_flush_enabled: true,
             away_stale_flush_interval_hours: 8,
             away_stale_flush_duration_minutes: 30,
@@ -480,6 +484,8 @@ thresholds:
   hvac_cool_setpoint_f: 77
   hvac_cool_off_temp_f: 79
   hvac_cool_on_temp_f: 82
+  expected_occupancy_start: "08:30"
+  expected_occupancy_end: "18:45"
 "#,
         )
         .expect("write config");
@@ -561,5 +567,7 @@ thresholds:
         assert_eq!(config.thresholds.hvac_heat_on_temp_f, 70);
         assert_eq!(config.thresholds.hvac_cool_setpoint_f, 77);
         assert_eq!(config.thresholds.hvac_cool_on_temp_f, 82);
+        assert_eq!(config.thresholds.expected_occupancy_start, "08:30");
+        assert_eq!(config.thresholds.expected_occupancy_end, "18:45");
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -582,6 +582,8 @@ async fn occupancy(
     Json(payload): Json<OccupancyRequest>,
 ) -> Response {
     let now = unix_timestamp_now();
+    let applied_transition = Arc::new(std::sync::Mutex::new(None));
+    let applied_transition_for_update = Arc::clone(&applied_transition);
     let policy_result = state
         .erv_automation
         .update_state_and_maybe_evaluate(|| {
@@ -598,6 +600,9 @@ async fn occupancy(
                 let status = machine.status_at(now);
                 (transition, status.state, status.erv_should_run)
             };
+            *applied_transition_for_update
+                .lock()
+                .expect("occupancy transition lock poisoned") = transition;
             log_state_transition(&state, transition, "mac_activity")
                 .context("failed to persist occupancy update")?;
             Ok((
@@ -631,7 +636,10 @@ async fn occupancy(
                 .read()
                 .expect("state machine lock poisoned")
                 .status_at(now);
-            (None, status.state, status.erv_should_run)
+            let transition = *applied_transition
+                .lock()
+                .expect("occupancy transition lock poisoned");
+            (transition, status.state, status.erv_should_run)
         }
     };
     clear_hvac_manual_override_on_transition(&state, transition);
@@ -653,6 +661,8 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
             let requested_state = payload.state.as_str();
             let now = unix_timestamp_now();
             let present = requested_state == "present";
+            let applied_transition = Arc::new(std::sync::Mutex::new(None));
+            let applied_transition_for_update = Arc::clone(&applied_transition);
             let policy_result = state
                 .erv_automation
                 .update_state_and_maybe_evaluate(|| {
@@ -665,6 +675,9 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                         let status = machine.status_at(now);
                         (transition, status.state, status.is_present)
                     };
+                    *applied_transition_for_update
+                        .lock()
+                        .expect("presence transition lock poisoned") = transition;
                     db::log_device_event(
                         &state.config.runtime.database_path,
                         "presence",
@@ -707,7 +720,10 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                         .read()
                         .expect("state machine lock poisoned")
                         .status_at(now);
-                    (None, status.state, status.is_present)
+                    let transition = *applied_transition
+                        .lock()
+                        .expect("presence transition lock poisoned");
+                    (transition, status.state, status.is_present)
                 }
             };
             clear_hvac_manual_override_on_transition(&state, transition);
@@ -3828,6 +3844,82 @@ mod tests {
             .await
             .expect("read status");
         let value: Value = serde_json::from_slice(&body).expect("status json");
+        assert_eq!(value["manual_override"]["hvac"], false);
+        assert_eq!(value["hvac"]["mode"], "cool");
+    }
+
+    #[tokio::test]
+    async fn presence_preserves_transition_when_erv_policy_fails() {
+        let mut config = configured_erv_config(true);
+        config.mitsubishi = configured_hvac_config(true).mitsubishi;
+        let qingping = QingpingState::default();
+        qingping.apply_reading(crate::qingping::QingpingReading {
+            temp_c: Some(28.0),
+            ..qingping_reading(2100)
+        });
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        hvac_state.record_manual_override(HvacControlMode::Off, 70.0);
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Err(anyhow::anyhow!("ERV write failed"))],
+        ));
+        let hvac_writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let service = try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            erv_writer.clone(),
+            hvac_writer.clone(),
+        )
+        .expect("app");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("presence response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(erv_writer.write_speeds(), vec![ErvFanSpeed::Quiet]);
+        assert_eq!(
+            hvac_writer.write_modes(),
+            vec![(HvacControlMode::Cool, Some(25.5))]
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("status response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read status");
+        let value: Value = serde_json::from_slice(&body).expect("status json");
+        assert_eq!(value["state"], "present");
         assert_eq!(value["manual_override"]["hvac"], false);
         assert_eq!(value["hvac"]["mode"], "cool");
     }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -39,11 +39,11 @@ use crate::{
     erv::{
         ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
     },
-    hvac::HvacState,
+    hvac::{HvacControlMode, HvacModeWriter, HvacState, KumoHvacModeWriter},
     mqtt,
-    policy::ErvPolicyState,
+    policy::{ErvPolicyState, HvacBandAction, HvacMode, get_hvac_band_action},
     qingping::QingpingState,
-    state::{StateMachine, StateTransition},
+    state::{OccupancyState, StateMachine, StateTransition},
     status::{Status, TemperatureBands},
     yolink::{self, YoLinkState},
 };
@@ -63,6 +63,7 @@ struct AppState {
     erv: ErvState,
     hvac: HvacState,
     erv_automation: ErvPolicyCoordinator,
+    hvac_writer: Arc<dyn HvacModeWriter>,
 }
 
 pub fn app(config: AppConfig) -> Router {
@@ -80,7 +81,7 @@ fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<R
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
-    let hvac_state = HvacState::default();
+    let hvac_state = HvacState::new(config.runtime.database_path.clone());
     try_app_with_state(
         config,
         qingping,
@@ -107,6 +108,7 @@ fn try_app_with_state(
         erv_state,
         hvac_state,
         Arc::new(RustuyaErvSpeedWriter),
+        Arc::new(KumoHvacModeWriter),
     )
 }
 
@@ -118,6 +120,7 @@ fn try_app_with_erv_writer(
     erv_state: ErvState,
     hvac_state: HvacState,
     erv_writer: Arc<dyn ErvSpeedWriter>,
+    hvac_writer: Arc<dyn HvacModeWriter>,
 ) -> Result<Router> {
     try_app_with_erv_writer_and_coordinator(
         config,
@@ -127,6 +130,7 @@ fn try_app_with_erv_writer(
         erv_state,
         hvac_state,
         erv_writer,
+        hvac_writer,
     )
     .map(|(router, _)| router)
 }
@@ -139,6 +143,7 @@ fn try_app_with_erv_writer_and_coordinator(
     erv_state: ErvState,
     hvac_state: HvacState,
     erv_writer: Arc<dyn ErvSpeedWriter>,
+    hvac_writer: Arc<dyn HvacModeWriter>,
 ) -> Result<(Router, ErvPolicyCoordinator)> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
@@ -175,6 +180,7 @@ fn try_app_with_erv_writer_and_coordinator(
         erv: erv_state,
         hvac: hvac_state,
         erv_automation: erv_automation.clone(),
+        hvac_writer,
     };
 
     let cors = CorsLayer::new()
@@ -247,7 +253,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
-    let hvac_state = HvacState::default();
+    let hvac_state = HvacState::new(config.runtime.database_path.clone());
     let (app, erv_automation) = try_app_with_erv_writer_and_coordinator(
         config.clone(),
         qingping.clone(),
@@ -256,6 +262,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         erv_state.clone(),
         hvac_state.clone(),
         Arc::new(RustuyaErvSpeedWriter),
+        Arc::new(KumoHvacModeWriter),
     )
     .context("failed to build HTTP app")?;
     let runtime_handle = tokio::runtime::Handle::current();
@@ -560,7 +567,7 @@ async fn occupancy(
             log_state_transition(&state, transition, "mac_activity")
                 .context("failed to persist occupancy update")?;
             Ok((
-                (state_name, erv_should_run),
+                (transition, state_name, erv_should_run),
                 transition,
                 now,
                 transition.is_some(),
@@ -569,7 +576,7 @@ async fn occupancy(
         })
         .await;
 
-    let (state_name, erv_should_run) = match policy_result {
+    let (transition, state_name, erv_should_run) = match policy_result {
         Ok(result) => result,
         Err(error)
             if error
@@ -590,9 +597,13 @@ async fn occupancy(
                 .read()
                 .expect("state machine lock poisoned")
                 .status_at(now);
-            (status.state, status.erv_should_run)
+            (None, status.state, status.erv_should_run)
         }
     };
+    clear_hvac_manual_override_on_transition(&state, transition);
+    if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+        tracing::warn!("HVAC automated policy apply failed after occupancy update: {error:#}");
+    }
     broadcast_status(&state);
     Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run})).into_response()
 }
@@ -630,7 +641,7 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                     .and_then(|_| log_state_transition(&state, transition, "manual"))
                     .context("failed to persist presence update")?;
                     Ok((
-                        (state_name, is_present),
+                        (transition, state_name, is_present),
                         transition,
                         now,
                         transition.is_some(),
@@ -639,7 +650,7 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                 })
                 .await;
 
-            let (state_name, is_present) = match policy_result {
+            let (transition, state_name, is_present) = match policy_result {
                 Ok(result) => result,
                 Err(error)
                     if error
@@ -662,9 +673,15 @@ async fn presence(State(state): State<AppState>, Json(payload): Json<PresenceReq
                         .read()
                         .expect("state machine lock poisoned")
                         .status_at(now);
-                    (status.state, status.is_present)
+                    (None, status.state, status.is_present)
                 }
             };
+            clear_hvac_manual_override_on_transition(&state, transition);
+            if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+                tracing::warn!(
+                    "HVAC automated policy apply failed after presence update: {error:#}"
+                );
+            }
             broadcast_status(&state);
             Json(json!({"ok": true, "state": state_name, "is_present": is_present})).into_response()
         }
@@ -741,29 +758,205 @@ async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> 
     }
 }
 
+async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
+    if !state.config.mitsubishi.active_control_enabled || state.hvac.manual_override_active() {
+        return Ok(());
+    }
+
+    let now = unix_timestamp_now();
+    let state_status = {
+        let machine = state
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        machine.status_at(now)
+    };
+    let hvac_snapshot = state.hvac.snapshot();
+
+    if state_status.safety_interlock {
+        if hvac_snapshot.mode != "off" {
+            let previous_mode = hvac_snapshot.mode.clone();
+            apply_hvac_mode(state, HvacControlMode::Off, None, "safety_interlock").await?;
+            state.hvac.set_suspended(true, Some(previous_mode));
+            broadcast_status(state);
+        }
+        return Ok(());
+    }
+
+    let temp_f = state
+        .qingping
+        .latest()
+        .and_then(|reading| reading.temp_c)
+        .map(celsius_to_fahrenheit);
+    let bands = active_temperature_bands(state);
+    let temp_band_mode = hvac_snapshot
+        .temp_band_mode
+        .as_deref()
+        .and_then(hvac_mode_from_str);
+    let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
+    let erv_snapshot = state.erv.snapshot();
+
+    let Some(action) = get_hvac_band_action(
+        temp_f,
+        hvac_mode,
+        temp_band_mode,
+        if state_status.is_present {
+            OccupancyState::Present
+        } else {
+            OccupancyState::Away
+        },
+        erv_snapshot.running,
+        state.config.thresholds.hvac_min_temp_f as f64,
+        true,
+        bands.heat_off_temp_f as f64,
+        bands.heat_on_temp_f as f64,
+        bands.cool_on_temp_f as f64,
+        bands.cool_off_temp_f as f64,
+    ) else {
+        return Ok(());
+    };
+
+    let temp_label = temp_f.unwrap_or_default().round() as i64;
+    match action {
+        HvacBandAction::PauseHeat => {
+            apply_hvac_mode(
+                state,
+                HvacControlMode::Off,
+                None,
+                &format!("heat_band_pause_{temp_label}F"),
+            )
+            .await?;
+            state.hvac.set_temp_band_mode(Some(HvacControlMode::Heat));
+        }
+        HvacBandAction::ResumeHeat => {
+            let setpoint_c = hvac_snapshot.heat_setpoint_c.unwrap_or(22.0);
+            apply_hvac_mode(
+                state,
+                HvacControlMode::Heat,
+                Some(setpoint_c),
+                &format!("heat_band_resume_{temp_label}F"),
+            )
+            .await?;
+            state.hvac.set_suspended(false, None);
+            state.hvac.set_temp_band_mode(None);
+        }
+        HvacBandAction::StopCool => {
+            apply_hvac_mode(
+                state,
+                HvacControlMode::Off,
+                None,
+                &format!("cool_band_stop_{temp_label}F"),
+            )
+            .await?;
+            state.hvac.set_temp_band_mode(Some(HvacControlMode::Cool));
+        }
+        HvacBandAction::StartCool => {
+            let setpoint_c = hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
+                fahrenheit_to_celsius(state.config.thresholds.hvac_cool_setpoint_f as f64)
+            });
+            apply_hvac_mode(
+                state,
+                HvacControlMode::Cool,
+                Some(setpoint_c),
+                &format!("cool_band_start_{temp_label}F"),
+            )
+            .await?;
+            state.hvac.set_suspended(false, None);
+            state.hvac.set_temp_band_mode(None);
+        }
+    }
+
+    broadcast_status(state);
+    Ok(())
+}
+
+fn clear_hvac_manual_override_on_transition(state: &AppState, transition: Option<StateTransition>) {
+    if transition.is_some() {
+        state.hvac.clear_manual_override();
+    }
+}
+
+async fn apply_hvac_mode(
+    state: &AppState,
+    mode: HvacControlMode,
+    setpoint_c: Option<f64>,
+    reason: &str,
+) -> Result<crate::hvac::HvacDeviceStatus> {
+    state
+        .hvac
+        .set_mode_with(
+            &state.config.mitsubishi,
+            state.hvac_writer.as_ref(),
+            mode,
+            setpoint_c,
+            reason,
+        )
+        .await
+}
+
+fn fahrenheit_to_celsius(value: f64) -> f64 {
+    (value - 32.0) * 5.0 / 9.0
+}
+
+fn celsius_to_fahrenheit(value: f64) -> f64 {
+    value * 9.0 / 5.0 + 32.0
+}
+
+fn round_tenth(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}
+
+fn hvac_mode_from_str(value: &str) -> Option<HvacMode> {
+    match value {
+        "off" => Some(HvacMode::Off),
+        "heat" => Some(HvacMode::Heat),
+        "cool" => Some(HvacMode::Cool),
+        "auto" => Some(HvacMode::Auto),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct HvacRequest {
     mode: String,
     setpoint_f: Option<f64>,
 }
 
-async fn hvac(Json(payload): Json<HvacRequest>) -> Response {
-    if !matches!(payload.mode.as_str(), "off" | "heat" | "cool") {
+async fn hvac(State(state): State<AppState>, Json(payload): Json<HvacRequest>) -> Response {
+    let mode_name = payload.mode.to_ascii_lowercase();
+    let Some(mode) = HvacControlMode::parse(&mode_name) else {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"ok": false, "error": "Invalid HVAC mode"})),
         )
             .into_response();
-    }
-    let _ = payload.setpoint_f;
+    };
 
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(
-            json!({"ok": false, "error": "HVAC control is not enabled in Rust compatibility mode"}),
-        ),
-    )
-        .into_response()
+    let setpoint_f = payload.setpoint_f.unwrap_or(70.0);
+    let setpoint_c = fahrenheit_to_celsius(setpoint_f);
+
+    match apply_hvac_mode(&state, mode, Some(setpoint_c), "manual_override").await {
+        Ok(status) => {
+            state.hvac.record_manual_override(mode, setpoint_f);
+            broadcast_status(&state);
+            Json(json!({
+                "ok": true,
+                "hvac": {
+                    "mode": mode.as_str(),
+                    "setpoint_f": setpoint_f,
+                    "setpoint_c": round_tenth(status.setpoint_c),
+                    "manual_override": true,
+                    "expires_in": crate::hvac::HVAC_MANUAL_OVERRIDE_SECONDS,
+                }
+            }))
+            .into_response()
+        }
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response(),
+    }
 }
 
 async fn hvac_temperature_bands(State(state): State<AppState>) -> Json<Value> {
@@ -1480,8 +1673,8 @@ mod tests {
             ErvConfig, GoogleOAuthConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig,
             RuntimeConfig, ThresholdsConfig, YoLinkConfig,
         },
-        erv::{BoxFutureResult, ErvDeviceStatus, parse_erv_status_payload},
-        hvac::parse_kumo_adapter_status,
+        erv::{BoxFutureResult as ErvBoxFutureResult, ErvDeviceStatus, parse_erv_status_payload},
+        hvac::{HvacDeviceStatus, parse_kumo_adapter_status},
     };
 
     #[derive(Default)]
@@ -1521,7 +1714,7 @@ mod tests {
         fn smoke_status<'a>(
             &'a self,
             _config: &'a ErvConfig,
-        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        ) -> ErvBoxFutureResult<'a, ErvDeviceStatus> {
             self.smoke_calls.fetch_add(1, Ordering::SeqCst);
             let result = self
                 .smoke_results
@@ -1536,7 +1729,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
             speed: ErvFanSpeed,
-        ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        ) -> ErvBoxFutureResult<'a, ErvDeviceStatus> {
             self.write_speeds
                 .lock()
                 .expect("fake writer speeds lock")
@@ -1547,6 +1740,74 @@ mod tests {
                 .expect("fake writer write lock")
                 .pop_front()
                 .unwrap_or_else(|| anyhow::bail!("no fake ERV write result configured"));
+            Box::pin(async move { result })
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeHvacWriter {
+        smoke_results: Mutex<VecDeque<Result<HvacDeviceStatus>>>,
+        write_results: Mutex<VecDeque<Result<HvacDeviceStatus>>>,
+        smoke_calls: AtomicUsize,
+        write_modes: Mutex<Vec<(HvacControlMode, Option<f64>)>>,
+    }
+
+    impl FakeHvacWriter {
+        fn new(
+            smoke_results: Vec<Result<HvacDeviceStatus>>,
+            write_results: Vec<Result<HvacDeviceStatus>>,
+        ) -> Self {
+            Self {
+                smoke_results: Mutex::new(smoke_results.into()),
+                write_results: Mutex::new(write_results.into()),
+                smoke_calls: AtomicUsize::new(0),
+                write_modes: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn smoke_calls(&self) -> usize {
+            self.smoke_calls.load(Ordering::SeqCst)
+        }
+
+        fn write_modes(&self) -> Vec<(HvacControlMode, Option<f64>)> {
+            self.write_modes
+                .lock()
+                .expect("fake HVAC modes lock")
+                .clone()
+        }
+    }
+
+    impl HvacModeWriter for FakeHvacWriter {
+        fn smoke_status<'a>(
+            &'a self,
+            _config: &'a MitsubishiConfig,
+        ) -> crate::hvac::BoxFutureResult<'a, HvacDeviceStatus> {
+            self.smoke_calls.fetch_add(1, Ordering::SeqCst);
+            let result = self
+                .smoke_results
+                .lock()
+                .expect("fake HVAC smoke lock")
+                .pop_front()
+                .unwrap_or_else(|| anyhow::bail!("no fake HVAC smoke result configured"));
+            Box::pin(async move { result })
+        }
+
+        fn set_mode<'a>(
+            &'a self,
+            _config: &'a MitsubishiConfig,
+            mode: HvacControlMode,
+            setpoint_c: Option<f64>,
+        ) -> crate::hvac::BoxFutureResult<'a, HvacDeviceStatus> {
+            self.write_modes
+                .lock()
+                .expect("fake HVAC modes lock")
+                .push((mode, setpoint_c));
+            let result = self
+                .write_results
+                .lock()
+                .expect("fake HVAC write lock")
+                .pop_front()
+                .unwrap_or_else(|| anyhow::bail!("no fake HVAC write result configured"));
             Box::pin(async move { result })
         }
     }
@@ -1619,9 +1880,31 @@ mod tests {
         config
     }
 
+    fn configured_hvac_config(active_control_enabled: bool) -> AppConfig {
+        let mut config = test_config();
+        config.mitsubishi = MitsubishiConfig {
+            device_type: "kumo".to_string(),
+            username: Some("kumo-user".to_string()),
+            password: Some("kumo-pass".to_string()),
+            device_serial: Some("kumo-serial".to_string()),
+            active_control_enabled,
+            ..MitsubishiConfig::default()
+        };
+        config
+    }
+
     fn qingping_with_co2(co2_ppm: i64) -> QingpingState {
         let qingping = QingpingState::default();
         qingping.apply_reading(qingping_reading(co2_ppm));
+        qingping
+    }
+
+    fn qingping_with_temp(temp_c: f64) -> QingpingState {
+        let qingping = QingpingState::default();
+        qingping.apply_reading(crate::qingping::QingpingReading {
+            temp_c: Some(temp_c),
+            ..qingping_reading(500)
+        });
         qingping
     }
 
@@ -1638,6 +1921,32 @@ mod tests {
             noise_db: Some(35),
             timestamp: "2026-06-05T12:30:00".to_string(),
             raw_data: "{}".to_string(),
+        }
+    }
+
+    fn hvac_status(mode: HvacControlMode, setpoint_c: f64) -> HvacDeviceStatus {
+        match mode {
+            HvacControlMode::Off => parse_kumo_adapter_status(&json!({
+                "power": 0,
+                "operationMode": "off",
+                "spHeat": 22.0,
+                "spCool": 25.5
+            }))
+            .expect("HVAC off status"),
+            HvacControlMode::Heat => parse_kumo_adapter_status(&json!({
+                "power": 1,
+                "operationMode": "heat",
+                "spHeat": setpoint_c,
+                "spCool": 25.5
+            }))
+            .expect("HVAC heat status"),
+            HvacControlMode::Cool => parse_kumo_adapter_status(&json!({
+                "power": 1,
+                "operationMode": "cool",
+                "spHeat": 22.0,
+                "spCool": setpoint_c
+            }))
+            .expect("HVAC cool status"),
         }
     }
 
@@ -1660,6 +1969,29 @@ mod tests {
             erv_state,
             HvacState::default(),
             writer,
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app")
+    }
+
+    fn app_with_hvac_writer(config: AppConfig, writer: Arc<dyn HvacModeWriter>) -> Router {
+        let qingping = QingpingState::default();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer,
         )
         .expect("app")
     }
@@ -1680,6 +2012,7 @@ mod tests {
             erv_state,
             hvac_state,
             Arc::new(FakeErvWriter::default()),
+            Arc::new(FakeHvacWriter::default()),
         )
         .expect("app")
     }
@@ -2444,6 +2777,455 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0]["action"], "turbo");
         assert_eq!(actions[0]["reason"], "manual_override");
+    }
+
+    #[tokio::test]
+    async fn manual_hvac_write_requires_active_control_gate() {
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Heat, 21.1))],
+        ));
+        let service = app_with_hvac_writer(configured_hvac_config(false), writer.clone());
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"mode":"heat","setpoint_f":70}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            value["error"]
+                .as_str()
+                .expect("error")
+                .contains("active control is disabled")
+        );
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn manual_hvac_write_surfaces_device_failure() {
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Err(anyhow::anyhow!("fake HVAC write failed"))],
+        ));
+        let service = app_with_hvac_writer(configured_hvac_config(true), writer.clone());
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"mode":"heat","setpoint_f":70}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            value["error"]
+                .as_str()
+                .expect("error")
+                .contains("fake HVAC write failed")
+        );
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Heat, Some(fahrenheit_to_celsius(70.0)))]
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_hvac_write_smokes_writes_logs_and_broadcasts_status() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 21.1111111111))],
+        ));
+        let service = app_with_hvac_writer(config.clone(), writer.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("addr");
+        let server_service = service.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                server_service.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .expect("server");
+        });
+
+        let (mut ws, _) = connect_async(format!("ws://{address}/ws"))
+            .await
+            .expect("connect");
+        timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("initial timeout")
+            .expect("initial message")
+            .expect("initial ok");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"mode":"cool","setpoint_f":70}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["hvac"]["mode"], "cool");
+        assert_eq!(value["hvac"]["setpoint_f"], 70.0);
+        assert_eq!(value["hvac"]["setpoint_c"], 21.1);
+        assert_eq!(value["hvac"]["manual_override"], true);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Cool, Some(fahrenheit_to_celsius(70.0)))]
+        );
+
+        let update = timeout(Duration::from_secs(1), ws.next())
+            .await
+            .expect("update timeout")
+            .expect("update message")
+            .expect("update ok");
+        assert!(
+            update
+                .into_text()
+                .expect("text")
+                .contains("\"manual_override\"")
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "hvac");
+        assert_eq!(value["climate_actions"][0]["action"], "cool");
+        assert_eq!(value["climate_actions"][0]["reason"], "manual_override");
+        assert_eq!(
+            value["climate_actions"][0]["setpoint"],
+            fahrenheit_to_celsius(70.0)
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_turns_off_for_safety_interlock() {
+        let config = configured_hvac_config(true);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .update_door(true, unix_timestamp_now());
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Heat, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+        ));
+        let service = try_app_with_erv_writer(
+            config.clone(),
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "hvac");
+        assert_eq!(value["climate_actions"][0]["action"], "off");
+        assert_eq!(value["climate_actions"][0]["reason"], "safety_interlock");
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_respects_disabled_active_control_gate() {
+        let config = configured_hvac_config(false);
+        let writer = Arc::new(FakeHvacWriter::new(Vec::new(), Vec::new()));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let service = try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_clears_manual_override_on_state_transition() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+            ],
+            vec![
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+                Ok(hvac_status(HvacControlMode::Cool, 25.5)),
+            ],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let service = try_app_with_erv_writer(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"mode":"off","setpoint_f":70}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("manual response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("status response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read status");
+        let value: Value = serde_json::from_slice(&body).expect("status json");
+        assert_eq!(value["manual_override"]["hvac"], true);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("presence response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 2);
+        assert_eq!(
+            writer.write_modes(),
+            vec![
+                (HvacControlMode::Off, Some(fahrenheit_to_celsius(70.0))),
+                (HvacControlMode::Cool, Some(25.5)),
+            ]
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("status response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read status");
+        let value: Value = serde_json::from_slice(&body).expect("status json");
+        assert_eq!(value["manual_override"]["hvac"], false);
+        assert_eq!(value["hvac"]["mode"], "cool");
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_starts_cooling_for_hot_present_room() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(
+                HvacControlMode::Cool,
+                fahrenheit_to_celsius(78.0),
+            ))],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let service = try_app_with_erv_writer(
+            config.clone(),
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"present"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Cool, Some(25.5))]
+        );
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "hvac");
+        assert_eq!(value["climate_actions"][0]["action"], "cool");
+        assert_eq!(value["climate_actions"][0]["reason"], "cool_band_start_82F");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -40,7 +40,10 @@ use crate::{
     erv::{
         ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
     },
-    hvac::{HvacControlMode, HvacModeWriter, HvacRuntimeSnapshot, HvacState, KumoHvacModeWriter},
+    hvac::{
+        HvacControlMode, HvacModeCommand, HvacModeWriter, HvacRuntimeSnapshot, HvacState,
+        KumoHvacModeWriter,
+    },
     mqtt,
     policy::{ErvPolicyState, HvacBandAction, HvacMode, get_hvac_band_action},
     qingping::QingpingState,
@@ -840,6 +843,8 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .smoke_status_with(&state.config.mitsubishi, state.hvac_writer.as_ref())
             .await?;
         if let Some(previous_mode) = active_hvac_control_mode(&verified_status.mode) {
+            let previous_heat_setpoint_c = verified_status.heat_setpoint_c;
+            let previous_cool_setpoint_c = verified_status.cool_setpoint_c;
             apply_hvac_mode_after_verified_status(
                 state,
                 HvacControlMode::Off,
@@ -847,7 +852,12 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 "safety_interlock",
             )
             .await?;
-            state.hvac.set_suspended(true, Some(previous_mode));
+            state.hvac.set_suspended_with_setpoints(
+                true,
+                Some(previous_mode),
+                previous_heat_setpoint_c,
+                previous_cool_setpoint_c,
+            );
             state.hvac.set_temp_band_mode(None);
             state.hvac.clear_manual_override();
             broadcast_status(state);
@@ -890,6 +900,8 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .smoke_status_with(&state.config.mitsubishi, state.hvac_writer.as_ref())
             .await?;
         if let Some(previous_mode) = active_hvac_control_mode(&verified_status.mode) {
+            let previous_heat_setpoint_c = verified_status.heat_setpoint_c;
+            let previous_cool_setpoint_c = verified_status.cool_setpoint_c;
             let temp_label = temp_f.expect("ERV suspension temperature checked").round() as i64;
             apply_hvac_mode_after_verified_status(
                 state,
@@ -898,7 +910,12 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 &format!("erv_running_temp_{temp_label}F"),
             )
             .await?;
-            state.hvac.set_suspended(true, Some(previous_mode));
+            state.hvac.set_suspended_with_setpoints(
+                true,
+                Some(previous_mode),
+                previous_heat_setpoint_c,
+                previous_cool_setpoint_c,
+            );
             state.hvac.set_temp_band_mode(None);
             broadcast_status(state);
         }
@@ -934,16 +951,43 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 erv_snapshot.running,
                 within_occupancy_hours,
             ) {
-                let setpoint_c = match restore_mode {
-                    HvacControlMode::Heat => Some(hvac_snapshot.heat_setpoint_c.unwrap_or(22.0)),
-                    HvacControlMode::Cool => {
-                        Some(hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
-                            fahrenheit_to_celsius(
-                                state.config.thresholds.hvac_cool_setpoint_f as f64,
-                            )
-                        }))
-                    }
-                    HvacControlMode::Auto => None,
+                let command = match restore_mode {
+                    HvacControlMode::Heat => HvacModeCommand::new(
+                        HvacControlMode::Heat,
+                        Some(
+                            hvac_snapshot
+                                .suspended_heat_setpoint_c
+                                .or(hvac_snapshot.heat_setpoint_c)
+                                .unwrap_or(22.0),
+                        ),
+                    ),
+                    HvacControlMode::Cool => HvacModeCommand::new(
+                        HvacControlMode::Cool,
+                        Some(
+                            hvac_snapshot
+                                .suspended_cool_setpoint_c
+                                .or(hvac_snapshot.cool_setpoint_c)
+                                .unwrap_or_else(|| {
+                                    fahrenheit_to_celsius(
+                                        state.config.thresholds.hvac_cool_setpoint_f as f64,
+                                    )
+                                }),
+                        ),
+                    ),
+                    HvacControlMode::Auto => HvacModeCommand::auto(
+                        hvac_snapshot
+                            .suspended_heat_setpoint_c
+                            .or(hvac_snapshot.heat_setpoint_c)
+                            .unwrap_or(22.0),
+                        hvac_snapshot
+                            .suspended_cool_setpoint_c
+                            .or(hvac_snapshot.cool_setpoint_c)
+                            .unwrap_or_else(|| {
+                                fahrenheit_to_celsius(
+                                    state.config.thresholds.hvac_cool_setpoint_f as f64,
+                                )
+                            }),
+                    ),
                     HvacControlMode::Off => unreachable!("restore mode is never off"),
                 };
                 let reason = if state_status.is_present {
@@ -951,7 +995,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 } else {
                     "erv_stopped_occupancy_hours"
                 };
-                apply_hvac_mode(state, restore_mode, setpoint_c, reason).await?;
+                apply_hvac_mode_command(state, command, reason).await?;
                 state.hvac.set_suspended(false, None);
                 state.hvac.set_temp_band_mode(None);
                 broadcast_status(state);
@@ -1029,6 +1073,22 @@ async fn apply_hvac_mode(
             state.hvac_writer.as_ref(),
             mode,
             setpoint_c,
+            reason,
+        )
+        .await
+}
+
+async fn apply_hvac_mode_command(
+    state: &AppState,
+    command: HvacModeCommand,
+    reason: &str,
+) -> Result<crate::hvac::HvacDeviceStatus> {
+    state
+        .hvac
+        .set_mode_command_with(
+            &state.config.mitsubishi,
+            state.hvac_writer.as_ref(),
+            command,
             reason,
         )
         .await
@@ -1979,7 +2039,7 @@ mod tests {
         smoke_results: Mutex<VecDeque<Result<HvacDeviceStatus>>>,
         write_results: Mutex<VecDeque<Result<HvacDeviceStatus>>>,
         smoke_calls: AtomicUsize,
-        write_modes: Mutex<Vec<(HvacControlMode, Option<f64>)>>,
+        write_commands: Mutex<Vec<HvacModeCommand>>,
     }
 
     impl FakeHvacWriter {
@@ -1991,7 +2051,7 @@ mod tests {
                 smoke_results: Mutex::new(smoke_results.into()),
                 write_results: Mutex::new(write_results.into()),
                 smoke_calls: AtomicUsize::new(0),
-                write_modes: Mutex::new(Vec::new()),
+                write_commands: Mutex::new(Vec::new()),
             }
         }
 
@@ -2000,9 +2060,18 @@ mod tests {
         }
 
         fn write_modes(&self) -> Vec<(HvacControlMode, Option<f64>)> {
-            self.write_modes
+            self.write_commands
                 .lock()
-                .expect("fake HVAC modes lock")
+                .expect("fake HVAC commands lock")
+                .iter()
+                .map(|command| (command.mode, command.setpoint_c))
+                .collect()
+        }
+
+        fn write_commands(&self) -> Vec<HvacModeCommand> {
+            self.write_commands
+                .lock()
+                .expect("fake HVAC commands lock")
                 .clone()
         }
     }
@@ -2028,10 +2097,18 @@ mod tests {
             mode: HvacControlMode,
             setpoint_c: Option<f64>,
         ) -> crate::hvac::BoxFutureResult<'a, HvacDeviceStatus> {
-            self.write_modes
+            self.set_mode_command(_config, HvacModeCommand::new(mode, setpoint_c))
+        }
+
+        fn set_mode_command<'a>(
+            &'a self,
+            _config: &'a MitsubishiConfig,
+            command: HvacModeCommand,
+        ) -> crate::hvac::BoxFutureResult<'a, HvacDeviceStatus> {
+            self.write_commands
                 .lock()
-                .expect("fake HVAC modes lock")
-                .push((mode, setpoint_c));
+                .expect("fake HVAC commands lock")
+                .push(command);
             let result = self
                 .write_results
                 .lock()
@@ -2196,6 +2273,16 @@ mod tests {
             }))
             .expect("HVAC auto status"),
         }
+    }
+
+    fn hvac_auto_status(heat_setpoint_c: f64, cool_setpoint_c: f64) -> HvacDeviceStatus {
+        parse_kumo_adapter_status(&json!({
+            "power": 1,
+            "operationMode": "auto",
+            "spHeat": heat_setpoint_c,
+            "spCool": cool_setpoint_c
+        }))
+        .expect("HVAC auto status")
     }
 
     fn office_door_device() -> yolink::YoLinkDevice {
@@ -3514,15 +3601,15 @@ mod tests {
         let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
         let erv_state = ErvState::new(config.runtime.database_path.clone());
         let hvac_state = HvacState::new(config.runtime.database_path.clone());
-        hvac_state.record_status(hvac_status(HvacControlMode::Auto, 22.0));
+        hvac_state.record_status(hvac_auto_status(20.0, 26.0));
         let writer = Arc::new(FakeHvacWriter::new(
             vec![
-                Ok(hvac_status(HvacControlMode::Auto, 22.0)),
+                Ok(hvac_auto_status(20.0, 26.0)),
                 Ok(hvac_status(HvacControlMode::Off, 22.0)),
             ],
             vec![
                 Ok(hvac_status(HvacControlMode::Off, 22.0)),
-                Ok(hvac_status(HvacControlMode::Auto, 22.0)),
+                Ok(hvac_auto_status(20.0, 26.0)),
             ],
         ));
         let qingping = qingping_with_temp(fahrenheit_to_celsius(72.0));
@@ -3551,8 +3638,11 @@ mod tests {
 
         assert_eq!(writer.smoke_calls(), 2);
         assert_eq!(
-            writer.write_modes(),
-            vec![(HvacControlMode::Off, None), (HvacControlMode::Auto, None),]
+            writer.write_commands(),
+            vec![
+                HvacModeCommand::new(HvacControlMode::Off, None),
+                HvacModeCommand::auto(20.0, 26.0),
+            ]
         );
         let snapshot = state.hvac.snapshot();
         assert_eq!(snapshot.mode, "auto");

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -39,7 +39,7 @@ use crate::{
     erv::{
         ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
     },
-    hvac::{HvacControlMode, HvacModeWriter, HvacState, KumoHvacModeWriter},
+    hvac::{HvacControlMode, HvacModeWriter, HvacRuntimeSnapshot, HvacState, KumoHvacModeWriter},
     mqtt,
     policy::{ErvPolicyState, HvacBandAction, HvacMode, get_hvac_band_action},
     qingping::QingpingState,
@@ -144,7 +144,7 @@ fn try_app_with_erv_writer_and_coordinator(
     hvac_state: HvacState,
     erv_writer: Arc<dyn ErvSpeedWriter>,
     hvac_writer: Arc<dyn HvacModeWriter>,
-) -> Result<(Router, ErvPolicyCoordinator)> {
+) -> Result<(Router, AppState)> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
@@ -234,11 +234,11 @@ fn try_app_with_erv_writer_and_coordinator(
             state.clone(),
             auth_middleware,
         ))
-        .with_state(state)
+        .with_state(state.clone())
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 
-    Ok((router, erv_automation))
+    Ok((router, state))
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
@@ -254,7 +254,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
     let hvac_state = HvacState::new(config.runtime.database_path.clone());
-    let (app, erv_automation) = try_app_with_erv_writer_and_coordinator(
+    let (app, app_state) = try_app_with_erv_writer_and_coordinator(
         config.clone(),
         qingping.clone(),
         state_machine,
@@ -265,25 +265,43 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         Arc::new(KumoHvacModeWriter),
     )
     .context("failed to build HTTP app")?;
+    let erv_automation = app_state.erv_automation.clone();
     let runtime_handle = tokio::runtime::Handle::current();
     let qingping_policy_trigger: mqtt::SensorIngressHook = Arc::new({
         let erv_automation = erv_automation.clone();
+        let app_state = app_state.clone();
+        let runtime_handle = runtime_handle.clone();
         move || {
             let erv_automation = erv_automation.clone();
+            let app_state = app_state.clone();
             runtime_handle.spawn(async move {
-                if let Err(error) = erv_automation.evaluate_erv_policy(false).await {
-                    tracing::warn!(
-                        "ERV automated policy apply failed after Qingping update: {error:#}"
-                    );
-                }
-                erv_automation.broadcast_status();
+                evaluate_sensor_policies(erv_automation, app_state, false, "Qingping").await;
             });
         }
     });
     let _mqtt_runtime =
         mqtt::start_qingping_ingress(&config, qingping, Some(qingping_policy_trigger))
             .context("failed to start MQTT ingress")?;
-    let _yolink_task = yolink::start_yolink_client(&config, yolink, Some(erv_automation.clone()));
+    let yolink_hvac_trigger: yolink::DeviceIngressHook = Arc::new({
+        let app_state = app_state.clone();
+        let runtime_handle = runtime_handle.clone();
+        move || {
+            let app_state = app_state.clone();
+            runtime_handle.spawn(async move {
+                if let Err(error) = evaluate_and_apply_hvac_policy(&app_state).await {
+                    tracing::warn!(
+                        "HVAC automated policy apply failed after YoLink update: {error:#}"
+                    );
+                }
+            });
+        }
+    });
+    let _yolink_task = yolink::start_yolink_client(
+        &config,
+        yolink,
+        Some(erv_automation.clone()),
+        Some(yolink_hvac_trigger),
+    );
     let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
     let _hvac_task = crate::hvac::start_hvac_status_poll(&config, hvac_state);
 
@@ -532,6 +550,21 @@ fn broadcast_status(state: &AppState) {
     let _ = state.status_broadcast.send(());
 }
 
+async fn evaluate_sensor_policies(
+    erv_automation: ErvPolicyCoordinator,
+    state: AppState,
+    bypass_dwell: bool,
+    source: &'static str,
+) {
+    if let Err(error) = erv_automation.evaluate_erv_policy(bypass_dwell).await {
+        tracing::warn!("ERV automated policy apply failed after {source} update: {error:#}");
+    }
+    if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+        tracing::warn!("HVAC automated policy apply failed after {source} update: {error:#}");
+    }
+    erv_automation.broadcast_status();
+}
+
 fn unix_timestamp_now() -> f64 {
     chrono::Local::now().timestamp_millis() as f64 / 1_000.0
 }
@@ -772,6 +805,13 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         machine.status_at(now)
     };
     let hvac_snapshot = state.hvac.snapshot();
+    let temp_f = state
+        .qingping
+        .latest()
+        .and_then(|reading| reading.temp_c)
+        .map(celsius_to_fahrenheit);
+    let bands = active_temperature_bands(state);
+    let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
 
     if state_status.safety_interlock {
         if hvac_snapshot.mode != "off" {
@@ -783,20 +823,32 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         return Ok(());
     }
 
-    let temp_f = state
-        .qingping
-        .latest()
-        .and_then(|reading| reading.temp_c)
-        .map(celsius_to_fahrenheit);
-    let bands = active_temperature_bands(state);
+    if !state_status.is_present
+        && temp_f.is_some_and(|temp_f| temp_f < state.config.thresholds.hvac_critical_temp_f as f64)
+        && hvac_mode != HvacMode::Heat
+    {
+        let temp_label = temp_f.expect("critical temperature checked").round() as i64;
+        let setpoint_c = hvac_snapshot.heat_setpoint_c.unwrap_or(22.0);
+        apply_hvac_mode(
+            state,
+            HvacControlMode::Heat,
+            Some(setpoint_c),
+            &format!("critical_temp_{temp_label}F"),
+        )
+        .await?;
+        state.hvac.set_suspended(false, None);
+        state.hvac.set_temp_band_mode(None);
+        broadcast_status(state);
+        return Ok(());
+    }
+
     let temp_band_mode = hvac_snapshot
         .temp_band_mode
         .as_deref()
         .and_then(hvac_mode_from_str);
-    let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
     let erv_snapshot = state.erv.snapshot();
 
-    let Some(action) = get_hvac_band_action(
+    let action = get_hvac_band_action(
         temp_f,
         hvac_mode,
         temp_band_mode,
@@ -812,13 +864,38 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         bands.heat_on_temp_f as f64,
         bands.cool_on_temp_f as f64,
         bands.cool_off_temp_f as f64,
-    ) else {
-        return Ok(());
-    };
+    );
 
     let temp_label = temp_f.unwrap_or_default().round() as i64;
     match action {
-        HvacBandAction::PauseHeat => {
+        None => {
+            if let Some(restore_mode) = suspended_restore_mode(
+                &hvac_snapshot,
+                temp_f,
+                bands,
+                state_status.is_present,
+                erv_snapshot.running,
+            ) {
+                let setpoint_c = match restore_mode {
+                    HvacControlMode::Heat => hvac_snapshot.heat_setpoint_c.unwrap_or(22.0),
+                    HvacControlMode::Cool => hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
+                        fahrenheit_to_celsius(state.config.thresholds.hvac_cool_setpoint_f as f64)
+                    }),
+                    HvacControlMode::Off => unreachable!("restore mode is never off"),
+                };
+                let reason = if state_status.is_present {
+                    "present_restore"
+                } else {
+                    "erv_stopped_occupancy_hours"
+                };
+                apply_hvac_mode(state, restore_mode, Some(setpoint_c), reason).await?;
+                state.hvac.set_suspended(false, None);
+                state.hvac.set_temp_band_mode(None);
+                broadcast_status(state);
+            }
+            return Ok(());
+        }
+        Some(HvacBandAction::PauseHeat) => {
             apply_hvac_mode(
                 state,
                 HvacControlMode::Off,
@@ -828,7 +905,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .await?;
             state.hvac.set_temp_band_mode(Some(HvacControlMode::Heat));
         }
-        HvacBandAction::ResumeHeat => {
+        Some(HvacBandAction::ResumeHeat) => {
             let setpoint_c = hvac_snapshot.heat_setpoint_c.unwrap_or(22.0);
             apply_hvac_mode(
                 state,
@@ -840,7 +917,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             state.hvac.set_suspended(false, None);
             state.hvac.set_temp_band_mode(None);
         }
-        HvacBandAction::StopCool => {
+        Some(HvacBandAction::StopCool) => {
             apply_hvac_mode(
                 state,
                 HvacControlMode::Off,
@@ -850,7 +927,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .await?;
             state.hvac.set_temp_band_mode(Some(HvacControlMode::Cool));
         }
-        HvacBandAction::StartCool => {
+        Some(HvacBandAction::StartCool) => {
             let setpoint_c = hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
                 fahrenheit_to_celsius(state.config.thresholds.hvac_cool_setpoint_f as f64)
             });
@@ -913,6 +990,44 @@ fn hvac_mode_from_str(value: &str) -> Option<HvacMode> {
         "cool" => Some(HvacMode::Cool),
         "auto" => Some(HvacMode::Auto),
         _ => None,
+    }
+}
+
+fn suspended_restore_mode(
+    snapshot: &HvacRuntimeSnapshot,
+    temp_f: Option<f64>,
+    bands: TemperatureBands,
+    is_present: bool,
+    erv_running: bool,
+) -> Option<HvacControlMode> {
+    if !snapshot.suspended || (!is_present && erv_running) {
+        return None;
+    }
+
+    let mode = snapshot
+        .last_mode
+        .as_deref()
+        .and_then(HvacControlMode::parse)?;
+    if should_restore_hvac_mode(mode, temp_f, bands) {
+        Some(mode)
+    } else {
+        None
+    }
+}
+
+fn should_restore_hvac_mode(
+    mode: HvacControlMode,
+    temp_f: Option<f64>,
+    bands: TemperatureBands,
+) -> bool {
+    let Some(temp_f) = temp_f else {
+        return true;
+    };
+
+    match mode {
+        HvacControlMode::Heat => temp_f < bands.heat_off_temp_f as f64,
+        HvacControlMode::Cool => temp_f > bands.cool_off_temp_f as f64,
+        HvacControlMode::Off => false,
     }
 }
 
@@ -1947,6 +2062,19 @@ mod tests {
                 "spCool": setpoint_c
             }))
             .expect("HVAC cool status"),
+        }
+    }
+
+    fn office_door_device() -> yolink::YoLinkDevice {
+        yolink::YoLinkDevice {
+            device_id: "door-1".to_string(),
+            name: "Office Door".to_string(),
+            token: "door-token".to_string(),
+            device_type: yolink::DeviceType::DoorSensor,
+            state: json!({"state": "closed", "online": true})
+                .as_object()
+                .expect("object")
+                .clone(),
         }
     }
 
@@ -3014,6 +3142,150 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn yolink_safety_event_drives_hvac_policy_without_route_update() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now);
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        yolink.apply_devices(vec![office_door_device()]);
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Heat, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+        ));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink.clone(),
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        yolink
+            .apply_event("door-1", json!({"state": "open"}), now + 1.0)
+            .expect("event applies");
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies");
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_restores_suspended_heat_after_safety_clears() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state machine lock poisoned");
+            machine.set_manual_presence(true, now);
+            machine.update_door(true, now + 1.0);
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Heat, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![
+                Ok(hvac_status(HvacControlMode::Heat, 22.0)),
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+            ],
+            vec![
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+                Ok(hvac_status(HvacControlMode::Heat, 22.0)),
+            ],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(68.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine.clone(),
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies safety off");
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .update_door(false, now + 2.0);
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy restores heat");
+
+        assert_eq!(writer.smoke_calls(), 2);
+        assert_eq!(
+            writer.write_modes(),
+            vec![
+                (HvacControlMode::Off, None),
+                (HvacControlMode::Heat, Some(22.0)),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_heats_away_room_below_critical_temp() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(54.0));
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies");
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Heat, Some(22.0))]
+        );
+    }
+
+    #[tokio::test]
     async fn automated_hvac_policy_respects_disabled_active_control_gate() {
         let config = configured_hvac_config(false);
         let writer = Arc::new(FakeHvacWriter::new(Vec::new(), Vec::new()));
@@ -3226,6 +3498,56 @@ mod tests {
         assert_eq!(value["climate_actions"][0]["system"], "hvac");
         assert_eq!(value["climate_actions"][0]["action"], "cool");
         assert_eq!(value["climate_actions"][0]["reason"], "cool_band_start_82F");
+    }
+
+    #[tokio::test]
+    async fn qingping_sensor_update_drives_hvac_policy_without_route_update() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(
+                HvacControlMode::Cool,
+                fahrenheit_to_celsius(78.0),
+            ))],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, unix_timestamp_now());
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_sensor_policies(
+            state.erv_automation.clone(),
+            state.clone(),
+            false,
+            "Qingping",
+        )
+        .await;
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Cool, Some(25.5))]
+        );
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -289,14 +289,10 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     let yolink_hvac_trigger: yolink::DeviceIngressHook = Arc::new({
         let app_state = app_state.clone();
         let runtime_handle = runtime_handle.clone();
-        move || {
+        move |transition| {
             let app_state = app_state.clone();
             runtime_handle.spawn(async move {
-                if let Err(error) = evaluate_and_apply_hvac_policy(&app_state).await {
-                    tracing::warn!(
-                        "HVAC automated policy apply failed after YoLink update: {error:#}"
-                    );
-                }
+                evaluate_yolink_hvac_update(app_state, transition).await;
             });
         }
     });
@@ -567,6 +563,13 @@ async fn evaluate_sensor_policies(
         tracing::warn!("HVAC automated policy apply failed after {source} update: {error:#}");
     }
     erv_automation.broadcast_status();
+}
+
+async fn evaluate_yolink_hvac_update(state: AppState, transition: Option<StateTransition>) {
+    clear_hvac_manual_override_on_transition(&state, transition);
+    if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+        tracing::warn!("HVAC automated policy apply failed after YoLink update: {error:#}");
+    }
 }
 
 fn unix_timestamp_now() -> f64 {
@@ -2298,6 +2301,19 @@ mod tests {
         }
     }
 
+    fn office_motion_device() -> yolink::YoLinkDevice {
+        yolink::YoLinkDevice {
+            device_id: "motion-1".to_string(),
+            name: "Office Motion".to_string(),
+            token: "motion-token".to_string(),
+            device_type: yolink::DeviceType::MotionSensor,
+            state: json!({"state": "normal", "online": true})
+                .as_object()
+                .expect("object")
+                .clone(),
+        }
+    }
+
     fn app_with_erv_writer(
         config: AppConfig,
         qingping: QingpingState,
@@ -3522,6 +3538,52 @@ mod tests {
 
         assert_eq!(writer.smoke_calls(), 1);
         assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+    }
+
+    #[tokio::test]
+    async fn yolink_transition_clears_hvac_manual_override_before_policy() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        yolink.apply_devices(vec![office_motion_device()]);
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        hvac_state.record_manual_override(HvacControlMode::Off, 70.0);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping_with_temp(28.0),
+            state_machine,
+            yolink.clone(),
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let applied = yolink
+            .apply_event("motion-1", json!({"state": "alert"}), now + 1.0)
+            .expect("event applies")
+            .expect("motion report applies");
+        assert!(applied.transition.is_some());
+
+        evaluate_yolink_hvac_update(state.clone(), applied.transition).await;
+
+        assert!(!state.hvac.manual_override_active());
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Cool, Some(25.5))]
+        );
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -793,7 +793,7 @@ async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> 
 }
 
 async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
-    if !state.config.mitsubishi.active_control_enabled || state.hvac.manual_override_active() {
+    if !state.config.mitsubishi.active_control_enabled {
         return Ok(());
     }
 
@@ -805,6 +805,10 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .expect("state machine lock poisoned");
         machine.status_at(now)
     };
+    if !state_status.safety_interlock && state.hvac.manual_override_active() {
+        return Ok(());
+    }
+
     let hvac_snapshot = state.hvac.snapshot();
     let temp_f = state
         .qingping
@@ -829,6 +833,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .await?;
             state.hvac.set_suspended(true, Some(previous_mode));
             state.hvac.set_temp_band_mode(None);
+            state.hvac.clear_manual_override();
             broadcast_status(state);
         }
         return Ok(());
@@ -3281,6 +3286,52 @@ mod tests {
         assert_eq!(value["climate_actions"][0]["system"], "hvac");
         assert_eq!(value["climate_actions"][0]["action"], "off");
         assert_eq!(value["climate_actions"][0]["reason"], "safety_interlock");
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_safety_interlock_bypasses_manual_override() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state machine lock poisoned");
+            machine.set_manual_presence(true, now);
+            machine.update_door(true, now + 1.0);
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Heat, 22.0));
+        hvac_state.record_manual_override(HvacControlMode::Heat, 70.0);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+        ));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies safety off despite manual override");
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+        assert!(!state.hvac.manual_override_active());
+        let snapshot = state.hvac.snapshot();
+        assert!(snapshot.suspended);
+        assert_eq!(snapshot.last_mode.as_deref(), Some("heat"));
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -566,9 +566,12 @@ async fn evaluate_sensor_policies(
 }
 
 async fn evaluate_yolink_hvac_update(state: AppState, transition: Option<StateTransition>) {
-    clear_hvac_manual_override_on_transition(&state, transition);
+    let cleared_override = clear_hvac_manual_override_on_transition(&state, transition);
     if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
         tracing::warn!("HVAC automated policy apply failed after YoLink update: {error:#}");
+    }
+    if cleared_override {
+        broadcast_status(&state);
     }
 }
 
@@ -827,10 +830,6 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
             .expect("state machine lock poisoned");
         machine.status_at(now)
     };
-    if !state_status.safety_interlock && state.hvac.manual_override_active() {
-        return Ok(());
-    }
-
     let hvac_snapshot = state.hvac.snapshot();
     let temp_f = state
         .qingping
@@ -839,6 +838,17 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         .map(celsius_to_fahrenheit);
     let bands = active_temperature_bands(state);
     let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
+    let critical_heat_needed = !state_status.is_present
+        && temp_f
+            .is_some_and(|temp_f| temp_f < state.config.thresholds.hvac_critical_temp_f as f64)
+        && hvac_mode != HvacMode::Heat;
+
+    if !state_status.safety_interlock
+        && !critical_heat_needed
+        && state.hvac.manual_override_active()
+    {
+        return Ok(());
+    }
 
     if state_status.safety_interlock {
         let verified_status = state
@@ -868,10 +878,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         return Ok(());
     }
 
-    if !state_status.is_present
-        && temp_f.is_some_and(|temp_f| temp_f < state.config.thresholds.hvac_critical_temp_f as f64)
-        && hvac_mode != HvacMode::Heat
-    {
+    if critical_heat_needed {
         let temp_label = temp_f.expect("critical temperature checked").round() as i64;
         let setpoint_c = hvac_snapshot.heat_setpoint_c.unwrap_or(22.0);
         apply_hvac_mode(
@@ -883,6 +890,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         .await?;
         state.hvac.set_suspended(false, None);
         state.hvac.set_temp_band_mode(None);
+        state.hvac.clear_manual_override();
         broadcast_status(state);
         return Ok(());
     }
@@ -1057,10 +1065,14 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
     Ok(())
 }
 
-fn clear_hvac_manual_override_on_transition(state: &AppState, transition: Option<StateTransition>) {
+fn clear_hvac_manual_override_on_transition(
+    state: &AppState,
+    transition: Option<StateTransition>,
+) -> bool {
     if transition.is_some() {
-        state.hvac.clear_manual_override();
+        return state.hvac.clear_manual_override();
     }
+    false
 }
 
 async fn apply_hvac_mode(
@@ -3587,6 +3599,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn yolink_transition_broadcasts_when_only_hvac_override_clears() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        hvac_state.record_manual_override(HvacControlMode::Off, 70.0);
+        let writer = Arc::new(FakeHvacWriter::new(Vec::new(), Vec::new()));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping_with_temp(21.0),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+        let mut receiver = state.status_broadcast.subscribe();
+
+        evaluate_yolink_hvac_update(
+            state.clone(),
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            }),
+        )
+        .await;
+
+        assert!(!state.hvac.manual_override_active());
+        assert_eq!(writer.smoke_calls(), 0);
+        timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast received");
+    }
+
+    #[tokio::test]
     async fn automated_hvac_policy_restores_suspended_heat_after_safety_clears() {
         let config = configured_hvac_config(true);
         let now = unix_timestamp_now();
@@ -3743,6 +3799,47 @@ mod tests {
             .await
             .expect("HVAC policy applies");
 
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Heat, Some(22.0))]
+        );
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_critical_heat_bypasses_manual_override() {
+        let config = configured_hvac_config(true);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(54.0));
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        hvac_state.record_manual_override(HvacControlMode::Off, 70.0);
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies");
+
+        assert!(!state.hvac.manual_override_active());
         assert_eq!(writer.smoke_calls(), 1);
         assert_eq!(
             writer.write_modes(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -20,6 +20,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::{get, get_service, post},
 };
+use chrono::{NaiveTime, Timelike};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::{net::TcpListener, sync::broadcast, time::timeout};
@@ -34,7 +35,7 @@ use crate::{
     artifacts::{ArtifactStore, is_valid_artifact_hash},
     auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
     automation::ErvPolicyCoordinator,
-    config::AppConfig,
+    config::{AppConfig, ThresholdsConfig},
     db,
     erv::{
         ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
@@ -814,10 +815,20 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
     let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
 
     if state_status.safety_interlock {
-        if hvac_snapshot.mode != "off" {
-            let previous_mode = hvac_snapshot.mode.clone();
-            apply_hvac_mode(state, HvacControlMode::Off, None, "safety_interlock").await?;
+        let verified_status = state
+            .hvac
+            .smoke_status_with(&state.config.mitsubishi, state.hvac_writer.as_ref())
+            .await?;
+        if let Some(previous_mode) = active_hvac_control_mode(&verified_status.mode) {
+            apply_hvac_mode_after_verified_status(
+                state,
+                HvacControlMode::Off,
+                None,
+                "safety_interlock",
+            )
+            .await?;
             state.hvac.set_suspended(true, Some(previous_mode));
+            state.hvac.set_temp_band_mode(None);
             broadcast_status(state);
         }
         return Ok(());
@@ -847,24 +858,29 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         .as_deref()
         .and_then(hvac_mode_from_str);
     let erv_snapshot = state.erv.snapshot();
+    let within_occupancy_hours = is_within_occupancy_hours(&state.config.thresholds);
     if !state_status.is_present
         && erv_snapshot.running
         && !hvac_snapshot.suspended
-        && matches!(hvac_mode, HvacMode::Heat | HvacMode::Cool | HvacMode::Auto)
         && temp_f.is_some_and(|temp_f| temp_f > state.config.thresholds.hvac_min_temp_f as f64)
     {
-        let temp_label = temp_f.expect("ERV suspension temperature checked").round() as i64;
-        let previous_mode = hvac_snapshot.mode.clone();
-        apply_hvac_mode(
-            state,
-            HvacControlMode::Off,
-            None,
-            &format!("erv_running_temp_{temp_label}F"),
-        )
-        .await?;
-        state.hvac.set_suspended(true, Some(previous_mode));
-        state.hvac.set_temp_band_mode(None);
-        broadcast_status(state);
+        let verified_status = state
+            .hvac
+            .smoke_status_with(&state.config.mitsubishi, state.hvac_writer.as_ref())
+            .await?;
+        if let Some(previous_mode) = active_hvac_control_mode(&verified_status.mode) {
+            let temp_label = temp_f.expect("ERV suspension temperature checked").round() as i64;
+            apply_hvac_mode_after_verified_status(
+                state,
+                HvacControlMode::Off,
+                None,
+                &format!("erv_running_temp_{temp_label}F"),
+            )
+            .await?;
+            state.hvac.set_suspended(true, Some(previous_mode));
+            state.hvac.set_temp_band_mode(None);
+            broadcast_status(state);
+        }
         return Ok(());
     }
 
@@ -879,7 +895,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         },
         erv_snapshot.running,
         state.config.thresholds.hvac_min_temp_f as f64,
-        true,
+        within_occupancy_hours,
         bands.heat_off_temp_f as f64,
         bands.heat_on_temp_f as f64,
         bands.cool_on_temp_f as f64,
@@ -895,6 +911,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 bands,
                 state_status.is_present,
                 erv_snapshot.running,
+                within_occupancy_hours,
             ) {
                 let setpoint_c = match restore_mode {
                     HvacControlMode::Heat => Some(hvac_snapshot.heat_setpoint_c.unwrap_or(22.0)),
@@ -996,6 +1013,33 @@ async fn apply_hvac_mode(
         .await
 }
 
+async fn apply_hvac_mode_after_verified_status(
+    state: &AppState,
+    mode: HvacControlMode,
+    setpoint_c: Option<f64>,
+    reason: &str,
+) -> Result<crate::hvac::HvacDeviceStatus> {
+    state
+        .hvac
+        .set_mode_after_verified_status_with(
+            &state.config.mitsubishi,
+            state.hvac_writer.as_ref(),
+            mode,
+            setpoint_c,
+            reason,
+        )
+        .await
+}
+
+fn active_hvac_control_mode(mode: &str) -> Option<String> {
+    match HvacControlMode::parse(mode) {
+        Some(HvacControlMode::Heat | HvacControlMode::Cool | HvacControlMode::Auto) => {
+            Some(mode.to_string())
+        }
+        Some(HvacControlMode::Off) | None => None,
+    }
+}
+
 fn fahrenheit_to_celsius(value: f64) -> f64 {
     (value - 32.0) * 5.0 / 9.0
 }
@@ -1018,14 +1062,31 @@ fn hvac_mode_from_str(value: &str) -> Option<HvacMode> {
     }
 }
 
+fn is_within_occupancy_hours(thresholds: &ThresholdsConfig) -> bool {
+    is_within_occupancy_hours_at(thresholds, chrono::Local::now().time())
+}
+
+fn is_within_occupancy_hours_at(thresholds: &ThresholdsConfig, now: NaiveTime) -> bool {
+    let start = NaiveTime::parse_from_str(&thresholds.expected_occupancy_start, "%H:%M");
+    let end = NaiveTime::parse_from_str(&thresholds.expected_occupancy_end, "%H:%M");
+    match (start, end) {
+        (Ok(start), Ok(end)) => start <= now && now <= end,
+        _ => {
+            tracing::warn!("Invalid occupancy hours config, defaulting to 7AM-10PM");
+            (7..22).contains(&now.hour())
+        }
+    }
+}
+
 fn suspended_restore_mode(
     snapshot: &HvacRuntimeSnapshot,
     temp_f: Option<f64>,
     bands: TemperatureBands,
     is_present: bool,
     erv_running: bool,
+    within_occupancy_hours: bool,
 ) -> Option<HvacControlMode> {
-    if !snapshot.suspended || (!is_present && erv_running) {
+    if !snapshot.suspended || (!is_present && (erv_running || !within_occupancy_hours)) {
         return None;
     }
 
@@ -2039,6 +2100,17 @@ mod tests {
             ..MitsubishiConfig::default()
         };
         config
+    }
+
+    fn set_occupancy_window_excluding_now(config: &mut AppConfig) {
+        let current_hour = chrono::Timelike::hour(&chrono::Local::now());
+        let (start, end) = if current_hour < 22 {
+            ("23:00", "23:30")
+        } else {
+            ("00:00", "01:00")
+        };
+        config.thresholds.expected_occupancy_start = start.to_string();
+        config.thresholds.expected_occupancy_end = end.to_string();
     }
 
     fn qingping_with_co2(co2_ppm: i64) -> QingpingState {
@@ -3212,6 +3284,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automated_hvac_policy_reads_device_before_safety_interlock_off() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .update_door(true, now + 1.0);
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+        ));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies safety off from fresh status");
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+        let snapshot = state.hvac.snapshot();
+        assert!(snapshot.suspended);
+        assert_eq!(snapshot.last_mode.as_deref(), Some("heat"));
+    }
+
+    #[tokio::test]
     async fn yolink_safety_event_drives_hvac_policy_without_route_update() {
         let config = configured_hvac_config(true);
         let now = unix_timestamp_now();
@@ -3414,6 +3529,44 @@ mod tests {
             writer.write_modes(),
             vec![(HvacControlMode::Heat, Some(22.0))]
         );
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_skips_away_heat_band_resume_outside_occupancy_hours() {
+        let mut config = configured_hvac_config(true);
+        set_occupancy_window_excluding_now(&mut config);
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(70.0));
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        hvac_state.set_temp_band_mode(Some(HvacControlMode::Heat));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy respects occupancy hours");
+
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -847,6 +847,26 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
         .as_deref()
         .and_then(hvac_mode_from_str);
     let erv_snapshot = state.erv.snapshot();
+    if !state_status.is_present
+        && erv_snapshot.running
+        && !hvac_snapshot.suspended
+        && matches!(hvac_mode, HvacMode::Heat | HvacMode::Cool | HvacMode::Auto)
+        && temp_f.is_some_and(|temp_f| temp_f > state.config.thresholds.hvac_min_temp_f as f64)
+    {
+        let temp_label = temp_f.expect("ERV suspension temperature checked").round() as i64;
+        let previous_mode = hvac_snapshot.mode.clone();
+        apply_hvac_mode(
+            state,
+            HvacControlMode::Off,
+            None,
+            &format!("erv_running_temp_{temp_label}F"),
+        )
+        .await?;
+        state.hvac.set_suspended(true, Some(previous_mode));
+        state.hvac.set_temp_band_mode(None);
+        broadcast_status(state);
+        return Ok(());
+    }
 
     let action = get_hvac_band_action(
         temp_f,
@@ -877,10 +897,15 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 erv_snapshot.running,
             ) {
                 let setpoint_c = match restore_mode {
-                    HvacControlMode::Heat => hvac_snapshot.heat_setpoint_c.unwrap_or(22.0),
-                    HvacControlMode::Cool => hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
-                        fahrenheit_to_celsius(state.config.thresholds.hvac_cool_setpoint_f as f64)
-                    }),
+                    HvacControlMode::Heat => Some(hvac_snapshot.heat_setpoint_c.unwrap_or(22.0)),
+                    HvacControlMode::Cool => {
+                        Some(hvac_snapshot.cool_setpoint_c.unwrap_or_else(|| {
+                            fahrenheit_to_celsius(
+                                state.config.thresholds.hvac_cool_setpoint_f as f64,
+                            )
+                        }))
+                    }
+                    HvacControlMode::Auto => None,
                     HvacControlMode::Off => unreachable!("restore mode is never off"),
                 };
                 let reason = if state_status.is_present {
@@ -888,7 +913,7 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
                 } else {
                     "erv_stopped_occupancy_hours"
                 };
-                apply_hvac_mode(state, restore_mode, Some(setpoint_c), reason).await?;
+                apply_hvac_mode(state, restore_mode, setpoint_c, reason).await?;
                 state.hvac.set_suspended(false, None);
                 state.hvac.set_temp_band_mode(None);
                 broadcast_status(state);
@@ -1027,6 +1052,7 @@ fn should_restore_hvac_mode(
     match mode {
         HvacControlMode::Heat => temp_f < bands.heat_off_temp_f as f64,
         HvacControlMode::Cool => temp_f > bands.cool_off_temp_f as f64,
+        HvacControlMode::Auto => true,
         HvacControlMode::Off => false,
     }
 }
@@ -1046,6 +1072,13 @@ async fn hvac(State(state): State<AppState>, Json(payload): Json<HvacRequest>) -
         )
             .into_response();
     };
+    if matches!(mode, HvacControlMode::Auto) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "Invalid HVAC mode"})),
+        )
+            .into_response();
+    }
 
     let setpoint_f = payload.setpoint_f.unwrap_or(70.0);
     let setpoint_c = fahrenheit_to_celsius(setpoint_f);
@@ -2062,6 +2095,13 @@ mod tests {
                 "spCool": setpoint_c
             }))
             .expect("HVAC cool status"),
+            HvacControlMode::Auto => parse_kumo_adapter_status(&json!({
+                "power": 1,
+                "operationMode": "auto",
+                "spHeat": 22.0,
+                "spCool": 25.5
+            }))
+            .expect("HVAC auto status"),
         }
     }
 
@@ -2943,6 +2983,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_hvac_write_rejects_auto_mode() {
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Auto, 22.0))],
+        ));
+        let service = app_with_hvac_writer(configured_hvac_config(true), writer.clone());
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/hvac")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"mode":"auto","setpoint_f":70}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["error"], "Invalid HVAC mode");
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
+    }
+
+    #[tokio::test]
     async fn manual_hvac_write_surfaces_device_failure() {
         let writer = Arc::new(FakeHvacWriter::new(
             vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
@@ -3247,6 +3317,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automated_hvac_policy_restores_suspended_auto_after_safety_clears() {
+        let config = configured_hvac_config(true);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state machine lock poisoned");
+            machine.set_manual_presence(true, now);
+            machine.update_door(true, now + 1.0);
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Auto, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![
+                Ok(hvac_status(HvacControlMode::Auto, 22.0)),
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+            ],
+            vec![
+                Ok(hvac_status(HvacControlMode::Off, 22.0)),
+                Ok(hvac_status(HvacControlMode::Auto, 22.0)),
+            ],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(72.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine.clone(),
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies safety off");
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .update_door(false, now + 2.0);
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy restores auto");
+
+        assert_eq!(writer.smoke_calls(), 2);
+        assert_eq!(
+            writer.write_modes(),
+            vec![(HvacControlMode::Off, None), (HvacControlMode::Auto, None),]
+        );
+        let snapshot = state.hvac.snapshot();
+        assert_eq!(snapshot.mode, "auto");
+        assert!(!snapshot.suspended);
+    }
+
+    #[tokio::test]
     async fn automated_hvac_policy_heats_away_room_below_critical_temp() {
         let config = configured_hvac_config(true);
         let writer = Arc::new(FakeHvacWriter::new(
@@ -3282,6 +3413,73 @@ mod tests {
         assert_eq!(
             writer.write_modes(),
             vec![(HvacControlMode::Heat, Some(22.0))]
+        );
+    }
+
+    #[tokio::test]
+    async fn automated_hvac_policy_suspends_heat_while_away_erv_running() {
+        let mut config = configured_hvac_config(true);
+        config.erv = configured_erv_config(true).erv;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let seed_erv_writer = FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Turbo))], vec![]);
+        erv_state
+            .smoke_status_with(&config.erv, &seed_erv_writer)
+            .await
+            .expect("seed ERV running status");
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Heat, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Heat, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+        ));
+        let qingping = qingping_with_temp(fahrenheit_to_celsius(70.0));
+        let (service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies ERV suspension");
+
+        assert_eq!(writer.smoke_calls(), 1);
+        assert_eq!(writer.write_modes(), vec![(HvacControlMode::Off, None)]);
+        let snapshot = state.hvac.snapshot();
+        assert!(snapshot.suspended);
+        assert_eq!(snapshot.last_mode.as_deref(), Some("heat"));
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["climate_actions"][0]["system"], "hvac");
+        assert_eq!(value["climate_actions"][0]["action"], "off");
+        assert_eq!(
+            value["climate_actions"][0]["reason"],
+            "erv_running_temp_70F"
         );
     }
 

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -50,6 +50,34 @@ impl HvacControlMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HvacModeCommand {
+    pub mode: HvacControlMode,
+    pub setpoint_c: Option<f64>,
+    pub heat_setpoint_c: Option<f64>,
+    pub cool_setpoint_c: Option<f64>,
+}
+
+impl HvacModeCommand {
+    pub fn new(mode: HvacControlMode, setpoint_c: Option<f64>) -> Self {
+        Self {
+            mode,
+            setpoint_c,
+            heat_setpoint_c: None,
+            cool_setpoint_c: None,
+        }
+    }
+
+    pub fn auto(heat_setpoint_c: f64, cool_setpoint_c: f64) -> Self {
+        Self {
+            mode: HvacControlMode::Auto,
+            setpoint_c: None,
+            heat_setpoint_c: Some(heat_setpoint_c),
+            cool_setpoint_c: Some(cool_setpoint_c),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct HvacDeviceStatus {
     pub power: bool,
@@ -81,6 +109,14 @@ pub trait HvacModeWriter: Send + Sync {
         mode: HvacControlMode,
         setpoint_c: Option<f64>,
     ) -> BoxFutureResult<'a, HvacDeviceStatus>;
+
+    fn set_mode_command<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+        command: HvacModeCommand,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+        self.set_mode(config, command.mode, command.setpoint_c)
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -115,9 +151,17 @@ impl HvacModeWriter for KumoHvacModeWriter {
         mode: HvacControlMode,
         setpoint_c: Option<f64>,
     ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+        self.set_mode_command(config, HvacModeCommand::new(mode, setpoint_c))
+    }
+
+    fn set_mode_command<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+        command: HvacModeCommand,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus> {
         Box::pin(async move {
             let client = KumoClient::new(config)?;
-            client.send_mode_command(mode, setpoint_c).await?;
+            client.send_mode_command(command).await?;
             client.get_full_status().await
         })
     }
@@ -135,6 +179,8 @@ struct HvacInner {
     latest_status: Option<HvacDeviceStatus>,
     suspended: bool,
     last_mode: Option<String>,
+    suspended_heat_setpoint_c: Option<f64>,
+    suspended_cool_setpoint_c: Option<f64>,
     temp_band_mode: Option<String>,
     manual_override: Option<HvacManualOverride>,
 }
@@ -154,6 +200,8 @@ pub struct HvacRuntimeSnapshot {
     pub cool_setpoint_c: Option<f64>,
     pub suspended: bool,
     pub last_mode: Option<String>,
+    pub suspended_heat_setpoint_c: Option<f64>,
+    pub suspended_cool_setpoint_c: Option<f64>,
     pub temp_band_mode: Option<String>,
 }
 
@@ -199,9 +247,28 @@ impl HvacState {
     where
         W: HvacModeWriter + ?Sized,
     {
+        self.set_mode_command_with(
+            config,
+            writer,
+            HvacModeCommand::new(mode, setpoint_c),
+            reason,
+        )
+        .await
+    }
+
+    pub async fn set_mode_command_with<W>(
+        &self,
+        config: &MitsubishiConfig,
+        writer: &W,
+        command: HvacModeCommand,
+        reason: &str,
+    ) -> Result<HvacDeviceStatus>
+    where
+        W: HvacModeWriter + ?Sized,
+    {
         self.smoke_status_with(config, writer).await?;
-        let status = writer.set_mode(config, mode, setpoint_c).await?;
-        self.record_write_success(status.clone(), mode, setpoint_c, reason);
+        let status = writer.set_mode_command(config, command).await?;
+        self.record_write_success(status.clone(), command.mode, command.setpoint_c, reason);
         Ok(status)
     }
 
@@ -236,10 +303,29 @@ impl HvacState {
     where
         W: HvacModeWriter + ?Sized,
     {
+        self.set_mode_command_after_verified_status_with(
+            config,
+            writer,
+            HvacModeCommand::new(mode, setpoint_c),
+            reason,
+        )
+        .await
+    }
+
+    pub async fn set_mode_command_after_verified_status_with<W>(
+        &self,
+        config: &MitsubishiConfig,
+        writer: &W,
+        command: HvacModeCommand,
+        reason: &str,
+    ) -> Result<HvacDeviceStatus>
+    where
+        W: HvacModeWriter + ?Sized,
+    {
         validate_active_hvac_config(config)?;
 
-        let status = writer.set_mode(config, mode, setpoint_c).await?;
-        self.record_write_success(status.clone(), mode, setpoint_c, reason);
+        let status = writer.set_mode_command(config, command).await?;
+        self.record_write_success(status.clone(), command.mode, command.setpoint_c, reason);
         Ok(status)
     }
 
@@ -277,6 +363,8 @@ impl HvacState {
             cool_setpoint_c: latest.as_ref().and_then(|status| status.cool_setpoint_c),
             suspended: inner.suspended,
             last_mode: inner.last_mode.clone(),
+            suspended_heat_setpoint_c: inner.suspended_heat_setpoint_c,
+            suspended_cool_setpoint_c: inner.suspended_cool_setpoint_c,
             temp_band_mode: inner.temp_band_mode.clone(),
         }
     }
@@ -289,6 +377,8 @@ impl HvacState {
             started_at: unix_timestamp_now(),
         });
         inner.suspended = false;
+        inner.suspended_heat_setpoint_c = None;
+        inner.suspended_cool_setpoint_c = None;
         inner.last_mode = if mode == HvacControlMode::Off {
             None
         } else {
@@ -312,10 +402,27 @@ impl HvacState {
     }
 
     pub fn set_suspended(&self, suspended: bool, last_mode: Option<String>) {
+        self.set_suspended_with_setpoints(suspended, last_mode, None, None);
+    }
+
+    pub fn set_suspended_with_setpoints(
+        &self,
+        suspended: bool,
+        last_mode: Option<String>,
+        heat_setpoint_c: Option<f64>,
+        cool_setpoint_c: Option<f64>,
+    ) {
         let mut inner = self.inner.write().expect("HVAC state lock poisoned");
         inner.suspended = suspended;
         if let Some(last_mode) = last_mode {
             inner.last_mode = Some(last_mode);
+        }
+        if suspended {
+            inner.suspended_heat_setpoint_c = heat_setpoint_c;
+            inner.suspended_cool_setpoint_c = cool_setpoint_c;
+        } else {
+            inner.suspended_heat_setpoint_c = None;
+            inner.suspended_cool_setpoint_c = None;
         }
     }
 
@@ -528,12 +635,9 @@ impl KumoClient {
             .with_context(|| format!("Kumo GET {path} response is not JSON"))
     }
 
-    async fn send_mode_command(
-        &self,
-        mode: HvacControlMode,
-        setpoint_c: Option<f64>,
-    ) -> Result<Value> {
+    async fn send_mode_command(&self, command: HvacModeCommand) -> Result<Value> {
         let token = self.login().await?;
+        let mode = command.mode;
         let mut commands = serde_json::Map::new();
         commands.insert(
             "operationMode".to_string(),
@@ -543,15 +647,23 @@ impl KumoClient {
         match mode {
             HvacControlMode::Off => {}
             HvacControlMode::Heat => {
-                commands.insert("spHeat".to_string(), json!(setpoint_c.unwrap_or(22.0)));
+                commands.insert(
+                    "spHeat".to_string(),
+                    json!(command.setpoint_c.unwrap_or(22.0)),
+                );
             }
             HvacControlMode::Cool => {
-                commands.insert("spCool".to_string(), json!(setpoint_c.unwrap_or(22.0)));
+                commands.insert(
+                    "spCool".to_string(),
+                    json!(command.setpoint_c.unwrap_or(22.0)),
+                );
             }
             HvacControlMode::Auto => {
-                if let Some(setpoint_c) = setpoint_c {
-                    commands.insert("spHeat".to_string(), json!(setpoint_c));
-                    commands.insert("spCool".to_string(), json!(setpoint_c));
+                if let Some(heat_setpoint_c) = command.heat_setpoint_c.or(command.setpoint_c) {
+                    commands.insert("spHeat".to_string(), json!(heat_setpoint_c));
+                }
+                if let Some(cool_setpoint_c) = command.cool_setpoint_c.or(command.setpoint_c) {
+                    commands.insert("spCool".to_string(), json!(cool_setpoint_c));
                 }
             }
         }

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -26,6 +26,7 @@ pub enum HvacControlMode {
     Off,
     Heat,
     Cool,
+    Auto,
 }
 
 impl HvacControlMode {
@@ -34,6 +35,7 @@ impl HvacControlMode {
             Self::Off => "off",
             Self::Heat => "heat",
             Self::Cool => "cool",
+            Self::Auto => "auto",
         }
     }
 
@@ -42,6 +44,7 @@ impl HvacControlMode {
             "off" => Some(Self::Off),
             "heat" => Some(Self::Heat),
             "cool" => Some(Self::Cool),
+            "auto" => Some(Self::Auto),
             _ => None,
         }
     }
@@ -510,6 +513,12 @@ impl KumoClient {
             }
             HvacControlMode::Cool => {
                 commands.insert("spCool".to_string(), json!(setpoint_c.unwrap_or(22.0)));
+            }
+            HvacControlMode::Auto => {
+                if let Some(setpoint_c) = setpoint_c {
+                    commands.insert("spHeat".to_string(), json!(setpoint_c));
+                    commands.insert("spCool".to_string(), json!(setpoint_c));
+                }
             }
         }
 

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    path::PathBuf,
     pin::Pin,
     sync::{Arc, RwLock},
     time::Duration,
@@ -13,10 +14,38 @@ use tokio::{sync::broadcast, task::JoinHandle, time};
 
 use crate::{
     config::{AppConfig, MitsubishiConfig},
+    db,
     status::Status,
 };
 
 const KUMO_APP_VERSION: &str = "1297";
+pub const HVAC_MANUAL_OVERRIDE_SECONDS: i64 = 30 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvacControlMode {
+    Off,
+    Heat,
+    Cool,
+}
+
+impl HvacControlMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Heat => "heat",
+            Self::Cool => "cool",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "off" => Some(Self::Off),
+            "heat" => Some(Self::Heat),
+            "cool" => Some(Self::Cool),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct HvacDeviceStatus {
@@ -37,6 +66,20 @@ pub trait HvacStatusReader: Send + Sync {
     ) -> BoxFutureResult<'a, HvacDeviceStatus>;
 }
 
+pub trait HvacModeWriter: Send + Sync {
+    fn smoke_status<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus>;
+
+    fn set_mode<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus>;
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct KumoHvacStatusReader;
 
@@ -53,12 +96,73 @@ impl HvacStatusReader for KumoHvacStatusReader {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct KumoHvacModeWriter;
+
+impl HvacModeWriter for KumoHvacModeWriter {
+    fn smoke_status<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+        KumoHvacStatusReader.read_status(config)
+    }
+
+    fn set_mode<'a>(
+        &'a self,
+        config: &'a MitsubishiConfig,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+    ) -> BoxFutureResult<'a, HvacDeviceStatus> {
+        Box::pin(async move {
+            let client = KumoClient::new(config)?;
+            client.send_mode_command(mode, setpoint_c).await?;
+            client.get_full_status().await
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct HvacState {
-    inner: Arc<RwLock<Option<HvacDeviceStatus>>>,
+    inner: Arc<RwLock<HvacInner>>,
+    database_path: PathBuf,
     status_broadcast: Arc<RwLock<Option<broadcast::Sender<()>>>>,
 }
 
+#[derive(Debug, Default)]
+struct HvacInner {
+    latest_status: Option<HvacDeviceStatus>,
+    suspended: bool,
+    last_mode: Option<String>,
+    temp_band_mode: Option<String>,
+    manual_override: Option<HvacManualOverride>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct HvacManualOverride {
+    mode: String,
+    setpoint_f: f64,
+    started_at: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HvacRuntimeSnapshot {
+    pub mode: String,
+    pub setpoint_c: f64,
+    pub heat_setpoint_c: Option<f64>,
+    pub cool_setpoint_c: Option<f64>,
+    pub suspended: bool,
+    pub last_mode: Option<String>,
+    pub temp_band_mode: Option<String>,
+}
+
 impl HvacState {
+    pub fn new(database_path: PathBuf) -> Self {
+        Self {
+            inner: Arc::default(),
+            database_path,
+            status_broadcast: Arc::default(),
+        }
+    }
+
     pub fn set_status_broadcast(&self, sender: broadcast::Sender<()>) {
         *self
             .status_broadcast
@@ -81,26 +185,171 @@ impl HvacState {
         Ok(status)
     }
 
+    pub async fn set_mode_with<W>(
+        &self,
+        config: &MitsubishiConfig,
+        writer: &W,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+        reason: &str,
+    ) -> Result<HvacDeviceStatus>
+    where
+        W: HvacModeWriter + ?Sized,
+    {
+        if !config.active_control_enabled {
+            bail!("HVAC active control is disabled");
+        }
+        if !config.is_configured() {
+            bail!("Mitsubishi Kumo config is incomplete");
+        }
+
+        let smoke_status = writer
+            .smoke_status(config)
+            .await
+            .context("HVAC smoke check failed before active write")?;
+        if self.record_status(smoke_status) {
+            self.notify_status();
+        }
+
+        let status = writer.set_mode(config, mode, setpoint_c).await?;
+        self.record_write_success(status.clone(), mode, setpoint_c, reason);
+        Ok(status)
+    }
+
     pub fn record_status(&self, status: HvacDeviceStatus) -> bool {
         let mut inner = self.inner.write().expect("HVAC state lock poisoned");
-        let changed = inner.as_ref() != Some(&status);
-        *inner = Some(status);
+        let changed = inner.latest_status.as_ref() != Some(&status);
+        if status.mode != "off" {
+            inner.last_mode = Some(status.mode.clone());
+        }
+        inner.latest_status = Some(status);
         changed
     }
 
     pub fn latest(&self) -> Option<HvacDeviceStatus> {
-        self.inner.read().expect("HVAC state lock poisoned").clone()
+        self.inner
+            .read()
+            .expect("HVAC state lock poisoned")
+            .latest_status
+            .clone()
+    }
+
+    pub fn snapshot(&self) -> HvacRuntimeSnapshot {
+        let inner = self.inner.read().expect("HVAC state lock poisoned");
+        let latest = inner.latest_status.clone();
+        HvacRuntimeSnapshot {
+            mode: latest
+                .as_ref()
+                .map(|status| status.mode.clone())
+                .unwrap_or_else(|| "off".to_string()),
+            setpoint_c: latest
+                .as_ref()
+                .map(|status| status.setpoint_c)
+                .unwrap_or(22.0),
+            heat_setpoint_c: latest.as_ref().and_then(|status| status.heat_setpoint_c),
+            cool_setpoint_c: latest.as_ref().and_then(|status| status.cool_setpoint_c),
+            suspended: inner.suspended,
+            last_mode: inner.last_mode.clone(),
+            temp_band_mode: inner.temp_band_mode.clone(),
+        }
+    }
+
+    pub fn record_manual_override(&self, mode: HvacControlMode, setpoint_f: f64) {
+        let mut inner = self.inner.write().expect("HVAC state lock poisoned");
+        inner.manual_override = Some(HvacManualOverride {
+            mode: mode.as_str().to_string(),
+            setpoint_f,
+            started_at: unix_timestamp_now(),
+        });
+        inner.suspended = false;
+        inner.last_mode = if mode == HvacControlMode::Off {
+            None
+        } else {
+            Some(mode.as_str().to_string())
+        };
+        inner.temp_band_mode = None;
+    }
+
+    pub fn manual_override_active(&self) -> bool {
+        let now = unix_timestamp_now();
+        let mut inner = self.inner.write().expect("HVAC state lock poisoned");
+        prune_expired_manual_override(&mut inner, now);
+        inner.manual_override.is_some()
+    }
+
+    pub fn clear_manual_override(&self) {
+        self.inner
+            .write()
+            .expect("HVAC state lock poisoned")
+            .manual_override = None;
+    }
+
+    pub fn set_suspended(&self, suspended: bool, last_mode: Option<String>) {
+        let mut inner = self.inner.write().expect("HVAC state lock poisoned");
+        inner.suspended = suspended;
+        if let Some(last_mode) = last_mode {
+            inner.last_mode = Some(last_mode);
+        }
+    }
+
+    pub fn set_temp_band_mode(&self, mode: Option<HvacControlMode>) {
+        self.inner
+            .write()
+            .expect("HVAC state lock poisoned")
+            .temp_band_mode = mode.map(|mode| mode.as_str().to_string());
     }
 
     pub fn overlay_status(&self, status: &mut Status) {
-        let Some(device_status) = self.latest() else {
-            return;
-        };
+        let now = unix_timestamp_now();
+        let mut inner = self.inner.write().expect("HVAC state lock poisoned");
+        prune_expired_manual_override(&mut inner, now);
 
-        status.hvac.mode = device_status.mode;
-        status.hvac.setpoint_c = device_status.setpoint_c;
+        if let Some(device_status) = &inner.latest_status {
+            status.hvac.mode = device_status.mode.clone();
+            status.hvac.setpoint_c = device_status.setpoint_c;
+        }
+        status.hvac.suspended = inner.suspended;
+
+        if let Some(manual_override) = &inner.manual_override {
+            let expires_in =
+                HVAC_MANUAL_OVERRIDE_SECONDS - (now - manual_override.started_at).floor() as i64;
+            status.manual_override.hvac = true;
+            status.manual_override.hvac_mode = Some(manual_override.mode.clone());
+            status.manual_override.hvac_setpoint_f = Some(manual_override.setpoint_f);
+            status.manual_override.hvac_expires_in = Some(expires_in.max(0));
+        }
     }
 
+    fn record_write_success(
+        &self,
+        device_status: HvacDeviceStatus,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+        reason: &str,
+    ) {
+        if self.record_status(device_status) {
+            self.notify_status();
+        }
+        if let Err(error) = db::log_climate_action(
+            &self.database_path,
+            "hvac",
+            mode.as_str(),
+            setpoint_c,
+            None,
+            Some(reason),
+        ) {
+            tracing::warn!("failed to log HVAC climate action: {error:#}");
+        }
+    }
+}
+
+impl Default for HvacState {
+    fn default() -> Self {
+        Self::new(PathBuf::new())
+    }
+}
+
+impl HvacState {
     fn notify_status(&self) {
         let Some(sender) = self
             .status_broadcast
@@ -242,6 +491,53 @@ impl KumoClient {
             .with_context(|| format!("Kumo GET {path} response is not JSON"))
     }
 
+    async fn send_mode_command(
+        &self,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+    ) -> Result<Value> {
+        let token = self.login().await?;
+        let mut commands = serde_json::Map::new();
+        commands.insert(
+            "operationMode".to_string(),
+            Value::String(mode.as_str().to_string()),
+        );
+
+        match mode {
+            HvacControlMode::Off => {}
+            HvacControlMode::Heat => {
+                commands.insert("spHeat".to_string(), json!(setpoint_c.unwrap_or(22.0)));
+            }
+            HvacControlMode::Cool => {
+                commands.insert("spCool".to_string(), json!(setpoint_c.unwrap_or(22.0)));
+            }
+        }
+
+        let response = self
+            .http
+            .post(self.url("/v3/devices/send-command"))
+            .headers(kumo_headers())
+            .bearer_auth(token)
+            .json(&json!({
+                "deviceSerial": self.device_serial,
+                "commands": commands,
+            }))
+            .send()
+            .await
+            .context("failed to send Kumo command request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            bail!("Kumo command failed: {status} - {text}");
+        }
+
+        response
+            .json()
+            .await
+            .context("Kumo command response is not JSON")
+    }
+
     fn url(&self, path: &str) -> String {
         format!("{}{}", self.base_url, path)
     }
@@ -316,6 +612,20 @@ fn value_as_f64(value: &Value) -> Option<f64> {
     value
         .as_f64()
         .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+}
+
+fn prune_expired_manual_override(inner: &mut HvacInner, now: f64) {
+    let expired = inner
+        .manual_override
+        .as_ref()
+        .is_some_and(|manual| now - manual.started_at > HVAC_MANUAL_OVERRIDE_SECONDS as f64);
+    if expired {
+        inner.manual_override = None;
+    }
+}
+
+fn unix_timestamp_now() -> f64 {
+    Local::now().timestamp_millis() as f64 / 1_000.0
 }
 
 pub fn start_hvac_status_poll(config: &AppConfig, hvac: HvacState) -> Option<JoinHandle<()>> {

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -199,20 +199,44 @@ impl HvacState {
     where
         W: HvacModeWriter + ?Sized,
     {
-        if !config.active_control_enabled {
-            bail!("HVAC active control is disabled");
-        }
-        if !config.is_configured() {
-            bail!("Mitsubishi Kumo config is incomplete");
-        }
+        self.smoke_status_with(config, writer).await?;
+        let status = writer.set_mode(config, mode, setpoint_c).await?;
+        self.record_write_success(status.clone(), mode, setpoint_c, reason);
+        Ok(status)
+    }
+
+    pub async fn smoke_status_with<W>(
+        &self,
+        config: &MitsubishiConfig,
+        writer: &W,
+    ) -> Result<HvacDeviceStatus>
+    where
+        W: HvacModeWriter + ?Sized,
+    {
+        validate_active_hvac_config(config)?;
 
         let smoke_status = writer
             .smoke_status(config)
             .await
             .context("HVAC smoke check failed before active write")?;
-        if self.record_status(smoke_status) {
+        if self.record_status(smoke_status.clone()) {
             self.notify_status();
         }
+        Ok(smoke_status)
+    }
+
+    pub async fn set_mode_after_verified_status_with<W>(
+        &self,
+        config: &MitsubishiConfig,
+        writer: &W,
+        mode: HvacControlMode,
+        setpoint_c: Option<f64>,
+        reason: &str,
+    ) -> Result<HvacDeviceStatus>
+    where
+        W: HvacModeWriter + ?Sized,
+    {
+        validate_active_hvac_config(config)?;
 
         let status = writer.set_mode(config, mode, setpoint_c).await?;
         self.record_write_success(status.clone(), mode, setpoint_c, reason);
@@ -344,6 +368,16 @@ impl HvacState {
             tracing::warn!("failed to log HVAC climate action: {error:#}");
         }
     }
+}
+
+fn validate_active_hvac_config(config: &MitsubishiConfig) -> Result<()> {
+    if !config.active_control_enabled {
+        bail!("HVAC active control is disabled");
+    }
+    if !config.is_configured() {
+        bail!("Mitsubishi Kumo config is incomplete");
+    }
+    Ok(())
 }
 
 impl Default for HvacState {

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -406,11 +406,13 @@ impl HvacState {
         inner.manual_override.is_some()
     }
 
-    pub fn clear_manual_override(&self) {
+    pub fn clear_manual_override(&self) -> bool {
         self.inner
             .write()
             .expect("HVAC state lock poisoned")
-            .manual_override = None;
+            .manual_override
+            .take()
+            .is_some()
     }
 
     pub fn set_suspended(&self, suspended: bool, last_mode: Option<String>) {

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -331,9 +331,21 @@ impl HvacState {
 
     pub fn record_status(&self, status: HvacDeviceStatus) -> bool {
         let mut inner = self.inner.write().expect("HVAC state lock poisoned");
-        let changed = inner.latest_status.as_ref() != Some(&status);
+        let mut changed = inner.latest_status.as_ref() != Some(&status);
         if status.mode != "off" {
+            if inner.last_mode.as_deref() != Some(status.mode.as_str()) {
+                changed = true;
+            }
             inner.last_mode = Some(status.mode.clone());
+            if inner.suspended
+                || inner.suspended_heat_setpoint_c.is_some()
+                || inner.suspended_cool_setpoint_c.is_some()
+            {
+                changed = true;
+            }
+            inner.suspended = false;
+            inner.suspended_heat_setpoint_c = None;
+            inner.suspended_cool_setpoint_c = None;
         }
         inner.latest_status = Some(status);
         changed
@@ -916,6 +928,27 @@ mod tests {
 
         assert_eq!(status.hvac.mode, "cool");
         assert_eq!(status.hvac.setpoint_c, 24.5);
+    }
+
+    #[test]
+    fn record_status_clears_stale_suspension_when_device_is_active() {
+        let hvac = HvacState::default();
+        let status = parse_kumo_adapter_status(&json!({
+            "power": 1,
+            "operationMode": "auto",
+            "spHeat": 20.0,
+            "spCool": 26.0
+        }))
+        .expect("status");
+        hvac.record_status(status.clone());
+        hvac.set_suspended_with_setpoints(true, Some("auto".to_string()), Some(20.0), Some(26.0));
+
+        assert!(hvac.record_status(status));
+        let snapshot = hvac.snapshot();
+        assert!(!snapshot.suspended);
+        assert_eq!(snapshot.last_mode.as_deref(), Some("auto"));
+        assert_eq!(snapshot.suspended_heat_setpoint_c, None);
+        assert_eq!(snapshot.suspended_cool_setpoint_c, None);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -3,7 +3,7 @@ use std::{
     future::Future,
     path::PathBuf,
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -640,7 +640,9 @@ async fn apply_yolink_report_with_policy(
     device_hook: Option<&DeviceIngressHook>,
 ) -> Result<()> {
     if let Some(erv_automation) = erv_automation {
-        let applied_device = erv_automation
+        let report_applied = Arc::new(Mutex::new(false));
+        let report_applied_for_hook = report_applied.clone();
+        let policy_result = erv_automation
             .update_state_and_maybe_evaluate(|| {
                 let applied = yolink
                     .apply_report(report, now)
@@ -648,6 +650,7 @@ async fn apply_yolink_report_with_policy(
                 let Some(applied) = applied else {
                     return Ok((None, None, now, false, false));
                 };
+                *report_applied_for_hook.lock().expect("report applied lock") = true;
                 let bypass_dwell = applied.transition.is_some();
                 Ok((
                     Some(applied.device_type),
@@ -657,10 +660,22 @@ async fn apply_yolink_report_with_policy(
                     true,
                 ))
             })
-            .await?;
-        if applied_device.is_some() {
-            if let Some(hook) = device_hook {
-                hook();
+            .await;
+        match policy_result {
+            Ok(applied_device) => {
+                if applied_device.is_some() {
+                    if let Some(hook) = device_hook {
+                        hook();
+                    }
+                }
+            }
+            Err(error) => {
+                if *report_applied.lock().expect("report applied lock") {
+                    if let Some(hook) = device_hook {
+                        hook();
+                    }
+                }
+                return Err(error);
             }
         }
         return Ok(());
@@ -700,13 +715,22 @@ mod tests {
 
     struct FakeErvWriter {
         smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        write_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
         write_speeds: Mutex<Vec<ErvFanSpeed>>,
     }
 
     impl FakeErvWriter {
         fn new(smoke_results: Vec<Result<ErvDeviceStatus>>) -> Self {
+            Self::with_write_results(smoke_results, Vec::new())
+        }
+
+        fn with_write_results(
+            smoke_results: Vec<Result<ErvDeviceStatus>>,
+            write_results: Vec<Result<ErvDeviceStatus>>,
+        ) -> Self {
             Self {
                 smoke_results: Mutex::new(smoke_results.into()),
+                write_results: Mutex::new(write_results.into()),
                 write_speeds: Mutex::new(Vec::new()),
             }
         }
@@ -739,7 +763,13 @@ mod tests {
                 .lock()
                 .expect("write speeds lock")
                 .push(speed);
-            Box::pin(async move { Ok(erv_status(speed)) })
+            let result = self
+                .write_results
+                .lock()
+                .expect("write results lock")
+                .pop_front()
+                .unwrap_or_else(|| Ok(erv_status(speed)));
+            Box::pin(async move { result })
         }
     }
 
@@ -1154,6 +1184,76 @@ mod tests {
         assert_eq!(
             *hook_observations.lock().expect("hook observations lock"),
             vec![false]
+        );
+    }
+
+    #[tokio::test]
+    async fn device_hook_runs_when_erv_policy_write_fails_after_report_applies() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let config = test_config(db_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::new(
+            StateConfig::from_thresholds(&config.thresholds),
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
+        yolink.apply_devices(sample_devices());
+        let qingping = QingpingState::default();
+        let erv = ErvState::new(db_path);
+        let writer = Arc::new(FakeErvWriter::with_write_results(
+            vec![Ok(erv_status(ErvFanSpeed::Medium))],
+            vec![Err(anyhow::anyhow!("ERV write failed"))],
+        ));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = tokio::sync::broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine.clone(),
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+        let hook_observations = Arc::new(Mutex::new(Vec::new()));
+        let hook: DeviceIngressHook = Arc::new({
+            let state_machine = state_machine.clone();
+            let hook_observations = hook_observations.clone();
+            move || {
+                let safety_interlock = state_machine
+                    .read()
+                    .expect("state machine lock poisoned")
+                    .status_at(1_002.0)
+                    .safety_interlock;
+                hook_observations
+                    .lock()
+                    .expect("hook observations lock")
+                    .push(safety_interlock);
+            }
+        });
+
+        let result = apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "door-1".to_string(),
+                data: json!({"state": "open"}),
+            },
+            1_002.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Off]);
+        assert_eq!(
+            *hook_observations.lock().expect("hook observations lock"),
+            vec![true]
         );
     }
 

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -605,54 +605,21 @@ async fn listen_yolink_mqtt(
                 match parse_mqtt_report_payload(&publish.payload) {
                     Ok(Some(report)) => {
                         let now = chrono::Local::now().timestamp_millis() as f64 / 1_000.0;
-                        if let Some(erv_automation) = &erv_automation {
-                            match erv_automation
-                                .update_state_and_maybe_evaluate(|| {
-                                    let applied = yolink
-                                        .apply_report(report, now)
-                                        .context("failed to apply YoLink report")?;
-                                    let Some(applied) = applied else {
-                                        return Ok((None, None, now, false, false));
-                                    };
-                                    if let Some(hook) = &device_hook {
-                                        hook();
-                                    }
-                                    let bypass_dwell = applied.transition.is_some();
-                                    Ok((
-                                        Some(applied.device_type),
-                                        applied.transition,
-                                        now,
-                                        bypass_dwell,
-                                        true,
-                                    ))
-                                })
-                                .await
-                            {
-                                Ok(Some(_)) | Ok(None) => {}
-                                Err(error)
-                                    if error
-                                        .to_string()
-                                        .contains("failed to apply YoLink report") =>
-                                {
-                                    tracing::warn!("failed to apply YoLink report: {error:#}")
-                                }
-                                Err(error) => {
-                                    tracing::warn!(
-                                        "ERV automated policy apply failed after YoLink update: {error:#}"
-                                    );
-                                }
-                            }
-                        } else {
-                            match yolink.apply_report(report, now) {
-                                Ok(Some(_)) => {
-                                    if let Some(hook) = &device_hook {
-                                        hook();
-                                    }
-                                }
-                                Ok(None) => {}
-                                Err(error) => {
-                                    tracing::warn!("failed to apply YoLink report: {error:#}")
-                                }
+                        if let Err(error) = apply_yolink_report_with_policy(
+                            &yolink,
+                            report,
+                            now,
+                            erv_automation.as_ref(),
+                            device_hook.as_ref(),
+                        )
+                        .await
+                        {
+                            if error.to_string().contains("failed to apply YoLink report") {
+                                tracing::warn!("failed to apply YoLink report: {error:#}")
+                            } else {
+                                tracing::warn!(
+                                    "ERV automated policy apply failed after YoLink update: {error:#}"
+                                );
                             }
                         }
                     }
@@ -665,15 +632,116 @@ async fn listen_yolink_mqtt(
     }
 }
 
+async fn apply_yolink_report_with_policy(
+    yolink: &YoLinkState,
+    report: YoLinkReport,
+    now: f64,
+    erv_automation: Option<&ErvPolicyCoordinator>,
+    device_hook: Option<&DeviceIngressHook>,
+) -> Result<()> {
+    if let Some(erv_automation) = erv_automation {
+        let applied_device = erv_automation
+            .update_state_and_maybe_evaluate(|| {
+                let applied = yolink
+                    .apply_report(report, now)
+                    .context("failed to apply YoLink report")?;
+                let Some(applied) = applied else {
+                    return Ok((None, None, now, false, false));
+                };
+                let bypass_dwell = applied.transition.is_some();
+                Ok((
+                    Some(applied.device_type),
+                    applied.transition,
+                    now,
+                    bypass_dwell,
+                    true,
+                ))
+            })
+            .await?;
+        if applied_device.is_some() {
+            if let Some(hook) = device_hook {
+                hook();
+            }
+        }
+        return Ok(());
+    }
+
+    if yolink
+        .apply_report(report, now)
+        .context("failed to apply YoLink report")?
+        .is_some()
+    {
+        if let Some(hook) = device_hook {
+            hook();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
     use super::*;
     use crate::{
-        config::ThresholdsConfig,
+        config::{
+            ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
+            ThresholdsConfig,
+        },
         db::migrate_database,
+        erv::{ErvDeviceStatus, ErvFanSpeed, ErvSpeedWriter, ErvState},
+        policy::ErvPolicyState,
+        qingping::QingpingState,
         state::{OccupancyState, StateConfig},
     };
+    use anyhow::Result;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    struct FakeErvWriter {
+        smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        write_speeds: Mutex<Vec<ErvFanSpeed>>,
+    }
+
+    impl FakeErvWriter {
+        fn new(smoke_results: Vec<Result<ErvDeviceStatus>>) -> Self {
+            Self {
+                smoke_results: Mutex::new(smoke_results.into()),
+                write_speeds: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn write_speeds(&self) -> Vec<ErvFanSpeed> {
+            self.write_speeds.lock().expect("write speeds lock").clone()
+        }
+    }
+
+    impl ErvSpeedWriter for FakeErvWriter {
+        fn smoke_status<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+        ) -> crate::erv::BoxFutureResult<'a, ErvDeviceStatus> {
+            let result = self
+                .smoke_results
+                .lock()
+                .expect("smoke results lock")
+                .pop_front()
+                .unwrap_or_else(|| Ok(erv_status(ErvFanSpeed::Off)));
+            Box::pin(async move { result })
+        }
+
+        fn set_speed<'a>(
+            &'a self,
+            _config: &'a ErvConfig,
+            speed: ErvFanSpeed,
+        ) -> crate::erv::BoxFutureResult<'a, ErvDeviceStatus> {
+            self.write_speeds
+                .lock()
+                .expect("write speeds lock")
+                .push(speed);
+            Box::pin(async move { Ok(erv_status(speed)) })
+        }
+    }
 
     fn test_state(database_path: PathBuf) -> YoLinkState {
         YoLinkState::new(
@@ -683,6 +751,61 @@ mod tests {
             ))),
             database_path,
         )
+    }
+
+    fn test_config(database_path: PathBuf) -> AppConfig {
+        let root = database_path
+            .parent()
+            .expect("database parent")
+            .to_path_buf();
+        AppConfig {
+            orchestrator: OrchestratorConfig::default(),
+            qingping: QingpingConfig::default(),
+            yolink: YoLinkConfig::default(),
+            erv: ErvConfig {
+                device_type: "tuya".to_string(),
+                ip: "192.0.2.10".to_string(),
+                device_id: "device-id".to_string(),
+                local_key: "local-key".to_string(),
+                active_control_enabled: true,
+                verify_delay_seconds: 0,
+                ..ErvConfig::default()
+            },
+            mitsubishi: MitsubishiConfig::default(),
+            thresholds: ThresholdsConfig {
+                erv_min_dwell_seconds: 0,
+                ..ThresholdsConfig::default()
+            },
+            runtime: RuntimeConfig {
+                root: root.clone(),
+                config_path: root.join("config.yaml"),
+                data_dir: root.clone(),
+                database_path,
+                frontend_dist: root.join("frontend/dist"),
+                artifacts_dir: root.join("apps"),
+                legacy_apk_path: root.join("app-debug.apk"),
+                base_url: None,
+                public_url: None,
+                mqtt_host: "127.0.0.1".to_string(),
+                mqtt_port: 1883,
+            },
+        }
+    }
+
+    fn erv_status(speed: ErvFanSpeed) -> ErvDeviceStatus {
+        let (power, supply_speed, exhaust_speed) = match speed {
+            ErvFanSpeed::Off => (false, Some(1), Some(1)),
+            ErvFanSpeed::Quiet => (true, Some(1), Some(1)),
+            ErvFanSpeed::Medium => (true, Some(3), Some(2)),
+            ErvFanSpeed::Turbo => (true, Some(8), Some(8)),
+        };
+        ErvDeviceStatus {
+            power,
+            fan_speed: Some(speed),
+            supply_speed,
+            exhaust_speed,
+            raw_dps: json!({}),
+        }
     }
 
     fn sample_devices() -> Vec<YoLinkDevice> {
@@ -968,6 +1091,70 @@ mod tests {
             .await
             .expect("broadcast timeout")
             .expect("broadcast received");
+    }
+
+    #[tokio::test]
+    async fn device_hook_runs_after_erv_policy_update() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let config = test_config(db_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::new(
+            StateConfig::from_thresholds(&config.thresholds),
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
+        yolink.apply_devices(sample_devices());
+        let qingping = QingpingState::default();
+        let erv = ErvState::new(db_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(
+            ErvFanSpeed::Medium,
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = tokio::sync::broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv.clone(),
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+        let hook_observations = Arc::new(Mutex::new(Vec::new()));
+        let hook: DeviceIngressHook = Arc::new({
+            let erv = erv.clone();
+            let hook_observations = hook_observations.clone();
+            move || {
+                hook_observations
+                    .lock()
+                    .expect("hook observations lock")
+                    .push(erv.snapshot().running);
+            }
+        });
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "door-1".to_string(),
+                data: json!({"state": "open"}),
+            },
+            1_002.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("report applies with policy");
+
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Off]);
+        assert_eq!(
+            *hook_observations.lock().expect("hook observations lock"),
+            vec![false]
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -21,7 +21,7 @@ use crate::{
     status::Status,
 };
 
-pub type DeviceIngressHook = Arc<dyn Fn() + Send + Sync + 'static>;
+pub type DeviceIngressHook = Arc<dyn Fn(Option<StateTransition>) + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceType {
@@ -640,8 +640,8 @@ async fn apply_yolink_report_with_policy(
     device_hook: Option<&DeviceIngressHook>,
 ) -> Result<()> {
     if let Some(erv_automation) = erv_automation {
-        let report_applied = Arc::new(Mutex::new(false));
-        let report_applied_for_hook = report_applied.clone();
+        let report_transition = Arc::new(Mutex::new(None::<Option<StateTransition>>));
+        let report_transition_for_hook = report_transition.clone();
         let policy_result = erv_automation
             .update_state_and_maybe_evaluate(|| {
                 let applied = yolink
@@ -650,11 +650,14 @@ async fn apply_yolink_report_with_policy(
                 let Some(applied) = applied else {
                     return Ok((None, None, now, false, false));
                 };
-                *report_applied_for_hook.lock().expect("report applied lock") = true;
+                let transition = applied.transition;
+                *report_transition_for_hook
+                    .lock()
+                    .expect("report transition lock") = Some(transition);
                 let bypass_dwell = applied.transition.is_some();
                 Ok((
-                    Some(applied.device_type),
-                    applied.transition,
+                    Some((applied.device_type, transition)),
+                    transition,
                     now,
                     bypass_dwell,
                     true,
@@ -662,17 +665,18 @@ async fn apply_yolink_report_with_policy(
             })
             .await;
         match policy_result {
-            Ok(applied_device) => {
-                if applied_device.is_some() {
+            Ok(applied) => {
+                if let Some((_device, transition)) = applied {
                     if let Some(hook) = device_hook {
-                        hook();
+                        hook(transition);
                     }
                 }
             }
             Err(error) => {
-                if *report_applied.lock().expect("report applied lock") {
+                let transition = *report_transition.lock().expect("report transition lock");
+                if let Some(transition) = transition {
                     if let Some(hook) = device_hook {
-                        hook();
+                        hook(transition);
                     }
                 }
                 return Err(error);
@@ -681,13 +685,12 @@ async fn apply_yolink_report_with_policy(
         return Ok(());
     }
 
-    if yolink
+    if let Some(applied) = yolink
         .apply_report(report, now)
         .context("failed to apply YoLink report")?
-        .is_some()
     {
         if let Some(hook) = device_hook {
-            hook();
+            hook(applied.transition);
         }
     }
 
@@ -1133,10 +1136,6 @@ mod tests {
             StateConfig::from_thresholds(&config.thresholds),
             1_000.0,
         )));
-        state_machine
-            .write()
-            .expect("state machine lock poisoned")
-            .set_manual_presence(true, 1_001.0);
         let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
         yolink.apply_devices(sample_devices());
         let qingping = QingpingState::default();
@@ -1159,19 +1158,19 @@ mod tests {
         let hook: DeviceIngressHook = Arc::new({
             let erv = erv.clone();
             let hook_observations = hook_observations.clone();
-            move || {
+            move |transition| {
                 hook_observations
                     .lock()
                     .expect("hook observations lock")
-                    .push(erv.snapshot().running);
+                    .push((transition, erv.snapshot().running));
             }
         });
 
         apply_yolink_report_with_policy(
             &yolink,
             YoLinkReport {
-                device_id: "door-1".to_string(),
-                data: json!({"state": "open"}),
+                device_id: "motion-1".to_string(),
+                data: json!({"state": "alert"}),
             },
             1_002.0,
             Some(&coordinator),
@@ -1183,7 +1182,13 @@ mod tests {
         assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Off]);
         assert_eq!(
             *hook_observations.lock().expect("hook observations lock"),
-            vec![false]
+            vec![(
+                Some(StateTransition {
+                    old_state: OccupancyState::Away,
+                    new_state: OccupancyState::Present,
+                }),
+                false,
+            )]
         );
     }
 
@@ -1224,7 +1229,7 @@ mod tests {
         let hook: DeviceIngressHook = Arc::new({
             let state_machine = state_machine.clone();
             let hook_observations = hook_observations.clone();
-            move || {
+            move |_transition| {
                 let safety_interlock = state_machine
                     .read()
                     .expect("state machine lock poisoned")

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -21,6 +21,8 @@ use crate::{
     status::Status,
 };
 
+pub type DeviceIngressHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceType {
     DoorSensor,
@@ -529,6 +531,7 @@ pub fn start_yolink_client(
     config: &AppConfig,
     yolink: YoLinkState,
     erv_automation: Option<ErvPolicyCoordinator>,
+    device_hook: Option<DeviceIngressHook>,
 ) -> Option<JoinHandle<()>> {
     if !config.yolink.is_configured() {
         tracing::warn!("YoLink credentials are not configured; client not started");
@@ -538,8 +541,13 @@ pub fn start_yolink_client(
     let config = config.clone();
     Some(tokio::spawn(async move {
         loop {
-            if let Err(error) =
-                run_yolink_client_once(&config, yolink.clone(), erv_automation.clone()).await
+            if let Err(error) = run_yolink_client_once(
+                &config,
+                yolink.clone(),
+                erv_automation.clone(),
+                device_hook.clone(),
+            )
+            .await
             {
                 tracing::warn!("YoLink client stopped: {error:#}");
             }
@@ -552,6 +560,7 @@ async fn run_yolink_client_once(
     config: &AppConfig,
     yolink: YoLinkState,
     erv_automation: Option<ErvPolicyCoordinator>,
+    device_hook: Option<DeviceIngressHook>,
 ) -> Result<()> {
     let cloud = YoLinkCloudClient::new(config.yolink.clone());
     let (access_token, home_id) = initialize_yolink_inventory(&cloud, &yolink).await?;
@@ -562,6 +571,7 @@ async fn run_yolink_client_once(
         &home_id,
         yolink,
         erv_automation,
+        device_hook,
     )
     .await
 }
@@ -572,6 +582,7 @@ async fn listen_yolink_mqtt(
     home_id: &str,
     yolink: YoLinkState,
     erv_automation: Option<ErvPolicyCoordinator>,
+    device_hook: Option<DeviceIngressHook>,
 ) -> Result<()> {
     let mut options = MqttOptions::new(
         "office-automate-yolink",
@@ -603,6 +614,9 @@ async fn listen_yolink_mqtt(
                                     let Some(applied) = applied else {
                                         return Ok((None, None, now, false, false));
                                     };
+                                    if let Some(hook) = &device_hook {
+                                        hook();
+                                    }
                                     let bypass_dwell = applied.transition.is_some();
                                     Ok((
                                         Some(applied.device_type),
@@ -630,7 +644,12 @@ async fn listen_yolink_mqtt(
                             }
                         } else {
                             match yolink.apply_report(report, now) {
-                                Ok(Some(_)) | Ok(None) => {}
+                                Ok(Some(_)) => {
+                                    if let Some(hook) = &device_hook {
+                                        hook();
+                                    }
+                                }
+                                Ok(None) => {}
                                 Err(error) => {
                                     tracing::warn!("failed to apply YoLink report: {error:#}")
                                 }


### PR DESCRIPTION
## Summary
- Add disabled-by-default active HVAC write control with smoke/read checks before Kumo writes.
- Route manual `/hvac` and automated HVAC policy writes through the gated writer with action logging and status broadcasts.
- Preserve manual override, suspension, safety interlock, and Fahrenheit/Celsius conversion behavior.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `/Users/rajesh/projects/office-automate/venv/bin/python -m pytest tests/ -v`

Fixes #72