### PR TITLE
Add primary-host launchd and cloudflared templates

### DIFF
--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -1,0 +1,95 @@
+# Primary Host Launchd Services
+
+Ticket #75 adds launchd templates for the Rust primary-host deployment described in `docs/working/62_primary_host_modern_stack.md`.
+
+The templates live in `scripts/launchd/primary-host/`:
+
+| Template | Label | Purpose |
+| --- | --- | --- |
+| `com.office-automate.server.plist.template` | `com.office-automate.server` | Runs `office-automate-server serve --config <config>` as the core API, WebSocket, MQTT ingress, presence, and device-client process. |
+| `com.office-automate.telemetry.plist.template` | `com.office-automate.telemetry` | Runs `office-automate-server collect --config <config> telemetry` on an interval. |
+| `com.office-automate.project-leverage.plist.template` | `com.office-automate.project-leverage` | Runs `office-automate-server collect --config <config> leverage` on an interval. |
+| `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --config <config> run <tunnel>` as the public transport process. |
+
+LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only; application auth remains owned by `office-automate-server`.
+
+## Template Values
+
+Render the templates with deployment-specific absolute paths before loading them:
+
+| Placeholder | Meaning |
+| --- | --- |
+| `__OFFICE_AUTOMATE_ROOT__` | Repository checkout or release directory. |
+| `__OFFICE_AUTOMATE_SERVER_BIN__` | Absolute path to the Rust `office-automate-server` binary. |
+| `__OFFICE_AUTOMATE_CONFIG__` | Absolute path to the deployment config file. |
+| `__OFFICE_AUTOMATE_PATH__` | PATH available to launchd jobs, usually including Homebrew and system paths. |
+| `__OFFICE_AUTOMATE_RUST_LOG__` | Rust log filter, for example `info,office_automate_server=info`. |
+| `__OFFICE_AUTOMATE_LOG_DIR__` | Directory for stdout/stderr logs. Create it before loading jobs. |
+| `__OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__` | Telemetry collector interval marker. The template ships with lintable default `1800`; render this integer for deployment. |
+| `__OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__` | Project-leverage collector interval marker. The template ships with lintable default `7200`; render this integer for deployment. |
+| `__CLOUDFLARED_BIN__` | Absolute path to the `cloudflared` binary. |
+| `__CLOUDFLARED_CONFIG__` | Absolute path to the Cloudflare Tunnel config file. |
+| `__CLOUDFLARED_TUNNEL__` | Cloudflare Tunnel name or UUID. |
+| `__CLOUDFLARED_WORKING_DIRECTORY__` | Directory where `cloudflared` should run. |
+
+Keep hostnames, public routes, credentials, and tunnel credential files in the Cloudflare config and deployment secrets, not in these templates.
+
+## Install
+
+Use LaunchAgents when the service needs the logged-in macOS user session, which is the target for internal presence polling.
+
+```bash
+mkdir -p "$HOME/Library/LaunchAgents" "$OFFICE_AUTOMATE_LOG_DIR"
+cp rendered/com.office-automate.*.plist "$HOME/Library/LaunchAgents/"
+
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+```
+
+Validate loaded jobs:
+
+```bash
+launchctl print "gui/$(id -u)/com.office-automate.server"
+launchctl print "gui/$(id -u)/com.office-automate.telemetry"
+launchctl print "gui/$(id -u)/com.office-automate.project-leverage"
+launchctl print "gui/$(id -u)/com.office-automate.tunnel"
+```
+
+## Unload
+
+```bash
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+```
+
+## Restart
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.office-automate.server"
+launchctl kickstart -k "gui/$(id -u)/com.office-automate.telemetry"
+launchctl kickstart -k "gui/$(id -u)/com.office-automate.project-leverage"
+launchctl kickstart -k "gui/$(id -u)/com.office-automate.tunnel"
+```
+
+The server and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
+
+## Logs
+
+```bash
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-server.out.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-server.err.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.out.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.err.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.out.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.err.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-tunnel.out.log
+tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-tunnel.err.log
+```
+
+## Cloudflare Tunnel Notes
+
+The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward to the local Rust server, and the Rust server should continue enforcing OAuth/JWT or trusted-network rules.

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -25,14 +25,20 @@ Render the templates with deployment-specific absolute paths before loading them
 | `__OFFICE_AUTOMATE_PATH__` | PATH available to launchd jobs, usually including Homebrew and system paths. |
 | `__OFFICE_AUTOMATE_RUST_LOG__` | Rust log filter, for example `info,office_automate_server=info`. |
 | `__OFFICE_AUTOMATE_LOG_DIR__` | Directory for stdout/stderr logs. Create it before loading jobs. |
-| `__OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__` | Telemetry collector interval marker. The template ships with lintable default `1800`; render this integer for deployment. |
-| `__OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__` | Project-leverage collector interval marker. The template ships with lintable default `7200`; render this integer for deployment. |
+| `__OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__` | Telemetry collector interval in seconds, for example `1800`. |
+| `__OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__` | Project-leverage collector interval in seconds, for example `7200`. |
 | `__CLOUDFLARED_BIN__` | Absolute path to the `cloudflared` binary. |
 | `__CLOUDFLARED_CONFIG__` | Absolute path to the Cloudflare Tunnel config file. |
 | `__CLOUDFLARED_TUNNEL__` | Cloudflare Tunnel name or UUID. |
 | `__CLOUDFLARED_WORKING_DIRECTORY__` | Directory where `cloudflared` should run. |
 
 Keep hostnames, public routes, credentials, and tunnel credential files in the Cloudflare config and deployment secrets, not in these templates.
+
+Raw `.plist.template` files are not loadable plists. Render every placeholder, including integer `StartInterval` values, then lint the rendered files:
+
+```bash
+plutil -lint rendered/com.office-automate.*.plist
+```
 
 ## Install
 

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -9,7 +9,7 @@ The templates live in `scripts/launchd/primary-host/`:
 | `com.office-automate.server.plist.template` | `com.office-automate.server` | Runs `office-automate-server serve --config <config>` as the core API, WebSocket, MQTT ingress, presence, and device-client process. |
 | `com.office-automate.telemetry.plist.template` | `com.office-automate.telemetry` | Runs `office-automate-server collect --config <config> telemetry` on an interval. |
 | `com.office-automate.project-leverage.plist.template` | `com.office-automate.project-leverage` | Runs `office-automate-server collect --config <config> leverage` on an interval. |
-| `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --config <config> run <tunnel>` as the public transport process. |
+| `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --no-autoupdate --config <config> run <tunnel>` as the public transport process. |
 
 LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only; application auth remains owned by `office-automate-server`.
 
@@ -81,7 +81,7 @@ launchctl kickstart -k "gui/$(id -u)/com.office-automate.project-leverage"
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.tunnel"
 ```
 
