### PR TITLE
Port telemetry and project-leverage collector subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1615,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "chrono",
+ "chrono-tz",
  "clap",
  "futures-util",
  "ipnet",
@@ -1743,6 +1754,24 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2494,6 +2523,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1"
 axum = { version = "0.8", features = ["multipart", "ws"] }
 base64 = "0.22"
 chrono = "0.4"
+chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive", "env"] }
 futures-util = "0.3"
 ipnet = "2"

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -457,6 +457,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: root.join("telemetry.db"),
+                session_tool_usage_db_path: root.join("claude-tool-usage.db"),
                 tool_usage_db_path: root.join("tool-usage.db"),
                 engram_db_path: root.join("engram.db"),
                 engram_registry_path: root.join("engram-registry.json"),

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -359,7 +359,7 @@ mod tests {
     use crate::{
         config::{
             ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+            RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
         },
         db,
         erv::BoxFutureResult,
@@ -443,6 +443,7 @@ mod tests {
             },
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
+            telemetry: TelemetryConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),
                 config_path: root.join("config.yaml"),
@@ -455,6 +456,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: root.join("telemetry.db"),
+                tool_usage_db_path: root.join("tool-usage.db"),
+                engram_db_path: root.join("engram.db"),
+                engram_registry_path: root.join("engram-registry.json"),
             },
         }
     }

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 
 use crate::{config::AppConfig, db, erv, http, hvac, presence, telemetry};
@@ -41,8 +41,8 @@ pub struct SmokeArgs {
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct CollectArgs {
-    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
-    pub config: PathBuf,
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG", global = true)]
+    pub config: Option<PathBuf>,
     #[command(subcommand)]
     pub target: CollectTarget,
 }
@@ -98,7 +98,10 @@ pub async fn run(cli: Cli) -> Result<()> {
             run_smoke(&config, args.target).await
         }
         Command::Collect(args) => {
-            let config = AppConfig::load(&args.config)?;
+            let config_path = args
+                .config
+                .context("collect requires --config or OFFICE_AUTOMATE_CONFIG")?;
+            let config = AppConfig::load(&config_path)?;
             run_collect(&config, args.target)
         }
     }
@@ -297,7 +300,31 @@ mod tests {
 
         match cli.command {
             Command::Collect(args) => {
-                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.config, Some(PathBuf::from("/tmp/office.yaml")));
+                assert_eq!(
+                    args.target,
+                    CollectTarget::Telemetry(CollectTelemetryArgs { dry_run: true })
+                );
+            }
+            other => panic!("expected collect command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_collect_telemetry_command_with_config_after_target() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "collect",
+            "telemetry",
+            "--config",
+            "/tmp/office.yaml",
+            "--dry-run",
+        ])
+        .expect("collect command should parse");
+
+        match cli.command {
+            Command::Collect(args) => {
+                assert_eq!(args.config, Some(PathBuf::from("/tmp/office.yaml")));
                 assert_eq!(
                     args.target,
                     CollectTarget::Telemetry(CollectTelemetryArgs { dry_run: true })
@@ -320,7 +347,7 @@ mod tests {
 
         match cli.command {
             Command::Collect(args) => {
-                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.config, Some(PathBuf::from("/tmp/office.yaml")));
                 assert_eq!(args.target, CollectTarget::Leverage);
             }
             other => panic!("expected collect command, got {other:?}"),

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-use crate::{config::AppConfig, db, erv, http, hvac, presence};
+use crate::{config::AppConfig, db, erv, http, hvac, presence, telemetry};
 
 #[derive(Debug, Parser)]
 #[command(name = "office-automate-server")]
@@ -21,6 +21,8 @@ pub enum Command {
     Migrate(ConfigArgs),
     /// Run local dependency checks without changing device state.
     Smoke(SmokeArgs),
+    /// Run local telemetry collectors.
+    Collect(CollectArgs),
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -37,6 +39,14 @@ pub struct SmokeArgs {
     pub target: Option<SmokeTarget>,
 }
 
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct CollectArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[command(subcommand)]
+    pub target: CollectTarget,
+}
+
 #[derive(Debug, Subcommand, Clone, Copy, PartialEq, Eq)]
 pub enum SmokeTarget {
     /// Verify local ERV read credential and connectivity.
@@ -45,6 +55,20 @@ pub enum SmokeTarget {
     Hvac,
     /// Verify macOS keyboard/display presence signals.
     Presence,
+}
+
+#[derive(Debug, Subcommand, Clone, Copy, PartialEq, Eq)]
+pub enum CollectTarget {
+    /// Collect session-output telemetry into telemetry.db.
+    Telemetry(CollectTelemetryArgs),
+    /// Collect project leverage rows into office_climate.db.
+    Leverage,
+}
+
+#[derive(Debug, Args, Clone, Copy, PartialEq, Eq)]
+pub struct CollectTelemetryArgs {
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 pub async fn run_cli() -> Result<()> {
@@ -72,6 +96,10 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Smoke(args) => {
             let config = AppConfig::load(&args.config)?;
             run_smoke(&config, args.target).await
+        }
+        Command::Collect(args) => {
+            let config = AppConfig::load(&args.config)?;
+            run_collect(&config, args.target)
         }
     }
 }
@@ -117,6 +145,23 @@ fn smoke_targets(target: Option<SmokeTarget>) -> &'static [SmokeTarget] {
         Some(SmokeTarget::Presence) => &[SmokeTarget::Presence],
         None => &[SmokeTarget::Erv, SmokeTarget::Hvac, SmokeTarget::Presence],
     }
+}
+
+fn run_collect(config: &AppConfig, target: CollectTarget) -> Result<()> {
+    match target {
+        CollectTarget::Telemetry(args) => {
+            let stats = telemetry::collect_telemetry(config, args.dry_run)?;
+            println!(
+                "Telemetry collection complete: sessions={} rows_written={} synthetic_rows={} matched_commits={}",
+                stats.sessions, stats.rows_written, stats.synthetic_rows, stats.matched_commits
+            );
+        }
+        CollectTarget::Leverage => {
+            let rows = telemetry::collect_project_leverage(config)?;
+            println!("Project leverage collection complete: rows_written={rows}");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -235,6 +280,50 @@ mod tests {
                 assert_eq!(args.target, Some(SmokeTarget::Presence));
             }
             other => panic!("expected smoke command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_collect_telemetry_command_with_dry_run() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "collect",
+            "--config",
+            "/tmp/office.yaml",
+            "telemetry",
+            "--dry-run",
+        ])
+        .expect("collect command should parse");
+
+        match cli.command {
+            Command::Collect(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(
+                    args.target,
+                    CollectTarget::Telemetry(CollectTelemetryArgs { dry_run: true })
+                );
+            }
+            other => panic!("expected collect command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_collect_leverage_command() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "collect",
+            "--config",
+            "/tmp/office.yaml",
+            "leverage",
+        ])
+        .expect("collect command should parse");
+
+        match cli.command {
+            Command::Collect(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.target, CollectTarget::Leverage);
+            }
+            other => panic!("expected collect command, got {other:?}"),
         }
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -42,6 +42,7 @@ impl Default for PresenceConfig {
 pub struct TelemetryConfig {
     pub repos: Vec<PathBuf>,
     pub tool_usage_db: Option<PathBuf>,
+    pub session_tool_usage_db: Option<PathBuf>,
     pub telemetry_db: Option<PathBuf>,
     pub engram_db: Option<PathBuf>,
     pub engram_registry: Option<PathBuf>,
@@ -345,6 +346,7 @@ pub struct RuntimeConfig {
     pub mqtt_host: String,
     pub mqtt_port: u16,
     pub telemetry_db_path: PathBuf,
+    pub session_tool_usage_db_path: PathBuf,
     pub tool_usage_db_path: PathBuf,
     pub engram_db_path: PathBuf,
     pub engram_registry_path: PathBuf,
@@ -483,6 +485,10 @@ impl AppConfig {
             file_config.telemetry.tool_usage_db = Some(PathBuf::from(path));
         }
 
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_SESSION_TOOL_USAGE_DB") {
+            file_config.telemetry.session_tool_usage_db = Some(PathBuf::from(path));
+        }
+
         if let Some(path) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_DB") {
             file_config.telemetry.telemetry_db = Some(PathBuf::from(path));
         }
@@ -511,21 +517,41 @@ impl AppConfig {
             .telemetry
             .telemetry_db
             .clone()
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
             .unwrap_or_else(|| data_dir.join("telemetry.db"));
+        let default_session_tool_usage_db_path = home_dir
+            .as_deref()
+            .map(|home| {
+                home.join(".local")
+                    .join("share")
+                    .join("claude-sessions")
+                    .join("tool_usage.db")
+            })
+            .unwrap_or_else(|| data_dir.join("tool_usage.db"));
+        let session_tool_usage_db_path = file_config
+            .telemetry
+            .session_tool_usage_db
+            .clone()
+            .or_else(|| file_config.telemetry.tool_usage_db.clone())
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
+            .unwrap_or(default_session_tool_usage_db_path);
         let tool_usage_db_path = file_config
             .telemetry
             .tool_usage_db
             .clone()
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
             .unwrap_or_else(|| data_dir.join("tool_usage.db"));
         let engram_db_path = file_config
             .telemetry
             .engram_db
             .clone()
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
             .unwrap_or_else(|| data_dir.join("engram_state.db"));
         let engram_registry_path = file_config
             .telemetry
             .engram_registry
             .clone()
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
             .unwrap_or_else(|| data_dir.join("engram_concept_registry.md"));
 
         let runtime = RuntimeConfig {
@@ -541,6 +567,7 @@ impl AppConfig {
             mqtt_host: file_config.qingping.mqtt_broker.clone(),
             mqtt_port: file_config.qingping.mqtt_port,
             telemetry_db_path,
+            session_tool_usage_db_path,
             tool_usage_db_path,
             engram_db_path,
             engram_registry_path,
@@ -658,6 +685,13 @@ thresholds:
                     .display()
                     .to_string(),
             ),
+            "OFFICE_AUTOMATE_SESSION_TOOL_USAGE_DB" => Some(
+                temp_dir
+                    .path()
+                    .join("session_tool_usage.sqlite")
+                    .display()
+                    .to_string(),
+            ),
             "OFFICE_AUTOMATE_TELEMETRY_DB" => Some(
                 temp_dir
                     .path()
@@ -735,6 +769,10 @@ thresholds:
             temp_dir.path().join("tool_usage.sqlite")
         );
         assert_eq!(
+            config.runtime.session_tool_usage_db_path,
+            temp_dir.path().join("session_tool_usage.sqlite")
+        );
+        assert_eq!(
             config.runtime.telemetry_db_path,
             temp_dir.path().join("telemetry.sqlite")
         );
@@ -786,6 +824,21 @@ telemetry:
             config.telemetry.repos,
             vec![home_dir.join("Desktop/automation/office-automate")]
         );
+        assert_eq!(
+            config.runtime.session_tool_usage_db_path,
+            home_dir
+                .join(".local")
+                .join("share")
+                .join("claude-sessions")
+                .join("tool_usage.db")
+        );
+        assert_eq!(
+            config.runtime.tool_usage_db_path,
+            std::env::current_dir()
+                .expect("current dir")
+                .join("data")
+                .join("tool_usage.db")
+        );
 
         let config = AppConfig::load_with_env(&config_path, |key| match key {
             "HOME" => Some(home_dir.display().to_string()),
@@ -798,5 +851,36 @@ telemetry:
             config.telemetry.repos,
             vec![home_dir.join("repo-a"), PathBuf::from("/absolute/repo-b")]
         );
+    }
+
+    #[test]
+    fn explicit_tool_usage_db_applies_to_session_telemetry_unless_split() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let home_dir = temp_dir.path().join("home");
+        let config_path = temp_dir.path().join("config.yaml");
+        fs::write(&config_path, "telemetry: {}\n").expect("write config");
+
+        let shared_tool_db = home_dir.join("shared-tool-usage.db");
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "HOME" => Some(home_dir.display().to_string()),
+            "OFFICE_AUTOMATE_TOOL_USAGE_DB" => Some("~/shared-tool-usage.db".to_string()),
+            _ => None,
+        })
+        .expect("load config");
+
+        assert_eq!(config.runtime.tool_usage_db_path, shared_tool_db);
+        assert_eq!(config.runtime.session_tool_usage_db_path, shared_tool_db);
+
+        let split_session_db = home_dir.join("claude-tool-usage.db");
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "HOME" => Some(home_dir.display().to_string()),
+            "OFFICE_AUTOMATE_TOOL_USAGE_DB" => Some("~/shared-tool-usage.db".to_string()),
+            "OFFICE_AUTOMATE_SESSION_TOOL_USAGE_DB" => Some("~/claude-tool-usage.db".to_string()),
+            _ => None,
+        })
+        .expect("load config");
+
+        assert_eq!(config.runtime.tool_usage_db_path, shared_tool_db);
+        assert_eq!(config.runtime.session_tool_usage_db_path, split_session_db);
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -393,6 +393,7 @@ impl AppConfig {
         let data_dir = env_lookup("OFFICE_AUTOMATE_DATA_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| root.join("data"));
+        let home_dir = env_lookup("HOME").map(PathBuf::from);
 
         if let Some(host) = env_lookup("OFFICE_AUTOMATE_MQTT_HOST") {
             file_config.qingping.mqtt_broker = host;
@@ -499,6 +500,12 @@ impl AppConfig {
                 format!("invalid OFFICE_AUTOMATE_TELEMETRY_DAYS value {days:?}")
             })?;
         }
+        file_config.telemetry.repos = file_config
+            .telemetry
+            .repos
+            .into_iter()
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
+            .collect();
 
         let telemetry_db_path = file_config
             .telemetry
@@ -559,6 +566,22 @@ fn parse_bool_env(name: &str, value: &str) -> Result<bool> {
         "0" | "false" | "no" | "off" => Ok(false),
         _ => anyhow::bail!("invalid {name} value {value:?}; expected true/false"),
     }
+}
+
+fn expand_home_relative_path(path: PathBuf, home_dir: Option<&Path>) -> PathBuf {
+    let Some(home_dir) = home_dir else {
+        return path;
+    };
+    let Some(raw_path) = path.to_str() else {
+        return path;
+    };
+    if raw_path == "~" {
+        return home_dir.to_path_buf();
+    }
+    raw_path
+        .strip_prefix("~/")
+        .map(|suffix| home_dir.join(suffix))
+        .unwrap_or(path)
 }
 
 #[cfg(test)]
@@ -736,5 +759,44 @@ thresholds:
         assert_eq!(config.thresholds.hvac_cool_on_temp_f, 82);
         assert_eq!(config.thresholds.expected_occupancy_start, "08:30");
         assert_eq!(config.thresholds.expected_occupancy_end, "18:45");
+    }
+
+    #[test]
+    fn expands_home_relative_telemetry_repo_paths() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let home_dir = temp_dir.path().join("home");
+        let config_path = temp_dir.path().join("config.yaml");
+        fs::write(
+            &config_path,
+            r#"
+telemetry:
+  repos:
+    - "~/Desktop/automation/office-automate"
+"#,
+        )
+        .expect("write config");
+
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "HOME" => Some(home_dir.display().to_string()),
+            _ => None,
+        })
+        .expect("load config");
+
+        assert_eq!(
+            config.telemetry.repos,
+            vec![home_dir.join("Desktop/automation/office-automate")]
+        );
+
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "HOME" => Some(home_dir.display().to_string()),
+            "OFFICE_AUTOMATE_TELEMETRY_REPOS" => Some("~/repo-a,/absolute/repo-b".to_string()),
+            _ => None,
+        })
+        .expect("load config");
+
+        assert_eq!(
+            config.telemetry.repos,
+            vec![home_dir.join("repo-a"), PathBuf::from("/absolute/repo-b")]
+        );
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -15,6 +15,7 @@ pub struct AppConfig {
     pub erv: ErvConfig,
     pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
+    pub telemetry: TelemetryConfig,
     pub runtime: RuntimeConfig,
 }
 
