### PR TITLE
Add internal presence poller

### DIFF
--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -358,8 +358,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-            ThresholdsConfig, YoLinkConfig,
+            ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
+            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
         },
         db,
         erv::BoxFutureResult,
@@ -429,6 +429,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv: ErvConfig {

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-use crate::{config::AppConfig, db, erv, http, hvac};
+use crate::{config::AppConfig, db, erv, http, hvac, presence};
 
 #[derive(Debug, Parser)]
 #[command(name = "office-automate-server")]
@@ -43,6 +43,8 @@ pub enum SmokeTarget {
     Erv,
     /// Verify Mitsubishi Kumo HVAC status read.
     Hvac,
+    /// Verify macOS keyboard/display presence signals.
+    Presence,
 }
 
 pub async fn run_cli() -> Result<()> {
@@ -95,6 +97,13 @@ async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()
                     status.mode, status.setpoint_c
                 );
             }
+            SmokeTarget::Presence => {
+                let status = presence::smoke_presence(config).await?;
+                println!(
+                    "Presence signals OK: idle_seconds={:.1} external_monitor={} display_count={}",
+                    status.idle_seconds, status.external_monitor, status.display_count
+                );
+            }
         }
     }
 
@@ -105,7 +114,8 @@ fn smoke_targets(target: Option<SmokeTarget>) -> &'static [SmokeTarget] {
     match target {
         Some(SmokeTarget::Erv) => &[SmokeTarget::Erv],
         Some(SmokeTarget::Hvac) => &[SmokeTarget::Hvac],
-        None => &[SmokeTarget::Erv, SmokeTarget::Hvac],
+        Some(SmokeTarget::Presence) => &[SmokeTarget::Presence],
+        None => &[SmokeTarget::Erv, SmokeTarget::Hvac, SmokeTarget::Presence],
     }
 }
 