-The server and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
+The server and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The tunnel template passes `--no-autoupdate` so launchd remains the only process supervisor. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
 
 ## Logs
 

--- a/scripts/launchd/primary-host/com.office-automate.project-leverage.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.project-leverage.plist.template
@@ -31,9 +31,8 @@
 
   <key>RunAtLoad</key>
   <true/>
-  <!-- Render from __OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__. -->
   <key>StartInterval</key>
-  <integer>7200</integer>
+  <integer>__OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__</integer>
 
   <key>StandardOutPath</key>
   <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-project-leverage.out.log</string>

--- a/scripts/launchd/primary-host/com.office-automate.project-leverage.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.project-leverage.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.project-leverage</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__OFFICE_AUTOMATE_SERVER_BIN__</string>
+    <string>collect</string>
+    <string>--config</string>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+    <string>leverage</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__OFFICE_AUTOMATE_ROOT__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OFFICE_AUTOMATE_CONFIG</key>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+    <key>OFFICE_AUTOMATE_ROOT</key>
+    <string>__OFFICE_AUTOMATE_ROOT__</string>
+    <key>PATH</key>
+    <string>__OFFICE_AUTOMATE_PATH__</string>
+    <key>RUST_LOG</key>
+    <string>__OFFICE_AUTOMATE_RUST_LOG__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Render from __OFFICE_AUTOMATE_PROJECT_LEVERAGE_INTERVAL_SECONDS__. -->
+  <key>StartInterval</key>
+  <integer>7200</integer>
+
+  <key>StandardOutPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-project-leverage.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-project-leverage.err.log</string>
+</dict>
+</plist>