@@ -34,6 +35,17 @@ impl Default for PresenceConfig {
             command_timeout_seconds: 10,
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(default)]
+pub struct TelemetryConfig {
+    pub repos: Vec<PathBuf>,
+    pub tool_usage_db: Option<PathBuf>,
+    pub telemetry_db: Option<PathBuf>,
+    pub engram_db: Option<PathBuf>,
+    pub engram_registry: Option<PathBuf>,
+    pub days: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -332,6 +344,10 @@ pub struct RuntimeConfig {
     pub public_url: Option<String>,
     pub mqtt_host: String,
     pub mqtt_port: u16,
+    pub telemetry_db_path: PathBuf,
+    pub tool_usage_db_path: PathBuf,
+    pub engram_db_path: PathBuf,
+    pub engram_registry_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -344,6 +360,7 @@ struct FileConfig {
     erv: ErvConfig,
     mitsubishi: MitsubishiConfig,
     thresholds: ThresholdsConfig,
+    telemetry: TelemetryConfig,
 }
 
 impl AppConfig {
@@ -452,6 +469,58 @@ impl AppConfig {
             })?;
         }
 
+        if let Some(repos) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_REPOS") {
+            file_config.telemetry.repos = repos
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .collect();
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_TOOL_USAGE_DB") {
+            file_config.telemetry.tool_usage_db = Some(PathBuf::from(path));
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_DB") {
+            file_config.telemetry.telemetry_db = Some(PathBuf::from(path));
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_ENGRAM_DB") {
+            file_config.telemetry.engram_db = Some(PathBuf::from(path));
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_ENGRAM_REGISTRY") {
+            file_config.telemetry.engram_registry = Some(PathBuf::from(path));
+        }
+
+        if let Some(days) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_DAYS") {
+            file_config.telemetry.days = days.parse().with_context(|| {
+                format!("invalid OFFICE_AUTOMATE_TELEMETRY_DAYS value {days:?}")
+            })?;
+        }
+
+        let telemetry_db_path = file_config
+            .telemetry
+            .telemetry_db
+            .clone()
+            .unwrap_or_else(|| data_dir.join("telemetry.db"));
+        let tool_usage_db_path = file_config
+            .telemetry
+            .tool_usage_db
+            .clone()
+            .unwrap_or_else(|| data_dir.join("tool_usage.db"));
+        let engram_db_path = file_config
+            .telemetry
+            .engram_db
+            .clone()
+            .unwrap_or_else(|| data_dir.join("engram_state.db"));
+        let engram_registry_path = file_config
+            .telemetry
+            .engram_registry
+            .clone()
+            .unwrap_or_else(|| data_dir.join("engram_concept_registry.md"));
+
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
             root,
@@ -464,6 +533,10 @@ impl AppConfig {
             public_url: env_lookup("OFFICE_AUTOMATE_PUBLIC_URL"),
             mqtt_host: file_config.qingping.mqtt_broker.clone(),
             mqtt_port: file_config.qingping.mqtt_port,
+            telemetry_db_path,
+            tool_usage_db_path,
+            engram_db_path,
+            engram_registry_path,
         };
 
         Ok(Self {
@@ -474,6 +547,7 @@ impl AppConfig {
             erv: file_config.erv,
             mitsubishi: file_config.mitsubishi,
             thresholds: file_config.thresholds,
+            telemetry: file_config.telemetry,
             runtime,
         })
     }
@@ -503,6 +577,9 @@ orchestrator:
   port: 9001
 presence:
   poll_interval_seconds: 7
+telemetry:
+  repos:
+    - "/yaml/repo"
 qingping:
   mqtt_broker: "legacy-broker"
   mqtt_port: 1883
@@ -550,6 +627,28 @@ thresholds:
             "OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS" => Some("3".to_string()),
+            "OFFICE_AUTOMATE_TELEMETRY_REPOS" => Some("/env/repo-a,/env/repo-b".to_string()),
+            "OFFICE_AUTOMATE_TOOL_USAGE_DB" => Some(
+                temp_dir
+                    .path()
+                    .join("tool_usage.sqlite")
+                    .display()
+                    .to_string(),
+            ),
+            "OFFICE_AUTOMATE_TELEMETRY_DB" => Some(
+                temp_dir
+                    .path()
+                    .join("telemetry.sqlite")
+                    .display()
+                    .to_string(),
+            ),
+            "OFFICE_AUTOMATE_ENGRAM_DB" => {
+                Some(temp_dir.path().join("engram.sqlite").display().to_string())
+            }
+            "OFFICE_AUTOMATE_ENGRAM_REGISTRY" => {
+                Some(temp_dir.path().join("registry.md").display().to_string())
+            }
+            "OFFICE_AUTOMATE_TELEMETRY_DAYS" => Some("14".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             _ => None,
         })
@@ -560,6 +659,11 @@ thresholds:
         assert!(config.presence.enabled);
         assert_eq!(config.presence.poll_interval_seconds, 7);
         assert_eq!(config.presence.command_timeout_seconds, 3);
+        assert_eq!(
+            config.telemetry.repos,
+            vec![PathBuf::from("/env/repo-a"), PathBuf::from("/env/repo-b")]
+        );
+        assert_eq!(config.telemetry.days, 14);
         assert_eq!(config.qingping.mqtt_broker, "rust-broker");
         assert_eq!(config.qingping.mqtt_port, 2883);
         assert_eq!(config.yolink.uaid, "env-uaid");
@@ -602,6 +706,22 @@ thresholds:
         assert_eq!(
             config.runtime.artifacts_dir,
             temp_dir.path().join("db").join("apps")
+        );
+        assert_eq!(
+            config.runtime.tool_usage_db_path,
+            temp_dir.path().join("tool_usage.sqlite")
+        );
+        assert_eq!(
+            config.runtime.telemetry_db_path,
+            temp_dir.path().join("telemetry.sqlite")
+        );
+        assert_eq!(
+            config.runtime.engram_db_path,
+            temp_dir.path().join("engram.sqlite")
+        );
+        assert_eq!(
+            config.runtime.engram_registry_path,
+            temp_dir.path().join("registry.md")
         );
         assert_eq!(
             config.runtime.legacy_apk_path,

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -800,6 +800,15 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
 }
 
 pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
+    let telemetry_path = telemetry_database_path(database_path);
+    read_leverage_history_with_telemetry(database_path, &telemetry_path, days)
+}
+
+pub fn read_leverage_history_with_telemetry(
+    database_path: &Path,
+    telemetry_database_path: &Path,
+    days: i64,
+) -> Result<Value> {
     let connection = Connection::open(database_path)
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
     let now = Local::now().naive_local();
@@ -835,7 +844,7 @@ pub fn read_leverage_history(database_path: &Path, days: i64) -> Result<Value> {
         }
     }
 