@@ -201,8 +211,28 @@ mod tests {
                 assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
                 assert_eq!(
                     smoke_targets(args.target),
-                    &[SmokeTarget::Erv, SmokeTarget::Hvac]
+                    &[SmokeTarget::Erv, SmokeTarget::Hvac, SmokeTarget::Presence]
                 );
+            }
+            other => panic!("expected smoke command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_smoke_presence_command_with_config() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "smoke",
+            "--config",
+            "/tmp/office.yaml",
+            "presence",
+        ])
+        .expect("smoke command should parse");
+
+        match cli.command {
+            Command::Smoke(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.target, Some(SmokeTarget::Presence));
             }
             other => panic!("expected smoke command, got {other:?}"),
         }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -9,12 +9,31 @@ use serde::Deserialize;
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
+    pub presence: PresenceConfig,
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
     pub erv: ErvConfig,
     pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
     pub runtime: RuntimeConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PresenceConfig {
+    pub enabled: bool,
+    pub poll_interval_seconds: u64,
+    pub command_timeout_seconds: u64,
+}
+
+impl Default for PresenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            poll_interval_seconds: 5,
+            command_timeout_seconds: 10,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -319,6 +338,7 @@ pub struct RuntimeConfig {
 #[serde(default)]
 struct FileConfig {
     orchestrator: OrchestratorConfig,
+    presence: PresenceConfig,
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
     erv: ErvConfig,
@@ -413,6 +433,25 @@ impl AppConfig {
                 parse_bool_env("OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED", &enabled)?;
         }
 
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_PRESENCE_ENABLED") {
+            file_config.presence.enabled =
+                parse_bool_env("OFFICE_AUTOMATE_PRESENCE_ENABLED", &enabled)?;
+        }
+
+        if let Some(seconds) = env_lookup("OFFICE_AUTOMATE_PRESENCE_POLL_INTERVAL_SECONDS") {
+            file_config.presence.poll_interval_seconds = seconds.parse().with_context(|| {
+                format!("invalid OFFICE_AUTOMATE_PRESENCE_POLL_INTERVAL_SECONDS value {seconds:?}")
+            })?;
+        }
+
+        if let Some(seconds) = env_lookup("OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS") {
+            file_config.presence.command_timeout_seconds = seconds.parse().with_context(|| {
+                format!(
+                    "invalid OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS value {seconds:?}"
+                )
+            })?;
+        }
+
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
             root,
@@ -429,6 +468,7 @@ impl AppConfig {
 
         Ok(Self {
             orchestrator: file_config.orchestrator,
+            presence: file_config.presence,
             qingping: file_config.qingping,
             yolink: file_config.yolink,
             erv: file_config.erv,
@@ -461,6 +501,8 @@ mod tests {
 orchestrator:
   host: "127.0.0.1"
   port: 9001
+presence:
+  poll_interval_seconds: 7
 qingping:
   mqtt_broker: "legacy-broker"
   mqtt_port: 1883
@@ -506,6 +548,8 @@ thresholds:
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
             "OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_PRESENCE_ENABLED" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS" => Some("3".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             _ => None,
         })
@@ -513,6 +557,9 @@ thresholds:
 
         assert_eq!(config.orchestrator.host, "127.0.0.1");
         assert_eq!(config.orchestrator.port, 9001);
+        assert!(config.presence.enabled);
+        assert_eq!(config.presence.poll_interval_seconds, 7);
+        assert_eq!(config.presence.command_timeout_seconds, 3);
         assert_eq!(config.qingping.mqtt_broker, "rust-broker");
         assert_eq!(config.qingping.mqtt_port, 2883);
         assert_eq!(config.yolink.uaid, "env-uaid");

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -934,6 +934,7 @@ mod tests {
     fn app_config(erv: ErvConfig) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv,

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -23,7 +23,12 @@ use axum::{
 use chrono::{NaiveTime, Timelike};
 use serde::Deserialize;
 use serde_json::{Value, json};
-use tokio::{net::TcpListener, sync::broadcast, time::timeout};
+use tokio::{
+    net::TcpListener,
+    sync::broadcast,
+    task::JoinHandle,
+    time::{self, timeout},
+};
 use tower_http::{
     cors::{Any, CorsLayer},
     services::ServeDir,
@@ -46,6 +51,7 @@ use crate::{
     },
     mqtt,
     policy::{ErvPolicyState, HvacBandAction, HvacMode, get_hvac_band_action},
+    presence::{MacOsPresenceReader, PresenceSnapshot},
     qingping::QingpingState,
     state::{OccupancyState, StateMachine, StateTransition},
     status::{Status, TemperatureBands},
@@ -126,7 +132,7 @@ fn try_app_with_erv_writer(
     erv_writer: Arc<dyn ErvSpeedWriter>,
     hvac_writer: Arc<dyn HvacModeWriter>,
 ) -> Result<Router> {
-    try_app_with_erv_writer_and_coordinator(
+    let (router, _) = try_app_with_erv_writer_and_coordinator(
         config,
         qingping,
         state_machine,
@@ -135,8 +141,8 @@ fn try_app_with_erv_writer(
         hvac_state,
         erv_writer,
         hvac_writer,
-    )
-    .map(|(router, _)| router)
+    )?;
+    Ok(router)
 }
 
 fn try_app_with_erv_writer_and_coordinator(
@@ -149,6 +155,30 @@ fn try_app_with_erv_writer_and_coordinator(
     erv_writer: Arc<dyn ErvSpeedWriter>,
     hvac_writer: Arc<dyn HvacModeWriter>,
 ) -> Result<(Router, AppState)> {
+    let (state, _) = build_app_state(
+        config,
+        qingping,
+        state_machine,
+        yolink,
+        erv_state,
+        hvac_state,
+        erv_writer,
+        hvac_writer,
+    )?;
+    let router = router_from_state(state.clone());
+    Ok((router, state))
+}
+
+fn build_app_state(
+    config: AppConfig,
+    qingping: QingpingState,
+    state_machine: Arc<RwLock<StateMachine>>,
+    yolink: YoLinkState,
+    erv_state: ErvState,
+    hvac_state: HvacState,
+    erv_writer: Arc<dyn ErvSpeedWriter>,
+    hvac_writer: Arc<dyn HvacModeWriter>,
+) -> Result<(AppState, ErvPolicyCoordinator)> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
     let artifacts = ArtifactStore::new(
@@ -187,6 +217,10 @@ fn try_app_with_erv_writer_and_coordinator(
         hvac_writer,
     };
 
+    Ok((state, erv_automation))
+}
+
+fn router_from_state(state: AppState) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
@@ -195,7 +229,7 @@ fn try_app_with_erv_writer_and_coordinator(
     let frontend_dist = state.config.runtime.frontend_dist.clone();
     let assets_dir = frontend_dist.join("assets");
 
-    let router = Router::new()
+    Router::new()
         .route("/status", get(status))
         .route("/ws", get(websocket))
         .route("/occupancy", post(occupancy))
@@ -240,9 +274,7 @@ fn try_app_with_erv_writer_and_coordinator(
         ))
         .with_state(state.clone())
         .layer(cors)
-        .layer(TraceLayer::new_for_http());
-
-    Ok((router, state))
+        .layer(TraceLayer::new_for_http())
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
@@ -258,7 +290,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
     let hvac_state = HvacState::new(config.runtime.database_path.clone());
-    let (app, app_state) = try_app_with_erv_writer_and_coordinator(
+    let (app_state, erv_automation) = build_app_state(
         config.clone(),
         qingping.clone(),
         state_machine,
@@ -268,8 +300,8 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         Arc::new(RustuyaErvSpeedWriter),
         Arc::new(KumoHvacModeWriter),
     )
-    .context("failed to build HTTP app")?;
-    let erv_automation = app_state.erv_automation.clone();
+    .context("failed to build HTTP app state")?;
+    let app = router_from_state(app_state.clone());
     let runtime_handle = tokio::runtime::Handle::current();
     let qingping_policy_trigger: mqtt::SensorIngressHook = Arc::new({
         let erv_automation = erv_automation.clone();
@@ -304,6 +336,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     );
     let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
     let _hvac_task = crate::hvac::start_hvac_status_poll(&config, hvac_state);
+    let _presence_task = start_presence_poll(app_state);
 
     tracing::info!("office-automate-server listening on {}", bind_address);
     axum::serve(
@@ -312,6 +345,32 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     )
     .await
     .context("HTTP server failed")
+}
+
+fn start_presence_poll(state: AppState) -> Option<JoinHandle<()>> {
+    if !state.config.presence.enabled {
+        tracing::info!("internal macOS presence polling disabled");
+        return None;
+    }
+
+    let poll_interval = Duration::from_secs(state.config.presence.poll_interval_seconds.max(1));
+    let reader = MacOsPresenceReader::from_config(&state.config.presence);
+    Some(tokio::spawn(async move {
+        let mut interval = time::interval(poll_interval);
+        loop {
+            interval.tick().await;
+            match reader.read_snapshot().await {
+                Ok(snapshot) => {
+                    if let Err(error) = apply_presence_snapshot(&state, snapshot).await {
+                        tracing::warn!("internal presence update failed: {error:#}");
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!("internal presence signal read failed: {error:#}");
+                }
+            }
+        }
+    }))
 }
 
 async fn auth_middleware(
@@ -590,6 +649,46 @@ async fn occupancy(
     State(state): State<AppState>,
     Json(payload): Json<OccupancyRequest>,
 ) -> Response {
+    match apply_occupancy_signal(
+        &state,
+        payload.last_active_timestamp,
+        payload.external_monitor,
+        "mac_activity",
+    )
+    .await
+    {
+        Ok((state_name, erv_should_run)) => {
+            Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run}))
+                .into_response()
+        }
+        Err(error) => {
+            tracing::error!("failed to apply occupancy update: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"ok": false, "error": "Failed to persist occupancy update"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn apply_presence_snapshot(state: &AppState, snapshot: PresenceSnapshot) -> Result<()> {
+    apply_occupancy_signal(
+        state,
+        snapshot.last_active_timestamp,
+        snapshot.external_monitor,
+        "internal_presence",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn apply_occupancy_signal(
+    state: &AppState,
+    last_active_timestamp: f64,
+    external_monitor: bool,
+    trigger: &str,
+) -> Result<(String, bool)> {
     let now = unix_timestamp_now();
     let applied_transition = Arc::new(std::sync::Mutex::new(None));
     let applied_transition_for_update = Arc::clone(&applied_transition);
@@ -601,18 +700,15 @@ async fn occupancy(
                     .state_machine
                     .write()
                     .expect("state machine lock poisoned");
-                let transition = machine.update_mac_occupancy(
-                    payload.last_active_timestamp,
-                    payload.external_monitor,
-                    now,
-                );
+                let transition =
+                    machine.update_mac_occupancy(last_active_timestamp, external_monitor, now);
                 let status = machine.status_at(now);
                 (transition, status.state, status.erv_should_run)
             };
             *applied_transition_for_update
                 .lock()
                 .expect("occupancy transition lock poisoned") = transition;
-            log_state_transition(&state, transition, "mac_activity")
+            log_state_transition(state, transition, trigger)
                 .context("failed to persist occupancy update")?;
             Ok((
                 (transition, state_name, erv_should_run),
@@ -631,12 +727,7 @@ async fn occupancy(
                 .to_string()
                 .contains("failed to persist occupancy update") =>
         {
-            tracing::error!("failed to log occupancy transition: {error:#}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"ok": false, "error": "Failed to persist occupancy update"})),
-            )
-                .into_response();
+            return Err(error);
         }
         Err(error) => {
             tracing::warn!("ERV automated policy apply failed after occupancy update: {error:#}");
@@ -651,12 +742,12 @@ async fn occupancy(
             (transition, status.state, status.erv_should_run)
         }
     };
-    clear_hvac_manual_override_on_transition(&state, transition);
-    if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+    clear_hvac_manual_override_on_transition(state, transition);
+    if let Err(error) = evaluate_and_apply_hvac_policy(state).await {
         tracing::warn!("HVAC automated policy apply failed after occupancy update: {error:#}");
     }
-    broadcast_status(&state);
-    Json(json!({"ok": true, "state": state_name, "erv_should_run": erv_should_run})).into_response()
+    broadcast_status(state);
+    Ok((state_name, erv_should_run))
 }
 
 #[derive(Debug, Deserialize)]
@@ -2139,6 +2230,7 @@ mod tests {
         let root = temp_dir.keep();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv: ErvConfig::default(),
@@ -2881,6 +2973,196 @@ mod tests {
         assert_eq!(value["device_events"][0]["event"], "manual_present");
         assert_eq!(value["occupancy_history"][0]["state"], "present");
         assert_eq!(value["occupancy_history"][0]["trigger"], "manual");
+    }
+
+    #[tokio::test]
+    async fn occupancy_route_preserves_external_reporter_contract() {
+        let service = app(test_config());
+        let last_active_timestamp = unix_timestamp_now();
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/occupancy")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "last_active_timestamp": last_active_timestamp,
+                            "external_monitor": true
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["state"], "present");
+        assert_eq!(value["erv_should_run"], false);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["state"], "present");
+        assert_eq!(value["sensors"]["mac_last_active"], last_active_timestamp);
+        assert_eq!(value["sensors"]["external_monitor"], true);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/history?hours=1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["occupancy_history"][0]["state"], "present");
+        assert_eq!(value["occupancy_history"][0]["trigger"], "mac_activity");
+    }
+
+    #[tokio::test]
+    async fn stale_occupancy_signal_does_not_undo_manual_away() {
+        let service = app(test_config());
+        let last_active_timestamp = unix_timestamp_now() - 5.0;
+        let occupancy_body = json!({
+            "last_active_timestamp": last_active_timestamp,
+            "external_monitor": true
+        })
+        .to_string();
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/occupancy")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(occupancy_body.clone()))
+                    .expect("request"),
+            )
+            .await
+            .expect("first occupancy response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"away"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("manual away response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/occupancy")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(occupancy_body))
+                    .expect("request"),
+            )
+            .await
+            .expect("second occupancy response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["state"], "away");
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("status response");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["state"], "away");
+        assert_eq!(value["sensors"]["mac_last_active"], last_active_timestamp);
+        assert_eq!(value["sensors"]["external_monitor"], true);
+    }
+
+    #[tokio::test]
+    async fn internal_presence_snapshot_uses_occupancy_update_path() {
+        let config = test_config();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let (state, _) = build_app_state(
+            config.clone(),
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            ErvState::new(config.runtime.database_path.clone()),
+            HvacState::new(config.runtime.database_path.clone()),
+            Arc::new(FakeErvWriter::default()),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app state");
+        let last_active_timestamp = unix_timestamp_now();
+
+        apply_presence_snapshot(
+            &state,
+            PresenceSnapshot {
+                last_active_timestamp,
+                external_monitor: true,
+                idle_seconds: 0.1,
+                display_count: 2,
+                external_displays: vec!["Studio Display".to_string()],
+            },
+        )
+        .await
+        .expect("presence update");
+
+        let status = state
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned")
+            .status_at(unix_timestamp_now());
+        assert_eq!(status.state, "present");
+        assert_eq!(status.sensors.mac_last_active, last_active_timestamp);
+        assert!(status.sensors.external_monitor);
+
+        let history = db::read_history(&config.runtime.database_path, 1, 10).expect("history");
+        assert_eq!(history.occupancy_history[0]["state"], "present");
+        assert_eq!(history.occupancy_history[0]["trigger"], "internal_presence");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -907,6 +907,7 @@ mod tests {
 
         let mut status = Status::read_only_default(&crate::config::AppConfig {
             orchestrator: crate::config::OrchestratorConfig::default(),
+            presence: crate::config::PresenceConfig::default(),
             qingping: crate::config::QingpingConfig::default(),
             yolink: crate::config::YoLinkConfig::default(),
             erv: crate::config::ErvConfig::default(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod http;
 pub mod hvac;
 pub mod mqtt;
 pub mod policy;
+pub mod presence;
 pub mod qingping;
 pub mod state;
 pub mod status;

--- a/rust/office-automate-server/src/presence.rs
+++ b/rust/office-automate-server/src/presence.rs
@@ -56,6 +56,7 @@ async fn run_command(program: &str, args: &[&str], command_timeout: Duration) ->
         command_timeout,
         Command::new(program)
             .args(args)
+            .kill_on_drop(true)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output(),

--- a/rust/office-automate-server/src/presence.rs
+++ b/rust/office-automate-server/src/presence.rs
@@ -1,0 +1,224 @@
+use std::{process::Stdio, time::Duration};
+
+use anyhow::{Context, Result, bail};
+use chrono::Local;
+use tokio::{process::Command, time::timeout};
+
+use crate::config::{AppConfig, PresenceConfig};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PresenceSnapshot {
+    pub last_active_timestamp: f64,
+    pub external_monitor: bool,
+    pub idle_seconds: f64,
+    pub display_count: usize,
+    pub external_displays: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MacOsPresenceReader {
+    command_timeout: Duration,
+}
+
+impl MacOsPresenceReader {
+    pub fn from_config(config: &PresenceConfig) -> Self {
+        Self {
+            command_timeout: Duration::from_secs(config.command_timeout_seconds.max(1)),
+        }
+    }
+
+    pub async fn read_snapshot(&self) -> Result<PresenceSnapshot> {
+        let idle_output =
+            run_command("ioreg", &["-c", "IOHIDSystem"], self.command_timeout).await?;
+        let display_output = run_command(
+            "system_profiler",
+            &["SPDisplaysDataType"],
+            self.command_timeout,
+        )
+        .await?;
+
+        let idle_seconds = parse_hid_idle_seconds(&idle_output)
+            .context("ioreg output did not include HIDIdleTime")?;
+        let (display_count, external_displays) = parse_display_info(&display_output);
+
+        Ok(PresenceSnapshot {
+            last_active_timestamp: unix_timestamp_now() - idle_seconds,
+            external_monitor: !external_displays.is_empty(),
+            idle_seconds,
+            display_count,
+            external_displays,
+        })
+    }
+}
+
+pub async fn smoke_presence(config: &AppConfig) -> Result<PresenceSnapshot> {
+    MacOsPresenceReader::from_config(&config.presence)
+        .read_snapshot()
+        .await
+}
+
+async fn run_command(program: &str, args: &[&str], command_timeout: Duration) -> Result<String> {
+    let output = timeout(
+        command_timeout,
+        Command::new(program)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await
+    .with_context(|| format!("{program} timed out after {command_timeout:?}"))?
+    .with_context(|| format!("failed to run {program}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("{program} failed with status {}: {stderr}", output.status);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn parse_hid_idle_seconds(output: &str) -> Option<f64> {
+    output
+        .lines()
+        .find(|line| line.contains("HIDIdleTime"))
+        .and_then(|line| {
+            line.split(|character: char| !character.is_ascii_digit())
+                .filter(|part| !part.is_empty())
+                .next_back()
+        })
+        .and_then(|value| value.parse::<f64>().ok())
+        .map(|nanoseconds| nanoseconds / 1_000_000_000.0)
+}
+
+pub fn parse_display_info(output: &str) -> (usize, Vec<String>) {
+    let lines = output.lines().collect::<Vec<_>>();
+    let mut all_displays = Vec::new();
+    let mut external_displays = Vec::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        let stripped = line.trim();
+        if !is_display_heading_candidate(stripped) {
+            continue;
+        }
+
+        let display_name = stripped.trim_end_matches(':').to_string();
+        let mut is_display = false;
+        let mut is_internal = false;
+
+        for lookahead in lines.iter().skip(index + 1).take(15) {
+            let lookahead = lookahead.trim();
+            if is_display_heading_candidate(lookahead) {
+                break;
+            }
+            if lookahead.contains("Resolution") || lookahead.contains("Display Type") {
+                is_display = true;
+            }
+            if lookahead.contains("Built-in") || lookahead.contains("Connection Type: Internal") {
+                is_internal = true;
+            }
+        }
+
+        if is_display {
+            all_displays.push(display_name.clone());
+            if !is_internal {
+                external_displays.push(display_name);
+            }
+        }
+    }
+
+    (all_displays.len(), external_displays)
+}
+
+fn is_display_heading_candidate(stripped: &str) -> bool {
+    const SKIP_PREFIXES: &[&str] = &[
+        "Chipset",
+        "Type:",
+        "Bus:",
+        "Vendor:",
+        "Metal",
+        "Total",
+        "Graphics/Displays:",
+        "Apple M",
+        "Resolution",
+        "Display Type",
+        "Main Display",
+        "Mirror",
+        "Online",
+        "Rotation",
+        "Connection",
+        "Automatically",
+        "UI Looks",
+    ];
+
+    stripped.ends_with(':')
+        && !SKIP_PREFIXES
+            .iter()
+            .any(|prefix| stripped.starts_with(prefix))
+}
+
+fn unix_timestamp_now() -> f64 {
+    Local::now().timestamp_millis() as f64 / 1_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hid_idle_time_nanoseconds() {
+        let output = r#"
+        | |   "HIDIdleTime" = 12500000000
+        | |   "OtherProperty" = 1
+        "#;
+
+        assert_eq!(parse_hid_idle_seconds(output), Some(12.5));
+    }
+
+    #[test]
+    fn parses_internal_and_external_displays() {
+        let output = r#"
+Graphics/Displays:
+
+    Apple M2:
+
+      Chipset Model: Apple M2
+
+      Color LCD:
+        Resolution: 3456 x 2234 Retina
+        Main Display: Yes
+        Connection Type: Internal
+
+      DELL U2720Q:
+        Resolution: 3840 x 2160
+        Display Type: External
+        Main Display: No
+
+      LG HDR 4K:
+        Resolution: 3840 x 2160
+        Display Type: External
+        Main Display: No
+"#;
+
+        let (display_count, external_displays) = parse_display_info(output);
+
+        assert_eq!(display_count, 3);
+        assert_eq!(external_displays, vec!["DELL U2720Q", "LG HDR 4K"]);
+    }
+
+    #[test]
+    fn treats_builtin_only_display_as_no_external_monitor() {
+        let output = r#"
+Graphics/Displays:
+    Apple M2:
+      Color LCD:
+        Resolution: 3456 x 2234 Retina
+        Display Type: Built-in Retina LCD
+"#;
+
+        let (display_count, external_displays) = parse_display_info(output);
+
+        assert_eq!(display_count, 1);
+        assert!(external_displays.is_empty());
+    }
+}

--- a/rust/office-automate-server/src/presence.rs
+++ b/rust/office-automate-server/src/presence.rs
@@ -30,6 +30,10 @@ impl MacOsPresenceReader {
     pub async fn read_snapshot(&self) -> Result<PresenceSnapshot> {
         let idle_output =
             run_command("ioreg", &["-c", "IOHIDSystem"], self.command_timeout).await?;
+        let idle_sample_timestamp = unix_timestamp_now();
+        let idle_seconds = parse_hid_idle_seconds(&idle_output)
+            .context("ioreg output did not include HIDIdleTime")?;
+
         let display_output = run_command(
             "system_profiler",
             &["SPDisplaysDataType"],
@@ -37,17 +41,7 @@ impl MacOsPresenceReader {
         )
         .await?;
 
-        let idle_seconds = parse_hid_idle_seconds(&idle_output)
-            .context("ioreg output did not include HIDIdleTime")?;
-        let (display_count, external_displays) = parse_display_info(&display_output);
-
-        Ok(PresenceSnapshot {
-            last_active_timestamp: unix_timestamp_now() - idle_seconds,
-            external_monitor: !external_displays.is_empty(),
-            idle_seconds,
-            display_count,
-            external_displays,
-        })
+        build_presence_snapshot(idle_seconds, idle_sample_timestamp, &display_output)
     }
 }
 
@@ -128,6 +122,22 @@ pub fn parse_display_info(output: &str) -> (usize, Vec<String>) {
     }
 
     (all_displays.len(), external_displays)
+}
+
+fn build_presence_snapshot(
+    idle_seconds: f64,
+    idle_sample_timestamp: f64,
+    display_output: &str,
+) -> Result<PresenceSnapshot> {
+    let (display_count, external_displays) = parse_display_info(display_output);
+
+    Ok(PresenceSnapshot {
+        last_active_timestamp: idle_sample_timestamp - idle_seconds,
+        external_monitor: !external_displays.is_empty(),
+        idle_seconds,
+        display_count,
+        external_displays,
+    })
 }
 
 fn is_display_heading_candidate(stripped: &str) -> bool {
@@ -220,5 +230,22 @@ Graphics/Displays:
 
         assert_eq!(display_count, 1);
         assert!(external_displays.is_empty());
+    }
+
+    #[test]
+    fn last_active_timestamp_uses_idle_sample_time() {
+        let display_output = r#"
+Graphics/Displays:
+    Apple M2:
+      DELL U2720Q:
+        Resolution: 3840 x 2160
+        Display Type: External
+"#;
+
+        let snapshot =
+            build_presence_snapshot(1.0, 1000.0, display_output).expect("presence snapshot");
+
+        assert_eq!(snapshot.last_active_timestamp, 999.0);
+        assert!(snapshot.external_monitor);
     }
 }

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -240,13 +240,14 @@ mod tests {
 
     use super::*;
     use crate::config::{
-        ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-        ThresholdsConfig, YoLinkConfig,
+        ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
+        RuntimeConfig, ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            presence: PresenceConfig::default(),
             qingping: QingpingConfig {
                 report_interval: 45,
                 ..QingpingConfig::default()

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -704,8 +704,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig, RuntimeConfig,
-            ThresholdsConfig,
+            ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
+            RuntimeConfig, ThresholdsConfig,
         },
         db::migrate_database,
         erv::{ErvDeviceStatus, ErvFanSpeed, ErvSpeedWriter, ErvState},
@@ -793,6 +793,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
             erv: ErvConfig {


### PR DESCRIPTION
## Summary
- Add macOS idle/display presence polling and `smoke presence` support.
- Feed internal presence snapshots through the same occupancy update and policy path used by external reporters.
- Preserve `POST /occupancy` compatibility and manual presence behavior.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `/Users/rajesh/projects/office-automate/venv/bin/python -m pytest tests/ -v`

Fixes #73