--- a/scripts/launchd/primary-host/com.office-automate.server.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.server.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.server</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__OFFICE_AUTOMATE_SERVER_BIN__</string>
+    <string>serve</string>
+    <string>--config</string>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__OFFICE_AUTOMATE_ROOT__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OFFICE_AUTOMATE_CONFIG</key>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+    <key>OFFICE_AUTOMATE_ROOT</key>
+    <string>__OFFICE_AUTOMATE_ROOT__</string>
+    <key>PATH</key>
+    <string>__OFFICE_AUTOMATE_PATH__</string>
+    <key>RUST_LOG</key>
+    <string>__OFFICE_AUTOMATE_RUST_LOG__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-server.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-server.err.log</string>
+</dict>
+</plist>

--- a/scripts/launchd/primary-host/com.office-automate.telemetry.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.telemetry.plist.template
@@ -31,9 +31,8 @@
 
   <key>RunAtLoad</key>
   <true/>
-  <!-- Render from __OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__. -->
   <key>StartInterval</key>
-  <integer>1800</integer>
+  <integer>__OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__</integer>
 
   <key>StandardOutPath</key>
   <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-telemetry.out.log</string>

--- a/scripts/launchd/primary-host/com.office-automate.telemetry.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.telemetry.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.telemetry</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__OFFICE_AUTOMATE_SERVER_BIN__</string>
+    <string>collect</string>
+    <string>--config</string>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+    <string>telemetry</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__OFFICE_AUTOMATE_ROOT__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OFFICE_AUTOMATE_CONFIG</key>
+    <string>__OFFICE_AUTOMATE_CONFIG__</string>
+    <key>OFFICE_AUTOMATE_ROOT</key>
+    <string>__OFFICE_AUTOMATE_ROOT__</string>
+    <key>PATH</key>
+    <string>__OFFICE_AUTOMATE_PATH__</string>
+    <key>RUST_LOG</key>
+    <string>__OFFICE_AUTOMATE_RUST_LOG__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Render from __OFFICE_AUTOMATE_TELEMETRY_INTERVAL_SECONDS__. -->
+  <key>StartInterval</key>
+  <integer>1800</integer>
+
+  <key>StandardOutPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-telemetry.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-telemetry.err.log</string>
+</dict>
+</plist>

--- a/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
@@ -9,6 +9,7 @@
   <array>
     <string>__CLOUDFLARED_BIN__</string>
     <string>tunnel</string>
+    <string>--no-autoupdate</string>
     <string>--config</string>
     <string>__CLOUDFLARED_CONFIG__</string>
     <string>run</string>

--- a/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.tunnel</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__CLOUDFLARED_BIN__</string>
+    <string>tunnel</string>
+    <string>--config</string>
+    <string>__CLOUDFLARED_CONFIG__</string>
+    <string>run</string>
+    <string>__CLOUDFLARED_TUNNEL__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__CLOUDFLARED_WORKING_DIRECTORY__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>__OFFICE_AUTOMATE_PATH__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-tunnel.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__OFFICE_AUTOMATE_LOG_DIR__/office-automate-tunnel.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add primary-host launchd templates for the Rust server, telemetry collector, project-leverage collector, and Cloudflare Tunnel.
- Document install, bootstrap, validation, and rollback notes for the launchd/cloudflared service bundle.
- Keep deployment values templated so local paths, hostnames, and tunnel names stay outside the repo.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`

## Test Plan
- [x] `git diff --check`
- [x] Rendered all primary-host templates with sample deployment values, then ran `plutil -lint` on the rendered `.plist` files.
- [x] `cloudflared tunnel run --help | rg -n "no-autoupdate|autoupdate|config"`

Fixes #75