-    for row in read_leverage_session_rows(&connection, database_path, &cutoff)? {
+    for row in read_leverage_session_rows(&connection, telemetry_database_path, &cutoff)? {
         if let Some(day) = grouped.get_mut(&row.date) {
             day.lines_added = row.lines_added;
             day.lines_removed = row.lines_removed;
@@ -903,12 +912,11 @@ struct LeverageSessionRow {
 
 fn read_leverage_session_rows(
     connection: &Connection,
-    database_path: &Path,
+    telemetry_database_path: &Path,
     cutoff: &str,
 ) -> Result<Vec<LeverageSessionRow>> {
-    let telemetry_path = telemetry_database_path(database_path);
-    ensure_telemetry_database(&telemetry_path)?;
-    let telemetry_path = telemetry_path.to_string_lossy().to_string();
+    ensure_telemetry_database(telemetry_database_path)?;
+    let telemetry_path = telemetry_database_path.to_string_lossy().to_string();
     connection
         .execute("ATTACH DATABASE ? AS telemetry", params![telemetry_path])
         .context("failed to attach telemetry database")?;
@@ -956,14 +964,14 @@ fn query_attached_leverage_session_rows(
         .context("failed to read leverage session rows")
 }
 
-fn telemetry_database_path(database_path: &Path) -> PathBuf {
+pub fn telemetry_database_path(database_path: &Path) -> PathBuf {
     database_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("telemetry.db")
 }
 
-fn ensure_telemetry_database(database_path: &Path) -> Result<()> {
+pub fn ensure_telemetry_database(database_path: &Path) -> Result<()> {
     if let Some(parent) = database_path.parent() {
         fs::create_dir_all(parent).with_context(|| {
             format!(
@@ -982,6 +990,125 @@ fn ensure_telemetry_database(database_path: &Path) -> Result<()> {
     connection
         .execute_batch(SESSION_OUTPUT_SCHEMA)
         .context("failed to apply telemetry SQLite schema")
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionOutputRow {
+    pub session_id: String,
+    pub project: String,
+    pub start_time: String,
+    pub duration_minutes: i64,
+    pub lines_added: i64,
+    pub lines_removed: i64,
+    pub files_modified: i64,
+    pub git_commits: i64,
+    pub git_pushes: i64,
+    pub user_message_count: i64,
+    pub assistant_message_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub tool_counts: Option<String>,
+    pub languages: Option<String>,
+    pub is_human_session: bool,
+}
+
+pub fn upsert_collector_session_output_rows(
+    telemetry_database_path: &Path,
+    rows: &[SessionOutputRow],
+) -> Result<usize> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    ensure_telemetry_database(telemetry_database_path)?;
+    let mut connection = Connection::open(telemetry_database_path).with_context(|| {
+        format!(
+            "failed to open telemetry SQLite database {}",
+            telemetry_database_path.display()
+        )
+    })?;
+    let transaction = connection.transaction()?;
+    {
+        let mut statement = transaction.prepare(
+            "INSERT INTO session_output (
+                session_id, project, start_time, duration_minutes, lines_added, lines_removed,
+                files_modified, git_commits, git_pushes, user_message_count,
+                assistant_message_count, input_tokens, output_tokens, tool_counts, languages,
+                is_human_session
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                project = excluded.project,
+                start_time = excluded.start_time,
+                duration_minutes = excluded.duration_minutes,
+                lines_added = excluded.lines_added,
+                lines_removed = excluded.lines_removed,
+                files_modified = excluded.files_modified,
+                git_commits = excluded.git_commits,
+                git_pushes = excluded.git_pushes,
+                tool_counts = excluded.tool_counts,
+                is_human_session = excluded.is_human_session
+            WHERE session_output.user_message_count = 0
+              AND session_output.assistant_message_count = 0
+              AND session_output.input_tokens = 0
+              AND session_output.output_tokens = 0",
+        )?;
+        for row in rows {
+            statement.execute(params![
+                row.session_id,
+                row.project,
+                row.start_time,
+                row.duration_minutes,
+                row.lines_added,
+                row.lines_removed,
+                row.files_modified,
+                row.git_commits,
+                row.git_pushes,
+                row.user_message_count,
+                row.assistant_message_count,
+                row.input_tokens,
+                row.output_tokens,
+                row.tool_counts,
+                row.languages,
+                if row.is_human_session { 1 } else { 0 },
+            ])?;
+        }
+    }
+    transaction.commit()?;
+    Ok(rows.len())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectLeverageRow {
+    pub date: String,
+    pub project: String,
+    pub metric: String,
+    pub value: f64,
+}
+
+pub fn upsert_project_leverage_rows(
+    database_path: &Path,
+    rows: &[ProjectLeverageRow],
+) -> Result<usize> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    migrate_database(database_path)?;
+    let mut connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let transaction = connection.transaction()?;
+    {
+        let mut statement = transaction.prepare(
+            "INSERT INTO project_leverage (date, project, metric, value)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(date, project, metric) DO UPDATE SET value = excluded.value",
+        )?;
+        for row in rows {
+            statement.execute(params![row.date, row.project, row.metric, row.value])?;
+        }
+    }
+    transaction.commit()?;
+    Ok(rows.len())
 }
 
 pub fn read_project_leverage(database_path: &Path, days: i64) -> Result<Value> {
@@ -1404,7 +1531,7 @@ impl ProjectFocusItem {
     }
 }
 
-fn normalize_project_name(project: &str) -> String {
+pub(crate) fn normalize_project_name(project: &str) -> String {
     let basename = project
         .trim()
         .replace('\\', "/")
@@ -1845,6 +1972,45 @@ mod tests {
         assert_eq!(payload["week"]["files_modified"], 6);
         assert_eq!(payload["week"]["commits"], 8);
         assert_eq!(payload["week"]["lines_per_session_minute"], 5.0);
+    }
+
+    #[test]
+    fn leverage_history_reads_configured_telemetry_database() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let telemetry_path = temp_dir.path().join("custom").join("telemetry.sqlite");
+        migrate_database(&db_path).expect("migration");
+        ensure_telemetry_database(&telemetry_path).expect("telemetry schema");
+
+        let today = Local::now().naive_local().date();
+        let timestamp = format_timestamp(day_start(today) + Duration::hours(10));
+        {
+            let connection = Connection::open(&telemetry_path).expect("open telemetry database");
+            connection
+                .execute(
+                    "INSERT INTO session_output \
+                     (session_id, project, start_time, duration_minutes, lines_added, lines_removed, files_modified, git_commits) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "session-1",
+                        "office-automate",
+                        &timestamp,
+                        10,
+                        40,
+                        2,
+                        1,
+                        3,
+                    ),
+                )
+                .expect("insert session output row");
+        }
+
+        let payload = read_leverage_history_with_telemetry(&db_path, &telemetry_path, 1)
+            .expect("leverage history");
+
+        assert_eq!(payload["days"][0]["lines_added"], 40);
+        assert_eq!(payload["days"][0]["lines_removed"], 2);
+        assert_eq!(payload["week"]["commits"], 3);
     }
 
     #[test]

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -954,6 +954,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: PathBuf::from("/tmp/office/data/telemetry.db"),
+                session_tool_usage_db_path: PathBuf::from("/tmp/office/data/claude_tool_usage.db"),
                 tool_usage_db_path: PathBuf::from("/tmp/office/data/tool_usage.db"),
                 engram_db_path: PathBuf::from("/tmp/office/data/engram_state.db"),
                 engram_registry_path: PathBuf::from("/tmp/office/data/engram_concept_registry.md"),

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -940,6 +940,7 @@ mod tests {
             erv,
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
+            telemetry: crate::config::TelemetryConfig::default(),
             runtime: RuntimeConfig {
                 root: PathBuf::from("/tmp/office"),
                 config_path: PathBuf::from("/tmp/office/config.yaml"),
@@ -952,6 +953,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: PathBuf::from("/tmp/office/data/telemetry.db"),
+                tool_usage_db_path: PathBuf::from("/tmp/office/data/tool_usage.db"),
+                engram_db_path: PathBuf::from("/tmp/office/data/engram_state.db"),
+                engram_registry_path: PathBuf::from("/tmp/office/data/engram_concept_registry.md"),
             },
         }
     }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1648,7 +1648,11 @@ async fn history_leverage(
     Query(query): Query<HistoryQuery>,
 ) -> Response {
     let days = clamp(query.days, 7, 1, 30);
-    match db::read_leverage_history(&state.config.runtime.database_path, days) {
+    match db::read_leverage_history_with_telemetry(
+        &state.config.runtime.database_path,
+        &state.config.runtime.telemetry_db_path,
+        days,
+    ) {
         Ok(payload) => Json(json!({"ok": true, "days": payload["days"], "week": payload["week"]}))
             .into_response(),
         Err(error) => history_error("history/leverage", error),
@@ -2236,6 +2240,7 @@ mod tests {
             erv: ErvConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
+            telemetry: crate::config::TelemetryConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),
                 config_path: root.join("config.yaml"),
@@ -2248,6 +2253,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: root.join("data/telemetry.db"),
+                tool_usage_db_path: root.join("data/tool_usage.db"),
+                engram_db_path: root.join("data/engram_state.db"),
+                engram_registry_path: root.join("data/engram_concept_registry.md"),
             },
         }
     }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2254,6 +2254,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: root.join("data/telemetry.db"),
+                session_tool_usage_db_path: root.join("data/claude_tool_usage.db"),
                 tool_usage_db_path: root.join("data/tool_usage.db"),
                 engram_db_path: root.join("data/engram_state.db"),
                 engram_registry_path: root.join("data/engram_concept_registry.md"),

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -913,6 +913,7 @@ mod tests {
             erv: crate::config::ErvConfig::default(),
             mitsubishi: crate::config::MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
+            telemetry: crate::config::TelemetryConfig::default(),
             runtime: crate::config::RuntimeConfig {
                 root: "/tmp/office".into(),
                 config_path: "/tmp/office/config.yaml".into(),
@@ -925,6 +926,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: "/tmp/office/data/telemetry.db".into(),
+                tool_usage_db_path: "/tmp/office/data/tool_usage.db".into(),
+                engram_db_path: "/tmp/office/data/engram_state.db".into(),
+                engram_registry_path: "/tmp/office/data/engram_concept_registry.md".into(),
             },
         });
         hvac.overlay_status(&mut status);

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -927,6 +927,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: "/tmp/office/data/telemetry.db".into(),
+                session_tool_usage_db_path: "/tmp/office/data/claude_tool_usage.db".into(),
                 tool_usage_db_path: "/tmp/office/data/tool_usage.db".into(),
                 engram_db_path: "/tmp/office/data/engram_state.db".into(),
                 engram_registry_path: "/tmp/office/data/engram_concept_registry.md".into(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod presence;
 pub mod qingping;
 pub mod state;
 pub mod status;
+pub mod telemetry;
 pub mod yolink;
 
 pub use cli::run_cli;

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -277,6 +277,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: PathBuf::from("/tmp/office/data/telemetry.db"),
+                session_tool_usage_db_path: PathBuf::from("/tmp/office/data/claude_tool_usage.db"),
                 tool_usage_db_path: PathBuf::from("/tmp/office/data/tool_usage.db"),
                 engram_db_path: PathBuf::from("/tmp/office/data/engram_state.db"),
                 engram_registry_path: PathBuf::from("/tmp/office/data/engram_concept_registry.md"),

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -241,7 +241,7 @@ mod tests {
     use super::*;
     use crate::config::{
         ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-        RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+        RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -263,6 +263,7 @@ mod tests {
                 away_stale_flush_enabled: false,
                 ..ThresholdsConfig::default()
             },
+            telemetry: TelemetryConfig::default(),
             runtime: RuntimeConfig {
                 root: PathBuf::from("/tmp/office"),
                 config_path: PathBuf::from("/tmp/office/config.yaml"),
@@ -275,6 +276,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: PathBuf::from("/tmp/office/data/telemetry.db"),
+                tool_usage_db_path: PathBuf::from("/tmp/office/data/tool_usage.db"),
+                engram_db_path: PathBuf::from("/tmp/office/data/engram_state.db"),
+                engram_registry_path: PathBuf::from("/tmp/office/data/engram_concept_registry.md"),
             },
         }
     }

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -59,7 +59,7 @@ pub fn collect_telemetry(config: &AppConfig, dry_run: bool) -> Result<TelemetryC
         config.telemetry.days
     };
     collect_session_telemetry(
-        &config.runtime.tool_usage_db_path,
+        &config.runtime.session_tool_usage_db_path,
         &config.runtime.telemetry_db_path,
         &config.telemetry.repos,
         days,

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Duration, Local, NaiveDateTime};
+use chrono_tz::America::Los_Angeles;
 use rusqlite::{Connection, OptionalExtension, params};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -759,7 +760,7 @@ fn parse_datetime(value: &str) -> Result<NaiveDateTime> {
         normalized.to_string()
     };
     if let Ok(timestamp) = DateTime::parse_from_rfc3339(&rfc3339) {
-        return Ok(timestamp.with_timezone(&Local).naive_local());
+        return Ok(timestamp.with_timezone(&Los_Angeles).naive_local());
     }
     for format in [
         "%Y-%m-%d %H:%M:%S%.f",
@@ -1224,6 +1225,18 @@ mod tests {
         assert_eq!(
             parse_shortstat(" 1 file changed, 1 insertion(+)"),
             Some((1, 1, 0))
+        );
+    }
+
+    #[test]
+    fn parses_offset_timestamps_as_pacific_database_time() {
+        assert_eq!(
+            parse_datetime("2026-03-27T16:00:10Z").expect("timestamp"),
+            parse_datetime("2026-03-27 09:00:10").expect("pacific timestamp")
+        );
+        assert_eq!(
+            parse_datetime("2026-01-15T18:30:00Z").expect("timestamp"),
+            parse_datetime("2026-01-15 10:30:00").expect("pacific timestamp")
         );
     }
 }

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -97,8 +97,6 @@ pub fn collect_session_telemetry(
 
     if !dry_run {
         db::upsert_collector_session_output_rows(telemetry_db_path, &rows)?;
-    } else {
-        db::ensure_telemetry_database(telemetry_db_path)?;
     }
 
     let synthetic_rows = rows
@@ -341,7 +339,7 @@ fn session_row(session: &SessionInfo, matched_commits: &[CommitStats]) -> Result
             .iter()
             .map(|commit| commit.files_changed)
             .sum(),
-        git_commits: session.git_commits.len() as i64,
+        git_commits: matched_commits.len() as i64,
         git_pushes: session
             .git_pushes
             .iter()
@@ -944,6 +942,18 @@ mod tests {
             &repo,
             "PreToolUse",
         );
+        insert_tool_usage(
+            &tool_db,
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            Some("git commit -m manual"),
+            "2026-03-27 11:00:00",
+            &repo,
+            "PreToolUse",
+        );
 
         let stats = collect_session_telemetry(
             &tool_db,
@@ -993,12 +1003,42 @@ mod tests {
         assert_eq!(rows[0].2, 1);
         assert_eq!(rows[0].3, 1);
         assert_eq!(rows[0].4, 1);
-        assert_eq!(rows[0].5.as_deref(), Some(r#"{"Bash":2,"Read":1}"#));
+        assert_eq!(rows[0].5.as_deref(), Some(r#"{"Bash":3,"Read":1}"#));
         assert_eq!(rows[0].6, 1);
         assert!(rows[1].0.starts_with("unattributed-office-automate-"));
         assert_eq!(rows[1].1, 1);
         assert_eq!(rows[1].3, 1);
         assert_eq!(rows[1].6, 0);
+    }
+
+    #[test]
+    fn collect_telemetry_dry_run_does_not_create_output_database() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let tool_db = temp_dir.path().join("tool_usage.db");
+        let telemetry_db = temp_dir.path().join("missing").join("telemetry.db");
+        create_tool_usage_db(&tool_db);
+
+        let stats = collect_session_telemetry(
+            &tool_db,
+            &telemetry_db,
+            &[],
+            30,
+            true,
+            parse_datetime("2026-03-28 12:00:00").expect("now"),
+        )
+        .expect("collect");
+
+        assert_eq!(
+            stats,
+            TelemetryCollectStats {
+                sessions: 0,
+                rows_written: 0,
+                synthetic_rows: 0,
+                matched_commits: 0,
+            }
+        );
+        assert!(!telemetry_db.exists());
+        assert!(!telemetry_db.parent().expect("parent").exists());
     }
 
     #[test]

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -82,6 +82,7 @@ pub fn collect_session_telemetry(
     let commits_by_repo = collect_git_stats(repos, start_of_day(cutoff))?;
 
     let mut matched_hashes = HashSet::new();
+    let mut unmatched_commit_commands: BTreeMap<(String, String), usize> = BTreeMap::new();
     let mut rows = Vec::new();
     for session in sessions.values() {
         let mut matched_commits = Vec::new();
@@ -89,12 +90,21 @@ pub fn collect_session_telemetry(
             if let Some(commit) = match_commit(command, &commits_by_repo, &matched_hashes) {
                 matched_hashes.insert(commit.commit_hash.clone());
                 matched_commits.push(commit);
+            } else {
+                let date = command.timestamp.date().to_string();
+                *unmatched_commit_commands
+                    .entry((command.repo.clone(), date))
+                    .or_insert(0) += 1;
             }
         }
         rows.push(session_row(session, &matched_commits)?);
     }
 
-    rows.extend(synthetic_rows(&commits_by_repo, &matched_hashes));
+    rows.extend(synthetic_rows(
+        &commits_by_repo,
+        &matched_hashes,
+        &unmatched_commit_commands,
+    ));
 
     if !dry_run {
         db::upsert_collector_session_output_rows(telemetry_db_path, &rows)?;
@@ -340,7 +350,7 @@ fn session_row(session: &SessionInfo, matched_commits: &[CommitStats]) -> Result
             .iter()
             .map(|commit| commit.files_changed)
             .sum(),
-        git_commits: matched_commits.len() as i64,
+        git_commits: session.git_commits.len() as i64,
         git_pushes: session
             .git_pushes
             .iter()
@@ -359,6 +369,7 @@ fn session_row(session: &SessionInfo, matched_commits: &[CommitStats]) -> Result
 fn synthetic_rows(
     commits_by_repo: &HashMap<String, Vec<CommitStats>>,
     matched_hashes: &HashSet<String>,
+    unmatched_commit_commands: &BTreeMap<(String, String), usize>,
 ) -> Vec<SessionOutputRow> {
     let mut grouped: BTreeMap<(String, String), Vec<CommitStats>> = BTreeMap::new();
     for (repo, commits) in commits_by_repo {
@@ -382,6 +393,11 @@ fn synthetic_rows(
                 .map(|commit| commit.author_date)
                 .min()
                 .expect("synthetic group has commits");
+            let command_claims = unmatched_commit_commands
+                .get(&(repo.clone(), date.clone()))
+                .copied()
+                .unwrap_or_default();
+            let git_commits = commits.len().saturating_sub(command_claims) as i64;
             SessionOutputRow {
                 session_id: format!("unattributed-{repo}-{date}"),
                 project: repo,
@@ -390,7 +406,7 @@ fn synthetic_rows(
                 lines_added: commits.iter().map(|commit| commit.insertions).sum(),
                 lines_removed: commits.iter().map(|commit| commit.deletions).sum(),
                 files_modified: commits.iter().map(|commit| commit.files_changed).sum(),
-                git_commits: commits.len() as i64,
+                git_commits,
                 git_pushes: 0,
                 user_message_count: 0,
                 assistant_message_count: 0,
@@ -1009,13 +1025,13 @@ mod tests {
         assert_eq!(rows[0].0, "session-1");
         assert_eq!(rows[0].1, 1);
         assert_eq!(rows[0].2, 1);
-        assert_eq!(rows[0].3, 1);
+        assert_eq!(rows[0].3, 2);
         assert_eq!(rows[0].4, 1);
         assert_eq!(rows[0].5.as_deref(), Some(r#"{"Bash":3,"Read":1}"#));
         assert_eq!(rows[0].6, 1);
         assert!(rows[1].0.starts_with("unattributed-office-automate-"));
         assert_eq!(rows[1].1, 1);
-        assert_eq!(rows[1].3, 1);
+        assert_eq!(rows[1].3, 0);
         assert_eq!(rows[1].6, 0);
     }
 

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -59,10 +59,12 @@ pub fn collect_telemetry(config: &AppConfig, dry_run: bool) -> Result<TelemetryC
     } else {
         config.telemetry.days
     };
-    collect_session_telemetry(
+    let worktree_map_path = config.runtime.data_dir.join("worktree_map.json");
+    collect_session_telemetry_with_worktree_map(
         &config.runtime.session_tool_usage_db_path,
         &config.runtime.telemetry_db_path,
         &config.telemetry.repos,
+        Some(worktree_map_path.as_path()),
         days,
         dry_run,
         Local::now().naive_local(),
@@ -77,8 +79,32 @@ pub fn collect_session_telemetry(
     dry_run: bool,
     now: NaiveDateTime,
 ) -> Result<TelemetryCollectStats> {
+    let fallback_worktree_map_path = telemetry_db_path
+        .parent()
+        .map(|parent| parent.join("worktree_map.json"));
+    collect_session_telemetry_with_worktree_map(
+        tool_usage_db_path,
+        telemetry_db_path,
+        repos,
+        fallback_worktree_map_path.as_deref(),
+        days,
+        dry_run,
+        now,
+    )
+}
+
+fn collect_session_telemetry_with_worktree_map(
+    tool_usage_db_path: &Path,
+    telemetry_db_path: &Path,
+    repos: &[PathBuf],
+    worktree_map_path: Option<&Path>,
+    days: u64,
+    dry_run: bool,
+    now: NaiveDateTime,
+) -> Result<TelemetryCollectStats> {
     let cutoff = now - Duration::days(days.max(1) as i64);
-    let sessions = build_session_index(tool_usage_db_path, cutoff)?;
+    let worktrees = WorktreeResolver::new(repos, worktree_map_path);
+    let sessions = build_session_index(tool_usage_db_path, cutoff, &worktrees)?;
     let commits_by_repo = collect_git_stats(repos, start_of_day(cutoff))?;
 
     let mut matched_hashes = HashSet::new();
@@ -136,6 +162,7 @@ pub fn collect_project_leverage(config: &AppConfig) -> Result<usize> {
 fn build_session_index(
     tool_usage_db_path: &Path,
     cutoff: NaiveDateTime,
+    worktrees: &WorktreeResolver,
 ) -> Result<BTreeMap<String, SessionInfo>> {
     if !tool_usage_db_path.exists() {
         tracing::warn!(
@@ -193,7 +220,7 @@ fn build_session_index(
         ) = row?;
         let timestamp = parse_datetime(&timestamp)?;
         let session_name = session_name.unwrap_or_else(|| session_id.clone());
-        let project_name = normalize_project_name(
+        let project_name = worktrees.normalize_project_name(
             project_name
                 .as_deref()
                 .or(cwd.as_deref())
@@ -217,7 +244,8 @@ fn build_session_index(
         let tool_name = tool_name.unwrap_or_else(|| "unknown".to_string());
         *session.tool_counts.entry(tool_name.clone()).or_insert(0) += 1;
         let bash_command = bash_command.unwrap_or_default().trim().to_string();
-        let repo = normalize_project_name(cwd.as_deref().unwrap_or(&session.project_name));
+        let repo =
+            worktrees.normalize_project_name(cwd.as_deref().unwrap_or(&session.project_name));
         if tool_name == "Bash" && bash_command.starts_with("git commit") {
             session.git_commits.push(GitCommand {
                 timestamp,
@@ -732,6 +760,117 @@ fn project_row(date: &str, project: &str, metric: &str, value: f64) -> ProjectLe
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct WorktreeResolver {
+    worktree_map: HashMap<String, String>,
+}
+
+impl WorktreeResolver {
+    fn new(repos: &[PathBuf], worktree_map_path: Option<&Path>) -> Self {
+        let mut worktree_map = HashMap::new();
+        if let Some(worktree_map_path) = worktree_map_path {
+            worktree_map.extend(load_worktree_map(worktree_map_path));
+        }
+
+        for repo in repos {
+            let Some(repo_name) = repo.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let worktrees_dir = repo.join(".git").join("worktrees");
+            let Ok(entries) = fs::read_dir(&worktrees_dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if !file_type.is_dir() {
+                    continue;
+                }
+                if let Some(name) = entry.file_name().to_str() {
+                    worktree_map
+                        .entry(name.to_string())
+                        .or_insert_with(|| repo_name.to_string());
+                }
+            }
+        }
+
+        Self { worktree_map }
+    }
+
+    fn normalize_project_name(&self, project: &str) -> String {
+        let normalized = project.trim().replace('\\', "/");
+        let normalized = normalized.trim_end_matches('/');
+        if normalized.is_empty() {
+            return "unknown".to_string();
+        }
+
+        if let Some(parent) = resolve_worktree_parent_from_disk(Path::new(normalized)) {
+            return normalize_project_name(&parent);
+        }
+
+        let basename = normalized.rsplit('/').next().unwrap_or(normalized);
+        if let Some(parent) = self.worktree_map.get(basename) {
+            return normalize_project_name(parent);
+        }
+
+        normalize_project_name(normalized)
+    }
+}
+
+fn load_worktree_map(path: &Path) -> HashMap<String, String> {
+    if !path.exists() {
+        return HashMap::new();
+    }
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            tracing::warn!("failed to read worktree map {}: {}", path.display(), error);
+            return HashMap::new();
+        }
+    };
+    match serde_json::from_str::<HashMap<String, String>>(&contents) {
+        Ok(map) => map,
+        Err(error) => {
+            tracing::warn!("failed to parse worktree map {}: {}", path.display(), error);
+            HashMap::new()
+        }
+    }
+}
+
+fn resolve_worktree_parent_from_disk(path: &Path) -> Option<String> {
+    for candidate in path.ancestors() {
+        let git_path = candidate.join(".git");
+        if git_path.is_file() {
+            let contents = fs::read_to_string(&git_path).ok()?;
+            let gitdir = contents
+                .lines()
+                .find_map(|line| line.trim().strip_prefix("gitdir:").map(str::trim))?;
+            return repo_basename_from_gitdir(gitdir);
+        }
+        if git_path.is_dir() {
+            return candidate
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(str::to_string);
+        }
+    }
+    None
+}
+
+fn repo_basename_from_gitdir(gitdir: &str) -> Option<String> {
+    let normalized = gitdir.replace('\\', "/");
+    let parts: Vec<&str> = normalized.split('/').collect();
+    let git_index = parts.iter().position(|part| *part == ".git")?;
+    if git_index == 0 {
+        return None;
+    }
+    parts
+        .get(git_index - 1)
+        .filter(|value| !value.is_empty())
+        .map(|value| (*value).to_string())
+}
+
 fn table_exists(connection: &Connection, table_name: &str) -> Result<bool> {
     connection
         .query_row(
@@ -1063,6 +1202,113 @@ mod tests {
         );
         assert!(!telemetry_db.exists());
         assert!(!telemetry_db.parent().expect("parent").exists());
+    }
+
+    #[test]
+    fn collect_telemetry_matches_commits_from_git_worktrees() {
+        let (_temp_dir, repo) = init_repo();
+        let base_file = repo.join("README.md");
+        fs::write(&base_file, "base\n").expect("write base");
+        run_git(&repo, &["add", "README.md"], None);
+        run_git(
+            &repo,
+            &["commit", "-m", "base"],
+            Some("2026-01-01T09:00:00-08:00"),
+        );
+
+        let worktree = repo
+            .parent()
+            .expect("repo parent")
+            .join("office-automate-ticket-79");
+        let worktree_arg = worktree.to_str().expect("worktree path");
+        run_git(
+            &repo,
+            &["worktree", "add", "-b", "feature/ticket-79", worktree_arg],
+            None,
+        );
+
+        let tracked = worktree.join("tracked.py");
+        fs::write(&tracked, "print('from worktree')\n").expect("write tracked");
+        run_git(&worktree, &["add", "tracked.py"], None);
+        run_git(
+            &worktree,
+            &["commit", "-m", "worktree commit"],
+            Some("2026-03-27T09:00:10-07:00"),
+        );
+
+        let tool_db = repo.parent().expect("parent").join("tool_usage.db");
+        let telemetry_db = repo.parent().expect("parent").join("telemetry.db");
+        create_tool_usage_db(&tool_db);
+        insert_tool_usage(
+            &tool_db,
+            "session-worktree",
+            "claude-a1b2c3d4",
+            "office-automate-ticket-79",
+            "Bash",
+            None,
+            Some("git commit -m 'worktree commit'"),
+            "2026-03-27 09:00:00",
+            &worktree,
+            "PreToolUse",
+        );
+
+        let stats = collect_session_telemetry(
+            &tool_db,
+            &telemetry_db,
+            std::slice::from_ref(&repo),
+            30,
+            false,
+            parse_datetime("2026-03-28 12:00:00").expect("now"),
+        )
+        .expect("collect");
+
+        assert_eq!(
+            stats,
+            TelemetryCollectStats {
+                sessions: 1,
+                rows_written: 1,
+                synthetic_rows: 0,
+                matched_commits: 1,
+            }
+        );
+
+        let connection = Connection::open(&telemetry_db).expect("open telemetry");
+        let row: (String, i64, i64, i64) = connection
+            .query_row(
+                "SELECT project, lines_added, files_modified, git_commits
+                 FROM session_output
+                 WHERE session_id = 'session-worktree'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("session row");
+
+        assert_eq!(row, ("office-automate".to_string(), 1, 1, 1));
+    }
+
+    #[test]
+    fn worktree_resolver_uses_persisted_map_for_pruned_worktrees() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let worktree_map_path = temp_dir.path().join("worktree_map.json");
+        fs::write(
+            &worktree_map_path,
+            r#"{"1234-feature":"office-automate","fractal-1808-em":"fractal"}"#,
+        )
+        .expect("write map");
+        let resolver = WorktreeResolver::new(&[], Some(&worktree_map_path));
+
+        assert_eq!(
+            resolver.normalize_project_name("/Users/rajesh/worktrees/1234-feature"),
+            "office-automate"
+        );
+        assert_eq!(
+            resolver.normalize_project_name("1234-feature"),
+            "office-automate"
+        );
+        assert_eq!(
+            resolver.normalize_project_name("fractal-1808-em"),
+            "fractal"
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -78,7 +78,7 @@ pub fn collect_session_telemetry(
 ) -> Result<TelemetryCollectStats> {
     let cutoff = now - Duration::days(days.max(1) as i64);
     let sessions = build_session_index(tool_usage_db_path, cutoff)?;
-    let commits_by_repo = collect_git_stats(repos, cutoff)?;
+    let commits_by_repo = collect_git_stats(repos, start_of_day(cutoff))?;
 
     let mut matched_hashes = HashSet::new();
     let mut rows = Vec::new();
@@ -778,6 +778,13 @@ fn format_timestamp(value: NaiveDateTime) -> String {
     value.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
+fn start_of_day(value: NaiveDateTime) -> NaiveDateTime {
+    value
+        .date()
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight should be a valid local naive time")
+}
+
 fn is_human_session(session_name: &str, session_id: &str) -> bool {
     if session_name.starts_with("claude-")
         && session_name
@@ -1039,6 +1046,63 @@ mod tests {
         );
         assert!(!telemetry_db.exists());
         assert!(!telemetry_db.parent().expect("parent").exists());
+    }
+
+    #[test]
+    fn synthetic_rows_keep_full_cutoff_day_across_repeated_runs() {
+        let (_temp_dir, repo) = init_repo();
+        let tracked = repo.join("tracked.py");
+        fs::write(&tracked, "print('morning')\n").expect("write tracked");
+        run_git(&repo, &["add", "tracked.py"], None);
+        run_git(
+            &repo,
+            &["commit", "-m", "morning"],
+            Some("2026-03-27T09:00:00-07:00"),
+        );
+        fs::write(&tracked, "print('morning')\nprint('evening')\n").expect("write tracked");
+        run_git(&repo, &["add", "tracked.py"], None);
+        run_git(
+            &repo,
+            &["commit", "-m", "evening"],
+            Some("2026-03-27T20:00:00-07:00"),
+        );
+
+        let tool_db = repo.parent().expect("parent").join("tool_usage.db");
+        let telemetry_db = repo.parent().expect("parent").join("telemetry.db");
+        create_tool_usage_db(&tool_db);
+
+        collect_session_telemetry(
+            &tool_db,
+            &telemetry_db,
+            std::slice::from_ref(&repo),
+            1,
+            false,
+            parse_datetime("2026-03-28 00:05:00").expect("now"),
+        )
+        .expect("initial collect");
+        collect_session_telemetry(
+            &tool_db,
+            &telemetry_db,
+            std::slice::from_ref(&repo),
+            1,
+            false,
+            parse_datetime("2026-03-28 18:00:00").expect("now"),
+        )
+        .expect("second collect");
+
+        let connection = Connection::open(&telemetry_db).expect("open telemetry");
+        let (git_commits, lines_added): (i64, i64) = connection
+            .query_row(
+                "SELECT git_commits, lines_added
+                 FROM session_output
+                 WHERE session_id = 'unattributed-office-automate-2026-03-27'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("synthetic row");
+
+        assert_eq!(git_commits, 2);
+        assert_eq!(lines_added, 2);
     }
 
     #[test]

--- a/rust/office-automate-server/src/telemetry.rs
+++ b/rust/office-automate-server/src/telemetry.rs
@@ -1,0 +1,1125 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{
+    config::AppConfig,
+    db::{
+        self, ProjectLeverageRow, SessionOutputRow, normalize_project_name, telemetry_database_path,
+    },
+};
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Duration, Local, NaiveDateTime};
+use rusqlite::{Connection, OptionalExtension, params};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryCollectStats {
+    pub sessions: usize,
+    pub rows_written: usize,
+    pub synthetic_rows: usize,
+    pub matched_commits: usize,
+}
+
+#[derive(Debug, Clone)]
+struct GitCommand {
+    timestamp: NaiveDateTime,
+    repo: String,
+    bash_command: String,
+}
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    session_id: String,
+    session_name: String,
+    project_name: String,
+    start_time: NaiveDateTime,
+    end_time: NaiveDateTime,
+    tool_counts: BTreeMap<String, i64>,
+    git_commits: Vec<GitCommand>,
+    git_pushes: Vec<GitCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommitStats {
+    repo: String,
+    commit_hash: String,
+    author_date: NaiveDateTime,
+    files_changed: i64,
+    insertions: i64,
+    deletions: i64,
+}
+
+pub fn collect_telemetry(config: &AppConfig, dry_run: bool) -> Result<TelemetryCollectStats> {
+    let days = if config.telemetry.days == 0 {
+        2
+    } else {
+        config.telemetry.days
+    };
+    collect_session_telemetry(
+        &config.runtime.tool_usage_db_path,
+        &config.runtime.telemetry_db_path,
+        &config.telemetry.repos,
+        days,
+        dry_run,
+        Local::now().naive_local(),
+    )
+}
+
+pub fn collect_session_telemetry(
+    tool_usage_db_path: &Path,
+    telemetry_db_path: &Path,
+    repos: &[PathBuf],
+    days: u64,
+    dry_run: bool,
+    now: NaiveDateTime,
+) -> Result<TelemetryCollectStats> {
+    let cutoff = now - Duration::days(days.max(1) as i64);
+    let sessions = build_session_index(tool_usage_db_path, cutoff)?;
+    let commits_by_repo = collect_git_stats(repos, cutoff)?;
+
+    let mut matched_hashes = HashSet::new();
+    let mut rows = Vec::new();
+    for session in sessions.values() {
+        let mut matched_commits = Vec::new();
+        for command in &session.git_commits {
+            if let Some(commit) = match_commit(command, &commits_by_repo, &matched_hashes) {
+                matched_hashes.insert(commit.commit_hash.clone());
+                matched_commits.push(commit);
+            }
+        }
+        rows.push(session_row(session, &matched_commits)?);
+    }
+
+    rows.extend(synthetic_rows(&commits_by_repo, &matched_hashes));
+
+    if !dry_run {
+        db::upsert_collector_session_output_rows(telemetry_db_path, &rows)?;
+    } else {
+        db::ensure_telemetry_database(telemetry_db_path)?;
+    }
+
+    let synthetic_rows = rows
+        .iter()
+        .filter(|row| row.session_id.starts_with("unattributed-"))
+        .count();
+    Ok(TelemetryCollectStats {
+        sessions: sessions.len(),
+        rows_written: rows.len(),
+        synthetic_rows,
+        matched_commits: matched_hashes.len(),
+    })
+}
+
+pub fn collect_project_leverage(config: &AppConfig) -> Result<usize> {
+    let rows = collect_project_leverage_rows(
+        &config.runtime.database_path,
+        &config.runtime.tool_usage_db_path,
+        &config.runtime.engram_db_path,
+        &config.runtime.engram_registry_path,
+        Local::now().naive_local(),
+    )?;
+    db::upsert_project_leverage_rows(&config.runtime.database_path, &rows)
+}
+
+fn build_session_index(
+    tool_usage_db_path: &Path,
+    cutoff: NaiveDateTime,
+) -> Result<BTreeMap<String, SessionInfo>> {
+    if !tool_usage_db_path.exists() {
+        tracing::warn!(
+            "tool_usage DB not found at {}; telemetry collection skipped",
+            tool_usage_db_path.display()
+        );
+        return Ok(BTreeMap::new());
+    }
+
+    let connection = Connection::open(tool_usage_db_path).with_context(|| {
+        format!(
+            "failed to open tool_usage SQLite database {}",
+            tool_usage_db_path.display()
+        )
+    })?;
+    if !table_exists(&connection, "tool_usage")? {
+        tracing::warn!(
+            "tool_usage table missing in {}; telemetry collection skipped",
+            tool_usage_db_path.display()
+        );
+        return Ok(BTreeMap::new());
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT session_id, session_name, project_name, tool_name, target_file, bash_command, timestamp, cwd
+         FROM tool_usage
+         WHERE hook_type = 'PreToolUse' AND timestamp >= ?
+         ORDER BY session_id, timestamp",
+    )?;
+    let cutoff = format_timestamp(cutoff);
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, Option<String>>(3)?,
+            row.get::<_, Option<String>>(4)?,
+            row.get::<_, Option<String>>(5)?,
+            row.get::<_, String>(6)?,
+            row.get::<_, Option<String>>(7)?,
+        ))
+    })?;
+
+    let mut sessions = BTreeMap::new();
+    for row in rows {
+        let (
+            session_id,
+            session_name,
+            project_name,
+            tool_name,
+            _target_file,
+            bash_command,
+            timestamp,
+            cwd,
+        ) = row?;
+        let timestamp = parse_datetime(&timestamp)?;
+        let session_name = session_name.unwrap_or_else(|| session_id.clone());
+        let project_name = normalize_project_name(
+            project_name
+                .as_deref()
+                .or(cwd.as_deref())
+                .unwrap_or("unknown"),
+        );
+        let session = sessions
+            .entry(session_id.clone())
+            .or_insert_with(|| SessionInfo {
+                session_id: session_id.clone(),
+                session_name,
+                project_name: project_name.clone(),
+                start_time: timestamp,
+                end_time: timestamp,
+                tool_counts: BTreeMap::new(),
+                git_commits: Vec::new(),
+                git_pushes: Vec::new(),
+            });
+        session.start_time = session.start_time.min(timestamp);
+        session.end_time = session.end_time.max(timestamp);
+
+        let tool_name = tool_name.unwrap_or_else(|| "unknown".to_string());
+        *session.tool_counts.entry(tool_name.clone()).or_insert(0) += 1;
+        let bash_command = bash_command.unwrap_or_default().trim().to_string();
+        let repo = normalize_project_name(cwd.as_deref().unwrap_or(&session.project_name));
+        if tool_name == "Bash" && bash_command.starts_with("git commit") {
+            session.git_commits.push(GitCommand {
+                timestamp,
+                repo,
+                bash_command,
+            });
+        } else if tool_name == "Bash" && bash_command.starts_with("git push") {
+            session.git_pushes.push(GitCommand {
+                timestamp,
+                repo,
+                bash_command,
+            });
+        }
+    }
+
+    Ok(sessions)
+}
+
+fn collect_git_stats(
+    repos: &[PathBuf],
+    cutoff: NaiveDateTime,
+) -> Result<HashMap<String, Vec<CommitStats>>> {
+    let mut commits_by_repo = HashMap::new();
+    let cutoff_arg = format_timestamp(cutoff);
+
+    for repo in repos {
+        if !repo.exists() {
+            tracing::warn!("skipping missing telemetry repo {}", repo.display());
+            continue;
+        }
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args([
+                "log",
+                "--all",
+                "--no-merges",
+                "--format=COMMIT:%H|%aI|%s",
+                "--shortstat",
+            ])
+            .arg(format!("--after={cutoff_arg}"))
+            .output()
+            .with_context(|| format!("failed to run git log for {}", repo.display()))?;
+        if !output.status.success() {
+            bail!(
+                "git log failed for {}: {}",
+                repo.display(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let repo_name = normalize_project_name(
+            repo.file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown"),
+        );
+        let mut commits = Vec::new();
+        let mut current: Option<CommitStats> = None;
+        for raw_line in String::from_utf8_lossy(&output.stdout).lines() {
+            let line = raw_line.trim_end();
+            if let Some(rest) = line.strip_prefix("COMMIT:") {
+                if let Some(commit) = current.take() {
+                    commits.push(commit);
+                }
+                let mut pieces = rest.splitn(3, '|');
+                let Some(commit_hash) = pieces.next() else {
+                    continue;
+                };
+                let Some(author_date) = pieces.next() else {
+                    continue;
+                };
+                current = Some(CommitStats {
+                    repo: repo_name.clone(),
+                    commit_hash: commit_hash.to_string(),
+                    author_date: parse_datetime(author_date)?,
+                    files_changed: 0,
+                    insertions: 0,
+                    deletions: 0,
+                });
+                continue;
+            }
+
+            if let Some(current) = &mut current {
+                if let Some((files_changed, insertions, deletions)) = parse_shortstat(line) {
+                    current.files_changed = files_changed;
+                    current.insertions = insertions;
+                    current.deletions = deletions;
+                }
+            }
+        }
+        if let Some(commit) = current {
+            commits.push(commit);
+        }
+        commits_by_repo.insert(repo_name, commits);
+    }
+
+    Ok(commits_by_repo)
+}
+
+fn match_commit(
+    command: &GitCommand,
+    commits_by_repo: &HashMap<String, Vec<CommitStats>>,
+    matched_hashes: &HashSet<String>,
+) -> Option<CommitStats> {
+    commits_by_repo
+        .get(&command.repo)?
+        .iter()
+        .filter(|commit| !matched_hashes.contains(&commit.commit_hash))
+        .filter_map(|commit| {
+            let delta = (commit.author_date - command.timestamp)
+                .num_seconds()
+                .unsigned_abs();
+            (delta < 60).then_some((delta, commit))
+        })
+        .min_by_key(|(delta, _)| *delta)
+        .map(|(_, commit)| commit.clone())
+}
+
+fn session_row(session: &SessionInfo, matched_commits: &[CommitStats]) -> Result<SessionOutputRow> {
+    let duration_minutes = ((session.end_time - session.start_time).num_seconds() / 60).max(0);
+    let tool_counts = serde_json::to_string(&session.tool_counts)?;
+    Ok(SessionOutputRow {
+        session_id: session.session_id.clone(),
+        project: session.project_name.clone(),
+        start_time: format_timestamp(session.start_time),
+        duration_minutes,
+        lines_added: matched_commits.iter().map(|commit| commit.insertions).sum(),
+        lines_removed: matched_commits.iter().map(|commit| commit.deletions).sum(),
+        files_modified: matched_commits
+            .iter()
+            .map(|commit| commit.files_changed)
+            .sum(),
+        git_commits: session.git_commits.len() as i64,
+        git_pushes: session
+            .git_pushes
+            .iter()
+            .filter(|push| !push.bash_command.contains("--delete"))
+            .count() as i64,
+        user_message_count: 0,
+        assistant_message_count: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        tool_counts: Some(tool_counts),
+        languages: None,
+        is_human_session: is_human_session(&session.session_name, &session.session_id),
+    })
+}
+
+fn synthetic_rows(
+    commits_by_repo: &HashMap<String, Vec<CommitStats>>,
+    matched_hashes: &HashSet<String>,
+) -> Vec<SessionOutputRow> {
+    let mut grouped: BTreeMap<(String, String), Vec<CommitStats>> = BTreeMap::new();
+    for (repo, commits) in commits_by_repo {
+        for commit in commits {
+            if matched_hashes.contains(&commit.commit_hash) {
+                continue;
+            }
+            let date = commit.author_date.date().to_string();
+            grouped
+                .entry((repo.clone(), date))
+                .or_default()
+                .push(commit.clone());
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|((repo, date), commits)| {
+            let earliest = commits
+                .iter()
+                .map(|commit| commit.author_date)
+                .min()
+                .expect("synthetic group has commits");
+            SessionOutputRow {
+                session_id: format!("unattributed-{repo}-{date}"),
+                project: repo,
+                start_time: format_timestamp(earliest),
+                duration_minutes: 0,
+                lines_added: commits.iter().map(|commit| commit.insertions).sum(),
+                lines_removed: commits.iter().map(|commit| commit.deletions).sum(),
+                files_modified: commits.iter().map(|commit| commit.files_changed).sum(),
+                git_commits: commits.len() as i64,
+                git_pushes: 0,
+                user_message_count: 0,
+                assistant_message_count: 0,
+                input_tokens: 0,
+                output_tokens: 0,
+                tool_counts: None,
+                languages: None,
+                is_human_session: false,
+            }
+        })
+        .collect()
+}
+
+pub fn collect_project_leverage_rows(
+    database_path: &Path,
+    tool_usage_db_path: &Path,
+    engram_db_path: &Path,
+    engram_registry_path: &Path,
+    now: NaiveDateTime,
+) -> Result<Vec<ProjectLeverageRow>> {
+    let mut rows = Vec::new();
+    rows.extend(collect_tool_usage_metrics(tool_usage_db_path)?);
+    rows.extend(collect_engram_metrics(
+        engram_db_path,
+        engram_registry_path,
+        now,
+    )?);
+    rows.extend(collect_office_automation_metrics(database_path)?);
+    Ok(rows)
+}
+
+fn collect_tool_usage_metrics(tool_usage_db_path: &Path) -> Result<Vec<ProjectLeverageRow>> {
+    if !tool_usage_db_path.exists() {
+        tracing::info!(
+            "skipping project leverage tool usage; DB not found at {}",
+            tool_usage_db_path.display()
+        );
+        return Ok(Vec::new());
+    }
+    let connection = Connection::open(tool_usage_db_path).with_context(|| {
+        format!(
+            "failed to open tool_usage SQLite database {}",
+            tool_usage_db_path.display()
+        )
+    })?;
+    if !table_exists(&connection, "tool_usage")? {
+        return Ok(Vec::new());
+    }
+
+    let mut rows = Vec::new();
+    collect_sm_metrics(&connection, &mut rows)?;
+    collect_persona_metrics(&connection, &mut rows)?;
+    collect_telegram_metrics(&connection, &mut rows)?;
+    Ok(rows)
+}
+
+fn collect_sm_metrics(connection: &Connection, rows: &mut Vec<ProjectLeverageRow>) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date,
+                SUM(CASE WHEN bash_command LIKE 'sm send%' THEN 1 ELSE 0 END) AS sm_sends,
+                SUM(CASE WHEN bash_command LIKE 'sm dispatch%' THEN 1 ELSE 0 END) AS sm_dispatches,
+                SUM(CASE WHEN bash_command LIKE 'sm remind%' THEN 1 ELSE 0 END) AS sm_reminds
+         FROM tool_usage
+         WHERE tool_name = 'Bash'
+           AND hook_type = 'PreToolUse'
+           AND bash_command LIKE 'sm %'
+         GROUP BY date(timestamp)",
+    )?;
+    let metric_rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?.unwrap_or_default(),
+            row.get::<_, Option<f64>>(2)?.unwrap_or_default(),
+            row.get::<_, Option<f64>>(3)?.unwrap_or_default(),
+        ))
+    })?;
+    for row in metric_rows {
+        let (date, sends, dispatches, reminds) = row?;
+        rows.push(project_row(&date, "session-manager", "sm_sends", sends));
+        rows.push(project_row(
+            &date,
+            "session-manager",
+            "sm_dispatches",
+            dispatches,
+        ));
+        rows.push(project_row(&date, "session-manager", "sm_reminds", reminds));
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COUNT(DISTINCT session_id) AS active_sessions
+         FROM tool_usage
+         WHERE hook_type = 'PreToolUse'
+         GROUP BY date(timestamp)",
+    )?;
+    let metric_rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?.unwrap_or_default(),
+        ))
+    })?;
+    for row in metric_rows {
+        let (date, active_sessions) = row?;
+        rows.push(project_row(
+            &date,
+            "session-manager",
+            "sm_active_sessions",
+            active_sessions,
+        ));
+    }
+
+    Ok(())
+}
+
+fn collect_persona_metrics(
+    connection: &Connection,
+    rows: &mut Vec<ProjectLeverageRow>,
+) -> Result<()> {
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COUNT(*) AS persona_reads
+         FROM tool_usage
+         WHERE tool_name = 'Read'
+           AND target_file LIKE '%agent-os/personas/%'
+         GROUP BY date(timestamp)",
+    )?;
+    let metric_rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?.unwrap_or_default(),
+        ))
+    })?;
+    for row in metric_rows {
+        let (date, persona_reads) = row?;
+        rows.push(project_row(
+            &date,
+            "agent-os",
+            "persona_reads",
+            persona_reads,
+        ));
+    }
+
+    let mut projects_by_date: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COALESCE(NULLIF(project_name, ''), 'unknown') AS project
+         FROM tool_usage
+         WHERE tool_name = 'Read'
+           AND target_file LIKE '%agent-os/personas/%'
+         ORDER BY date(timestamp), project",
+    )?;
+    let metric_rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in metric_rows {
+        let (date, project) = row?;
+        projects_by_date
+            .entry(date)
+            .or_default()
+            .insert(normalize_project_name(&project));
+    }
+
+    for (date, projects) in projects_by_date {
+        rows.push(project_row(
+            &date,
+            "agent-os",
+            "persona_projects",
+            projects.len() as f64,
+        ));
+        for project in projects {
+            rows.push(project_row(
+                &date,
+                "agent-os",
+                &format!("persona_project::{project}"),
+                1.0,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_telegram_metrics(
+    connection: &Connection,
+    rows: &mut Vec<ProjectLeverageRow>,
+) -> Result<()> {
+    if !table_exists(connection, "telegram_telemetry")? {
+        return Ok(());
+    }
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date,
+                SUM(CASE WHEN direction = 'in' THEN 1 ELSE 0 END) AS telegram_in,
+                SUM(CASE WHEN direction = 'out' THEN 1 ELSE 0 END) AS telegram_out
+         FROM telegram_telemetry
+         GROUP BY date(timestamp)",
+    )?;
+    let metric_rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?.unwrap_or_default(),
+            row.get::<_, Option<f64>>(2)?.unwrap_or_default(),
+        ))
+    })?;
+    for row in metric_rows {
+        let (date, telegram_in, telegram_out) = row?;
+        rows.push(project_row(
+            &date,
+            "session-manager",
+            "sm_telegram_in",
+            telegram_in,
+        ));
+        rows.push(project_row(
+            &date,
+            "session-manager",
+            "sm_telegram_out",
+            telegram_out,
+        ));
+    }
+    Ok(())
+}
+
+fn collect_engram_metrics(
+    engram_db_path: &Path,
+    engram_registry_path: &Path,
+    now: NaiveDateTime,
+) -> Result<Vec<ProjectLeverageRow>> {
+    if !engram_db_path.exists() {
+        return Ok(Vec::new());
+    }
+    let connection = Connection::open(engram_db_path).with_context(|| {
+        format!(
+            "failed to open engram SQLite database {}",
+            engram_db_path.display()
+        )
+    })?;
+    if !table_exists(&connection, "dispatches")? {
+        return Ok(Vec::new());
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT created_at FROM dispatches WHERE state = 'committed' ORDER BY created_at DESC",
+    )?;
+    let dispatch_rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    let mut committed = Vec::new();
+    for row in dispatch_rows {
+        committed.push(parse_datetime(&row?)?);
+    }
+
+    let date = now.date().to_string();
+    let mut rows = Vec::new();
+    let folds_7d = committed
+        .iter()
+        .filter(|timestamp| **timestamp >= now - Duration::days(7))
+        .count() as f64;
+    rows.push(project_row(&date, "engram", "engram_folds_7d", folds_7d));
+    rows.push(project_row(
+        &date,
+        "engram",
+        "engram_active_concepts",
+        count_active_concepts(engram_registry_path)? as f64,
+    ));
+    if let Some(last_fold) = committed.into_iter().max() {
+        rows.push(project_row(
+            &date,
+            "engram",
+            "engram_last_fold_age_hours",
+            (now - last_fold).num_seconds() as f64 / 3600.0,
+        ));
+    }
+    Ok(rows)
+}
+
+fn collect_office_automation_metrics(database_path: &Path) -> Result<Vec<ProjectLeverageRow>> {
+    if !database_path.exists() {
+        return Ok(Vec::new());
+    }
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let mut rows = Vec::new();
+
+    for (table, metric) in [
+        ("climate_actions", "automation_events"),
+        ("occupancy_log", "state_transitions"),
+    ] {
+        if !table_exists(&connection, table)? {
+            continue;
+        }
+        let mut statement = connection.prepare(&format!(
+            "SELECT date(timestamp) AS date, COUNT(*) AS count FROM {table} GROUP BY date(timestamp)"
+        ))?;
+        let metric_rows = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<f64>>(1)?.unwrap_or_default(),
+            ))
+        })?;
+        for row in metric_rows {
+            let (date, count) = row?;
+            rows.push(project_row(&date, "office-automate", metric, count));
+        }
+    }
+    Ok(rows)
+}
+
+fn count_active_concepts(path: &Path) -> Result<usize> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read engram registry {}", path.display()))?;
+    Ok(contents
+        .lines()
+        .filter(|line| {
+            let line = line.trim();
+            line.starts_with("## C") && line.to_ascii_uppercase().contains("(ACTIVE")
+        })
+        .count())
+}
+
+fn project_row(date: &str, project: &str, metric: &str, value: f64) -> ProjectLeverageRow {
+    ProjectLeverageRow {
+        date: date.to_string(),
+        project: project.to_string(),
+        metric: metric.to_string(),
+        value,
+    }
+}
+
+fn table_exists(connection: &Connection, table_name: &str) -> Result<bool> {
+    connection
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            params![table_name],
+            |_| Ok(()),
+        )
+        .optional()
+        .map(|row| row.is_some())
+        .context("failed to inspect SQLite schema")
+}
+
+fn parse_shortstat(line: &str) -> Option<(i64, i64, i64)> {
+    let mut files = None;
+    let mut insertions = 0;
+    let mut deletions = 0;
+    for segment in line.trim().split(',') {
+        let segment = segment.trim();
+        if segment.contains("file") && segment.contains("changed") {
+            files = first_i64(segment);
+        } else if segment.contains("insertion") {
+            insertions = first_i64(segment).unwrap_or_default();
+        } else if segment.contains("deletion") {
+            deletions = first_i64(segment).unwrap_or_default();
+        }
+    }
+    files.map(|files| (files, insertions, deletions))
+}
+
+fn first_i64(value: &str) -> Option<i64> {
+    value
+        .split(|character: char| !character.is_ascii_digit())
+        .find(|part| !part.is_empty())
+        .and_then(|part| part.parse().ok())
+}
+
+fn parse_datetime(value: &str) -> Result<NaiveDateTime> {
+    let normalized = value.trim();
+    let rfc3339 = if let Some(prefix) = normalized.strip_suffix('Z') {
+        format!("{prefix}+00:00")
+    } else {
+        normalized.to_string()
+    };
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(&rfc3339) {
+        return Ok(timestamp.with_timezone(&Local).naive_local());
+    }
+    for format in [
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S",
+    ] {
+        if let Ok(timestamp) = NaiveDateTime::parse_from_str(normalized, format) {
+            return Ok(timestamp);
+        }
+    }
+    bail!("unsupported timestamp {value:?}")
+}
+
+fn format_timestamp(value: NaiveDateTime) -> String {
+    value.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn is_human_session(session_name: &str, session_id: &str) -> bool {
+    if session_name.starts_with("claude-")
+        && session_name
+            .trim_start_matches("claude-")
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return true;
+    }
+    session_name.is_empty() || session_name == session_id
+}
+
+#[allow(dead_code)]
+pub fn default_telemetry_database_path(config: &AppConfig) -> PathBuf {
+    telemetry_database_path(&config.runtime.database_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_tool_usage_db(path: &Path) {
+        let connection = Connection::open(path).expect("open tool DB");
+        connection
+            .execute_batch(
+                "CREATE TABLE tool_usage (
+                    session_id TEXT,
+                    session_name TEXT,
+                    project_name TEXT,
+                    tool_name TEXT,
+                    target_file TEXT,
+                    bash_command TEXT,
+                    timestamp TEXT,
+                    cwd TEXT,
+                    hook_type TEXT
+                );",
+            )
+            .expect("schema");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_tool_usage(
+        path: &Path,
+        session_id: &str,
+        session_name: &str,
+        project_name: &str,
+        tool_name: &str,
+        target_file: Option<&str>,
+        bash_command: Option<&str>,
+        timestamp: &str,
+        cwd: &Path,
+        hook_type: &str,
+    ) {
+        let connection = Connection::open(path).expect("open tool DB");
+        connection
+            .execute(
+                "INSERT INTO tool_usage (
+                    session_id, session_name, project_name, tool_name, target_file,
+                    bash_command, timestamp, cwd, hook_type
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    session_id,
+                    session_name,
+                    project_name,
+                    tool_name,
+                    target_file,
+                    bash_command,
+                    timestamp,
+                    cwd.display().to_string(),
+                    hook_type,
+                ],
+            )
+            .expect("insert tool usage");
+    }
+
+    fn run_git(repo: &Path, args: &[&str], env_date: Option<&str>) {
+        let mut command = Command::new("git");
+        command.arg("-C").arg(repo).args(args);
+        if let Some(date) = env_date {
+            command.env("GIT_AUTHOR_DATE", date);
+            command.env("GIT_COMMITTER_DATE", date);
+        }
+        let output = command.output().expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> (TempDir, PathBuf) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let repo = temp_dir.path().join("office-automate");
+        fs::create_dir(&repo).expect("repo dir");
+        run_git(&repo, &["init"], None);
+        run_git(&repo, &["config", "user.name", "Telemetry Test"], None);
+        run_git(
+            &repo,
+            &["config", "user.email", "telemetry@example.com"],
+            None,
+        );
+        (temp_dir, repo)
+    }
+
+    #[test]
+    fn collect_telemetry_attributes_git_stats_and_synthetic_rows() {
+        let (_temp_dir, repo) = init_repo();
+        let tracked = repo.join("tracked.py");
+        fs::write(&tracked, "print('v1')\n").expect("write tracked");
+        run_git(&repo, &["add", "tracked.py"], None);
+        run_git(
+            &repo,
+            &["commit", "-m", "tracked"],
+            Some("2026-03-27T09:00:10-07:00"),
+        );
+        fs::write(&tracked, "print('v1')\nprint('v2')\n").expect("write tracked");
+        run_git(&repo, &["add", "tracked.py"], None);
+        run_git(
+            &repo,
+            &["commit", "-m", "manual"],
+            Some("2026-03-27T11:15:00-07:00"),
+        );
+
+        let tool_db = repo.parent().expect("parent").join("tool_usage.db");
+        let telemetry_db = repo.parent().expect("parent").join("telemetry.db");
+        create_tool_usage_db(&tool_db);
+        insert_tool_usage(
+            &tool_db,
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Read",
+            None,
+            None,
+            "2026-03-27 08:55:00",
+            &repo,
+            "PreToolUse",
+        );
+        insert_tool_usage(
+            &tool_db,
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            Some("git commit -m tracked"),
+            "2026-03-27 09:00:00",
+            &repo,
+            "PreToolUse",
+        );
+        insert_tool_usage(
+            &tool_db,
+            "session-1",
+            "claude-a1b2c3d4",
+            "office-automate",
+            "Bash",
+            None,
+            Some("git push origin feature/test"),
+            "2026-03-27 09:01:00",
+            &repo,
+            "PreToolUse",
+        );
+
+        let stats = collect_session_telemetry(
+            &tool_db,
+            &telemetry_db,
+            std::slice::from_ref(&repo),
+            30,
+            false,
+            parse_datetime("2026-03-28 12:00:00").expect("now"),
+        )
+        .expect("collect");
+
+        assert_eq!(
+            stats,
+            TelemetryCollectStats {
+                sessions: 1,
+                rows_written: 2,
+                synthetic_rows: 1,
+                matched_commits: 1,
+            }
+        );
+
+        let connection = Connection::open(&telemetry_db).expect("open telemetry");
+        let mut statement = connection
+            .prepare(
+                "SELECT session_id, lines_added, files_modified, git_commits, git_pushes, tool_counts, is_human_session
+                 FROM session_output ORDER BY session_id",
+            )
+            .expect("query");
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, i64>(6)?,
+                ))
+            })
+            .expect("rows")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect rows");
+
+        assert_eq!(rows[0].0, "session-1");
+        assert_eq!(rows[0].1, 1);
+        assert_eq!(rows[0].2, 1);
+        assert_eq!(rows[0].3, 1);
+        assert_eq!(rows[0].4, 1);
+        assert_eq!(rows[0].5.as_deref(), Some(r#"{"Bash":2,"Read":1}"#));
+        assert_eq!(rows[0].6, 1);
+        assert!(rows[1].0.starts_with("unattributed-office-automate-"));
+        assert_eq!(rows[1].1, 1);
+        assert_eq!(rows[1].3, 1);
+        assert_eq!(rows[1].6, 0);
+    }
+
+    #[test]
+    fn collect_project_leverage_rows_from_fake_databases() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let office_db = temp_dir.path().join("office.db");
+        let tool_db = temp_dir.path().join("tool_usage.db");
+        let engram_db = temp_dir.path().join("engram_state.db");
+        let registry = temp_dir.path().join("engram_concept_registry.md");
+        let today = Local::now().naive_local().date().to_string();
+        let sm_timestamp = format!("{today} 09:00:00");
+        let persona_timestamp = format!("{today} 10:00:00");
+        let climate_timestamp = format!("{today} 11:00:00");
+        let occupancy_timestamp = format!("{today} 12:00:00");
+        db::migrate_database(&office_db).expect("office schema");
+        create_tool_usage_db(&tool_db);
+
+        for index in 0..5 {
+            insert_tool_usage(
+                &tool_db,
+                &format!("s{index}"),
+                &format!("s{index}"),
+                "office-automate",
+                "Bash",
+                None,
+                Some(&format!("sm send agent-{index} hello")),
+                &sm_timestamp,
+                temp_dir.path(),
+                "PreToolUse",
+            );
+        }
+        for project in [
+            "fractal-market-simulator",
+            "fractal-1808-em",
+            "office-automate",
+        ] {
+            insert_tool_usage(
+                &tool_db,
+                project,
+                project,
+                project,
+                "Read",
+                Some("/Users/rajesh/.agent-os/personas/engineer.md"),
+                None,
+                &persona_timestamp,
+                temp_dir.path(),
+                "PreToolUse",
+            );
+        }
+
+        {
+            let connection = Connection::open(&engram_db).expect("engram DB");
+            connection
+                .execute_batch("CREATE TABLE dispatches (created_at TEXT, state TEXT);")
+                .expect("engram rows");
+            connection
+                .execute(
+                    "INSERT INTO dispatches (created_at, state) VALUES (?, 'committed')",
+                    params![persona_timestamp],
+                )
+                .expect("engram dispatch");
+        }
+        fs::write(
+            &registry,
+            "## C001: One (ACTIVE)\n## C002: Two (DEAD)\n## C003: Three (ACTIVE)\n",
+        )
+        .expect("registry");
+        {
+            let connection = Connection::open(&office_db).expect("office DB");
+            connection
+                .execute(
+                    "INSERT INTO climate_actions (timestamp, system, action) VALUES (?, ?, ?)",
+                    params![climate_timestamp, "erv", "turbo"],
+                )
+                .expect("climate");
+            connection
+                .execute(
+                    "INSERT INTO occupancy_log (timestamp, state) VALUES (?, ?)",
+                    params![occupancy_timestamp, "present"],
+                )
+                .expect("occupancy");
+        }
+
+        let rows = collect_project_leverage_rows(
+            &office_db,
+            &tool_db,
+            &engram_db,
+            &registry,
+            parse_datetime(&occupancy_timestamp).expect("now"),
+        )
+        .expect("collect rows");
+        db::upsert_project_leverage_rows(&office_db, &rows).expect("upsert");
+
+        let payload = db::read_project_leverage(&office_db, 1).expect("payload");
+        assert_eq!(
+            payload["projects"]["session-manager"]["week"]["sm_sends"],
+            5.0
+        );
+        assert_eq!(
+            payload["projects"]["agent-os"]["week"]["persona_projects"],
+            2.0
+        );
+        assert_eq!(
+            payload["projects"]["engram"]["current"]["active_concepts"],
+            2.0
+        );
+        assert_eq!(
+            payload["projects"]["office-automate"]["week"]["automation_events"],
+            1.0
+        );
+    }
+
+    #[test]
+    fn parses_git_shortstat_variants() {
+        assert_eq!(
+            parse_shortstat(" 2 files changed, 12 insertions(+), 3 deletions(-)"),
+            Some((2, 12, 3))
+        );
+        assert_eq!(
+            parse_shortstat(" 1 file changed, 1 insertion(+)"),
+            Some((1, 1, 0))
+        );
+    }
+}

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -824,6 +824,7 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: root.join("telemetry.db"),
+                session_tool_usage_db_path: root.join("claude-tool-usage.db"),
                 tool_usage_db_path: root.join("tool-usage.db"),
                 engram_db_path: root.join("engram.db"),
                 engram_registry_path: root.join("engram-registry.json"),

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -705,7 +705,7 @@ mod tests {
     use crate::{
         config::{
             ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-            RuntimeConfig, ThresholdsConfig,
+            RuntimeConfig, TelemetryConfig, ThresholdsConfig,
         },
         db::migrate_database,
         erv::{ErvDeviceStatus, ErvFanSpeed, ErvSpeedWriter, ErvState},
@@ -810,6 +810,7 @@ mod tests {
                 erv_min_dwell_seconds: 0,
                 ..ThresholdsConfig::default()
             },
+            telemetry: TelemetryConfig::default(),
             runtime: RuntimeConfig {
                 root: root.clone(),
                 config_path: root.join("config.yaml"),
@@ -822,6 +823,10 @@ mod tests {
                 public_url: None,
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
+                telemetry_db_path: root.join("telemetry.db"),
+                tool_usage_db_path: root.join("tool-usage.db"),
+                engram_db_path: root.join("engram.db"),
+                engram_registry_path: root.join("engram-registry.json"),
             },
         }
     }


### PR DESCRIPTION
## Summary
- Add Rust `collect telemetry` and `collect leverage` subcommands backed by configured local paths.
- Port telemetry/project-leverage collection into `office-automate-server` with fake-DB coverage for git stats, tool usage, and leverage rows.
- Preserve existing leverage/project-leverage HTTP response compatibility and legacy operational sync behavior.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`
- Epic #62

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `/Users/rajesh/projects/office-automate/venv/bin/python -m pytest tests/ -v`

Fixes #74