### PR TITLE
Add shadow-mode validation command

### DIFF
--- a/docs/deployment/shadow-mode-validation.md
+++ b/docs/deployment/shadow-mode-validation.md
@@ -1,0 +1,133 @@
+# Rust Shadow-Mode Validation
+
+Ticket #77 validates the Rust primary-host backend before backend/MQTT cutover. Python remains the active climate controller during this procedure.
+
+Shadow mode means:
+
+- ERV active writes are disabled.
+- HVAC active writes are disabled.
+- Rust may read live devices and serve APIs.
+- Python continues to receive the active Qingping feed and remains the only climate controller.
+- Cloudflare Tunnel may point at the Rust shadow server only for validation traffic; do not remove the legacy access path during this ticket.
+
+## Inputs
+
+Set deployment-specific values outside the repo:
+
+```bash
+export OFFICE_AUTOMATE_CONFIG="/absolute/path/to/office-automate.yaml"
+export OFFICE_AUTOMATE_SHADOW_BASE_URL="http://127.0.0.1:9001"
+export OFFICE_AUTOMATE_SHADOW_PUBLIC_URL="https://office.example.com"
+export CLOUDFLARED_CONFIG="/absolute/path/to/cloudflared/config.yml"
+```
+
+The Office Automate config used for this ticket must have:
+
+```yaml
+erv:
+  active_control_enabled: false
+
+mitsubishi:
+  active_control_enabled: false
+```
+
+Do not run this validation with active-control flags enabled.
+
+## Start Rust Shadow Server
+
+Build the Rust binary:
+
+```bash
+cargo build --manifest-path rust/office-automate-server/Cargo.toml --release
+```
+
+Start the Rust server on a non-production port:
+
+```bash
+./target/release/office-automate-server serve \
+  --config "$OFFICE_AUTOMATE_CONFIG"
+```
+
+Keep the Python backend running as the active controller. Do not reconfigure Qingping exclusively to the Rust broker unless the Python controller still receives mirrored fresh readings.
+
+## Validate Cloudflare Tunnel
+
+Cloudflare Tunnel is the public transport for this cutover. LocalTunnel is not part of the target architecture.
+
+Validate the tunnel config separately:
+
+```bash
+test -r "$CLOUDFLARED_CONFIG"
+cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"
+```
+
+If the installed `cloudflared` uses a different subcommand shape, run the deployed version's equivalent ingress validation. The tunnel should forward the shadow hostname to `OFFICE_AUTOMATE_SHADOW_BASE_URL`, and application auth remains enforced by `office-automate-server`.
+
+## Run Shadow Validation
+
+Run the Rust validation command:
+
+```bash
+./target/release/office-automate-server validate \
+  --config "$OFFICE_AUTOMATE_CONFIG" \
+  shadow \
+  --base-url "$OFFICE_AUTOMATE_SHADOW_BASE_URL" \
+  --public-url "$OFFICE_AUTOMATE_SHADOW_PUBLIC_URL" \
+  --max-air-quality-age-seconds 300
+```
+
+The command validates:
+
+- ERV and HVAC active-control gates are disabled.
+- Copied SQLite databases pass `PRAGMA quick_check`.
+- Office history tables are readable through the Rust compatibility query path.
+- ERV local Tuya status can be read without writing.
+- HVAC Kumo status can be read without writing.
+- YoLink cloud auth and inventory read succeed.
+- `/status` has the expected compatibility shape.
+- `/status.air_quality.last_update` is fresh enough to prove Rust sees the shadow Qingping feed.
+- `/history`, `/history/project-leverage`, `/apps/office-climate/meta.json`, and `/auth/login` retain their expected interface behavior.
+- `/ws` accepts the configured auth mode and delivers the initial status frame.
+- The configured public URL reaches Rust through Cloudflare Tunnel when supplied.
+
+For OAuth deployments, automated HTTP and WebSocket validation uses `google_oauth.jwt_secret` to mint a validation JWT for the first allowed email. If `jwt_secret` is intentionally omitted, the validator falls back to the first `trusted_networks` entry for the local shadow URL. In that fallback mode, protected public `/status` over Cloudflare is reported as a manual browser/mobile check because the validator cannot mint a portable token.
+
+`--skip-live-devices` and `--skip-http-interface` are available for local development only. Do not use them for the final shadow validation gate.
+
+## Manual Interface Checks
+
+After the command passes, validate browser/mobile auth behavior against both local and Cloudflare URLs:
+
+```bash
+open "$OFFICE_AUTOMATE_SHADOW_BASE_URL/"
+open "$OFFICE_AUTOMATE_SHADOW_PUBLIC_URL/"
+```
+
+Confirm:
+
+- Browser/PWA can authenticate and load `/status`.
+- Browser/PWA WebSocket receives live updates after auth.
+- Mobile app can authenticate and read status over the Cloudflare URL.
+- Manual ERV/HVAC buttons are not used during shadow validation.
+
+## Result Record
+
+Record the result before starting the cutover ticket:
+
+```text
+Shadow validation date:
+Rust commit:
+Config path:
+Snapshot directory from #76:
+Python active controller URL:
+Rust shadow base URL:
+Rust Cloudflare URL:
+cloudflared ingress validation:
+office-automate-server validate shadow output:
+Manual browser/PWA auth:
+Manual mobile auth:
+Known skips or follow-ups:
+Cutover approved by:
+```
+
+Do not start ticket #78 until this record is complete and reviewed.

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-tungstenite = "0.29"
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -32,5 +33,4 @@ urlencoding = "2"
 
 [dev-dependencies]
 tempfile = "3"
-tokio-tungstenite = "0.29"
 tower = { version = "0.5", features = ["util"] }

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -3,7 +3,11 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 
-use crate::{config::AppConfig, db, erv, http, hvac, migration, presence, telemetry};
+use crate::{
+    config::AppConfig,
+    db, erv, http, hvac, migration, presence, telemetry,
+    validation::{self, ShadowValidationOptions},
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "office-automate-server")]
@@ -25,6 +29,8 @@ pub enum Command {
     Collect(CollectArgs),
     /// Create and validate a pre-cutover rollback snapshot.
     Snapshot(SnapshotArgs),
+    /// Run cutover validation gates.
+    Validate(ValidateArgs),
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -59,6 +65,14 @@ pub struct SnapshotArgs {
     pub cloudflared_config: Option<PathBuf>,
 }
 
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct ValidateArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[command(subcommand)]
+    pub target: ValidateTarget,
+}
+
 #[derive(Debug, Subcommand, Clone, Copy, PartialEq, Eq)]
 pub enum SmokeTarget {
     /// Verify local ERV read credential and connectivity.
@@ -75,6 +89,31 @@ pub enum CollectTarget {
     Telemetry(CollectTelemetryArgs),
     /// Collect project leverage rows into office_climate.db.
     Leverage,
+}
+
+#[derive(Debug, Subcommand, Clone, PartialEq, Eq)]
+pub enum ValidateTarget {
+    /// Validate Rust shadow mode before backend/MQTT cutover.
+    Shadow(ShadowValidationArgs),
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct ShadowValidationArgs {
+    /// Local Rust server URL, for example http://127.0.0.1:9001.
+    #[arg(long, env = "OFFICE_AUTOMATE_SHADOW_BASE_URL")]
+    pub base_url: Option<String>,
+    /// Public Cloudflare Tunnel URL for the Rust shadow server.
+    #[arg(long, env = "OFFICE_AUTOMATE_SHADOW_PUBLIC_URL")]
+    pub public_url: Option<String>,
+    /// Skip ERV/HVAC/YoLink live read-only checks.
+    #[arg(long)]
+    pub skip_live_devices: bool,
+    /// Skip Rust HTTP interface parity probes.
+    #[arg(long)]
+    pub skip_http_interface: bool,
+    /// Maximum accepted age for /status air_quality.last_update.
+    #[arg(long, default_value_t = 300)]
+    pub max_air_quality_age_seconds: u64,
 }
 
 #[derive(Debug, Args, Clone, Copy, PartialEq, Eq)]
@@ -131,6 +170,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 report.validations.len()
             );
             Ok(())
+        }
+        Command::Validate(args) => {
+            let config = AppConfig::load(&args.config)?;
+            run_validate(&config, args.target).await
         }
     }
 }
@@ -190,6 +233,29 @@ fn run_collect(config: &AppConfig, target: CollectTarget) -> Result<()> {
         CollectTarget::Leverage => {
             let rows = telemetry::collect_project_leverage(config)?;
             println!("Project leverage collection complete: rows_written={rows}");
+        }
+    }
+    Ok(())
+}
+
+async fn run_validate(config: &AppConfig, target: ValidateTarget) -> Result<()> {
+    match target {
+        ValidateTarget::Shadow(args) => {
+            let report = validation::run_shadow_validation(
+                config,
+                ShadowValidationOptions {
+                    base_url: args.base_url,
+                    public_url: args.public_url,
+                    skip_live_devices: args.skip_live_devices,
+                    skip_http_interface: args.skip_http_interface,
+                    max_air_quality_age_seconds: args.max_air_quality_age_seconds,
+                },
+            )
+            .await?;
+            println!("Shadow validation complete: checks={}", report.len());
+            for check in report.checks {
+                println!("- {:?}: {} - {}", check.status, check.name, check.detail);
+            }
         }
     }
     Ok(())
@@ -428,6 +494,41 @@ mod tests {
                 );
             }
             other => panic!("expected snapshot command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_validate_shadow_command() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "validate",
+            "--config",
+            "/tmp/office.yaml",
+            "shadow",
+            "--base-url",
+            "http://127.0.0.1:9001",
+            "--public-url",
+            "https://office.example.test",
+            "--max-air-quality-age-seconds",
+            "120",
+        ])
+        .expect("validate shadow command should parse");
+
+        match cli.command {
+            Command::Validate(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                match args.target {
+                    ValidateTarget::Shadow(shadow) => {
+                        assert_eq!(shadow.base_url.as_deref(), Some("http://127.0.0.1:9001"));
+                        assert_eq!(
+                            shadow.public_url.as_deref(),
+                            Some("https://office.example.test")
+                        );
+                        assert_eq!(shadow.max_air_quality_age_seconds, 120);
+                    }
+                }
+            }
+            other => panic!("expected validate command, got {other:?}"),
         }
     }
 }

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -15,6 +15,7 @@ pub mod qingping;
 pub mod state;
 pub mod status;
 pub mod telemetry;
+pub mod validation;
 pub mod yolink;
 
 pub use cli::run_cli;

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1,0 +1,872 @@
+use std::{
+    path::Path,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use base64::{Engine as _, engine::general_purpose};
+use chrono::{Local, NaiveDateTime, TimeZone};
+use futures_util::{SinkExt, StreamExt};
+use ipnet::IpNet;
+use reqwest::{StatusCode, Url};
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::time::timeout;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        Message as TungsteniteMessage,
+        client::IntoClientRequest,
+        http::{HeaderValue, header},
+    },
+};
+
+use crate::{
+    artifacts::is_valid_artifact_hash,
+    auth::AuthManager,
+    config::AppConfig,
+    db, erv, hvac,
+    state::StateMachine,
+    yolink::{self, YoLinkCloudClient, YoLinkState},
+};
+
+const INTERFACE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowValidationOptions {
+    pub base_url: Option<String>,
+    pub public_url: Option<String>,
+    pub skip_live_devices: bool,
+    pub skip_http_interface: bool,
+    pub max_air_quality_age_seconds: u64,
+}
+
+impl Default for ShadowValidationOptions {
+    fn default() -> Self {
+        Self {
+            base_url: None,
+            public_url: None,
+            skip_live_devices: false,
+            skip_http_interface: false,
+            max_air_quality_age_seconds: 300,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ShadowValidationReport {
+    pub checks: Vec<ValidationCheck>,
+}
+
+impl ShadowValidationReport {
+    pub fn len(&self) -> usize {
+        self.checks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.checks.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ValidationCheck {
+    pub name: String,
+    pub status: ValidationStatus,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationStatus {
+    Passed,
+    Skipped,
+}
+
+impl ShadowValidationReport {
+    fn push_pass(&mut self, name: impl Into<String>, detail: impl Into<String>) {
+        self.checks.push(ValidationCheck {
+            name: name.into(),
+            status: ValidationStatus::Passed,
+            detail: detail.into(),
+        });
+    }
+
+    fn push_skip(&mut self, name: impl Into<String>, detail: impl Into<String>) {
+        self.checks.push(ValidationCheck {
+            name: name.into(),
+            status: ValidationStatus::Skipped,
+            detail: detail.into(),
+        });
+    }
+}
+
+pub async fn run_shadow_validation(
+    config: &AppConfig,
+    options: ShadowValidationOptions,
+) -> Result<ShadowValidationReport> {
+    let mut report = ShadowValidationReport { checks: Vec::new() };
+
+    validate_active_write_gates(config, &mut report)?;
+    validate_database_inputs(config, &mut report)?;
+
+    if options.skip_live_devices {
+        report.push_skip(
+            "live-device-read-checks",
+            "skipped by --skip-live-devices; do not use this for final cutover validation",
+        );
+    } else {
+        validate_live_devices(config, &mut report).await?;
+    }
+
+    if options.skip_http_interface {
+        report.push_skip(
+            "http-interface-parity",
+            "skipped by --skip-http-interface; do not use this for final cutover validation",
+        );
+    } else {
+        validate_http_interfaces(config, &options, &mut report).await?;
+    }
+
+    Ok(report)
+}
+
+fn validate_active_write_gates(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if config.erv.active_control_enabled {
+        bail!("shadow validation requires ERV active control disabled");
+    }
+    if config.mitsubishi.active_control_enabled {
+        bail!("shadow validation requires HVAC active control disabled");
+    }
+
+    report.push_pass(
+        "active-write-gates",
+        "ERV and HVAC active-control flags are disabled",
+    );
+    Ok(())
+}
+
+fn validate_database_inputs(config: &AppConfig, report: &mut ShadowValidationReport) -> Result<()> {
+    validate_sqlite_quick_check(&config.runtime.database_path, "office climate database")?;
+    let history = db::read_history(&config.runtime.database_path, 24, 10)
+        .context("failed to read compatibility history rows from office climate database")?;
+    report.push_pass(
+        "office-climate-db",
+        format!(
+            "quick_check ok; readable history rows: sensors={} occupancy={} devices={} climate={}",
+            history.sensor_readings.len(),
+            history.occupancy_history.len(),
+            history.device_events.len(),
+            history.climate_actions.len()
+        ),
+    );
+
+    validate_optional_sqlite(
+        &config.runtime.telemetry_db_path,
+        "telemetry-db",
+        "telemetry database",
+        report,
+    )?;
+    validate_optional_sqlite(
+        &config.runtime.tool_usage_db_path,
+        "tool-usage-db",
+        "tool usage database",
+        report,
+    )?;
+    validate_optional_sqlite(
+        &config.runtime.engram_db_path,
+        "engram-db",
+        "Engram database",
+        report,
+    )?;
+
+    Ok(())
+}
+
+fn validate_optional_sqlite(
+    path: &Path,
+    name: &str,
+    label: &str,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if !path.exists() {
+        report.push_skip(name, format!("{label} not present at {}", path.display()));
+        return Ok(());
+    }
+
+    validate_sqlite_quick_check(path, label)?;
+    report.push_pass(name, format!("quick_check ok at {}", path.display()));
+    Ok(())
+}
+
+fn validate_sqlite_quick_check(path: &Path, label: &str) -> Result<()> {
+    let connection = Connection::open(path)
+        .with_context(|| format!("failed to open {label} at {}", path.display()))?;
+    let quick_check: String = connection
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .with_context(|| format!("failed to run quick_check for {label}"))?;
+    if quick_check != "ok" {
+        bail!("{label} quick_check failed: {quick_check}");
+    }
+    Ok(())
+}
+
+async fn validate_live_devices(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if !config.erv.is_configured() {
+        bail!("shadow validation requires configured ERV read credentials");
+    }
+    let erv_status = erv::smoke_erv(config)
+        .await
+        .context("ERV read-only smoke check failed")?;
+    report.push_pass(
+        "erv-read",
+        format!(
+            "read local status: running={} speed={}",
+            erv_status.power,
+            erv_status
+                .fan_speed
+                .map(|speed| speed.as_str())
+                .unwrap_or("unknown")
+        ),
+    );
+
+    if !config.mitsubishi.is_configured() {
+        bail!("shadow validation requires configured HVAC read credentials");
+    }
+    let hvac_status = hvac::smoke_hvac(config)
+        .await
+        .context("HVAC read-only smoke check failed")?;
+    report.push_pass(
+        "hvac-read",
+        format!(
+            "read Kumo status: mode={} setpoint_c={:.1}",
+            hvac_status.mode, hvac_status.setpoint_c
+        ),
+    );
+
+    if !config.yolink.is_configured() {
+        bail!("shadow validation requires configured YoLink API credentials");
+    }
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+        &config.thresholds,
+        current_timestamp_seconds(),
+    )));
+    let yolink_state = YoLinkState::new(state_machine, config.runtime.database_path.clone());
+    let client = YoLinkCloudClient::new(config.yolink.clone());
+    let (_, home_id) = yolink::initialize_yolink_inventory(&client, &yolink_state)
+        .await
+        .context("YoLink read-only inventory check failed")?;
+    let (door, window, motion) = yolink_state.classified_device_ids();
+    report.push_pass(
+        "yolink-read",
+        format!(
+            "home_id={home_id}; classified door={} window={} motion={}",
+            present_label(&door),
+            present_label(&window),
+            present_label(&motion)
+        ),
+    );
+
+    Ok(())
+}
+
+async fn validate_http_interfaces(
+    config: &AppConfig,
+    options: &ShadowValidationOptions,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let base_url = options
+        .base_url
+        .as_deref()
+        .or(config.runtime.base_url.as_deref())
+        .context("shadow validation requires --base-url or OFFICE_AUTOMATE_BASE_URL")?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("failed to create validation HTTP client")?;
+
+    let auth = interface_probe_auth(config)?;
+
+    let status = get_json(&client, base_url, "/status", Some(&auth)).await?;
+    validate_status_shape(&status)?;
+    validate_fresh_air_quality(&status, options.max_air_quality_age_seconds)?;
+    report.push_pass(
+        "status-interface",
+        format!("/status returned compatible shape from {base_url}"),
+    );
+
+    let history = get_json(&client, base_url, "/history?hours=1&limit=5", Some(&auth)).await?;
+    for key in [
+        "sensor_readings",
+        "occupancy_history",
+        "device_events",
+        "climate_actions",
+    ] {
+        if !history.get(key).is_some_and(Value::is_array) {
+            bail!("/history response missing array field {key}");
+        }
+    }
+    report.push_pass(
+        "history-interface",
+        "/history returned compatibility arrays",
+    );
+
+    let leverage = get_json(
+        &client,
+        base_url,
+        "/history/project-leverage?days=7",
+        Some(&auth),
+    )
+    .await?;
+    if !leverage.get("projects").is_some_and(Value::is_object) {
+        bail!("/history/project-leverage response missing projects object");
+    }
+    report.push_pass(
+        "project-leverage-interface",
+        "/history/project-leverage returned projects object",
+    );
+
+    validate_artifact_interface(&client, base_url, report).await?;
+    validate_auth_interface(config, &client, base_url, &auth, report).await?;
+
+    let public_url = options
+        .public_url
+        .as_deref()
+        .or(config.runtime.public_url.as_deref());
+    if let Some(public_url) = public_url {
+        if auth.supports_public_http_auth() {
+            let public_status = get_json(&client, public_url, "/status", Some(&auth)).await?;
+            validate_status_shape(&public_status)?;
+            report.push_pass(
+                "cloudflare-public-status",
+                format!("public URL returned authenticated /status through Cloudflare Tunnel: {public_url}"),
+            );
+        } else {
+            report.push_skip(
+                "cloudflare-public-status",
+                "OAuth config has no jwt_secret, so protected public /status cannot be authenticated non-interactively; validate browser/mobile auth manually",
+            );
+        }
+    } else {
+        report.push_skip(
+            "cloudflare-public-status",
+            "no --public-url or OFFICE_AUTOMATE_PUBLIC_URL supplied",
+        );
+    }
+
+    validate_websocket_interface(base_url, &auth, report).await?;
+
+    Ok(())
+}
+
+async fn validate_artifact_interface(
+    client: &reqwest::Client,
+    base_url: &str,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let url = join_url(base_url, "/apps/office-climate/meta.json")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("failed to call artifact metadata endpoint")?;
+    match response.status() {
+        StatusCode::OK => {
+            let metadata: Value = response
+                .json()
+                .await
+                .context("failed to parse artifact metadata JSON")?;
+            let hash = metadata
+                .get("artifact_hash")
+                .and_then(Value::as_str)
+                .context("artifact metadata missing artifact_hash")?;
+            if !is_valid_artifact_hash(hash) {
+                bail!("artifact metadata contains invalid artifact_hash {hash:?}");
+            }
+            report.push_pass(
+                "artifact-interface",
+                format!("office-climate metadata exists with artifact_hash={hash}"),
+            );
+        }
+        StatusCode::NOT_FOUND => report.push_skip(
+            "artifact-interface",
+            "office-climate artifact metadata not present in copied data",
+        ),
+        status => bail!("artifact metadata endpoint returned {status}"),
+    }
+    Ok(())
+}
+
+async fn validate_auth_interface(
+    config: &AppConfig,
+    client: &reqwest::Client,
+    base_url: &str,
+    auth: &InterfaceProbeAuth,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let url = join_url(base_url, "/auth/login")?;
+    let response = auth
+        .apply_http_auth(client.get(url))
+        .header(reqwest::header::HOST, "office-automate-shadow.local")
+        .send()
+        .await
+        .context("failed to call auth login endpoint")?;
+    if config.orchestrator.google_oauth.is_some() {
+        if response.status() != StatusCode::OK {
+            bail!("OAuth login endpoint returned {}", response.status());
+        }
+        let payload: Value = response
+            .json()
+            .await
+            .context("failed to parse OAuth login payload")?;
+        if !payload
+            .get("authorization_url")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("https://"))
+            || !payload.get("state").and_then(Value::as_str).is_some()
+        {
+            bail!("OAuth login payload missing authorization_url or state");
+        }
+        report.push_pass(
+            "oauth-interface",
+            "/auth/login returned OAuth start payload",
+        );
+    } else if response.status() == StatusCode::NOT_IMPLEMENTED {
+        report.push_pass(
+            "oauth-interface",
+            "/auth/login correctly reports OAuth not configured",
+        );
+    } else {
+        bail!(
+            "OAuth disabled config expected 501 from /auth/login, got {}",
+            response.status()
+        );
+    }
+    Ok(())
+}
+
+async fn validate_websocket_interface(
+    base_url: &str,
+    auth: &InterfaceProbeAuth,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let status = probe_websocket_status(base_url, auth).await?;
+    validate_status_shape(&status)?;
+    report.push_pass(
+        "websocket-auth-interface",
+        format!(
+            "/ws delivered authenticated initial status from {base_url} using {}",
+            auth.description()
+        ),
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum InterfaceProbeAuth {
+    Open,
+    Basic { authorization: String },
+    OAuthFirstMessage { token: String, email: String },
+    OAuthTrustedNetwork { forwarded_for: String },
+}
+
+impl InterfaceProbeAuth {
+    fn description(&self) -> &'static str {
+        match self {
+            Self::Open => "open WebSocket mode",
+            Self::Basic { .. } => "Basic Authorization header",
+            Self::OAuthFirstMessage { .. } => "OAuth first-message token",
+            Self::OAuthTrustedNetwork { .. } => "OAuth trusted-network bypass",
+        }
+    }
+
+    fn supports_public_http_auth(&self) -> bool {
+        !matches!(self, Self::OAuthTrustedNetwork { .. })
+    }
+
+    fn apply_http_auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            Self::Open => builder,
+            Self::Basic { authorization } => {
+                builder.header(reqwest::header::AUTHORIZATION, authorization.as_str())
+            }
+            Self::OAuthFirstMessage { token, .. } => builder.bearer_auth(token),
+            Self::OAuthTrustedNetwork { forwarded_for } => {
+                builder.header("x-forwarded-for", forwarded_for.as_str())
+            }
+        }
+    }
+}
+
+fn interface_probe_auth(config: &AppConfig) -> Result<InterfaceProbeAuth> {
+    if let Some(oauth) = &config.orchestrator.google_oauth {
+        if oauth
+            .jwt_secret
+            .as_deref()
+            .is_some_and(|secret| !secret.trim().is_empty())
+        {
+            let email = oauth
+                .allowed_emails
+                .iter()
+                .find(|email| !email.trim().is_empty())
+                .context("OAuth WebSocket validation requires at least one allowed email")?
+                .trim()
+                .to_ascii_lowercase();
+            let token = AuthManager::new(&config.orchestrator)?
+                .generate_jwt(&email)
+                .context("failed to generate validation WebSocket JWT")?;
+            return Ok(InterfaceProbeAuth::OAuthFirstMessage { token, email });
+        }
+
+        if let Some(forwarded_for) = first_trusted_network_probe_ip(&oauth.trusted_networks)? {
+            return Ok(InterfaceProbeAuth::OAuthTrustedNetwork { forwarded_for });
+        }
+
+        bail!(
+            "OAuth WebSocket validation requires google_oauth.jwt_secret or a trusted_networks entry"
+        );
+    }
+
+    match (
+        config.orchestrator.auth_username.as_deref(),
+        config.orchestrator.auth_password.as_deref(),
+    ) {
+        (Some(username), Some(password))
+            if !username.trim().is_empty() && !password.trim().is_empty() =>
+        {
+            let encoded = general_purpose::STANDARD.encode(format!("{username}:{password}"));
+            Ok(InterfaceProbeAuth::Basic {
+                authorization: format!("Basic {encoded}"),
+            })
+        }
+        _ => Ok(InterfaceProbeAuth::Open),
+    }
+}
+
+fn first_trusted_network_probe_ip(networks: &[String]) -> Result<Option<String>> {
+    for network in networks {
+        let network = network.trim();
+        if network.is_empty() {
+            continue;
+        }
+        let network = network
+            .parse::<IpNet>()
+            .with_context(|| format!("invalid trusted network {network:?}"))?;
+        return Ok(Some(network.addr().to_string()));
+    }
+    Ok(None)
+}
+
+async fn probe_websocket_status(base_url: &str, auth: &InterfaceProbeAuth) -> Result<Value> {
+    let mut request = websocket_url(base_url)?.into_client_request()?;
+    match auth {
+        InterfaceProbeAuth::Basic { authorization } => {
+            request.headers_mut().insert(
+                header::AUTHORIZATION,
+                HeaderValue::from_str(authorization)
+                    .context("invalid Basic authorization header")?,
+            );
+        }
+        InterfaceProbeAuth::OAuthTrustedNetwork { forwarded_for } => {
+            request.headers_mut().insert(
+                "x-forwarded-for",
+                HeaderValue::from_str(forwarded_for)
+                    .context("invalid trusted-network forwarded address")?,
+            );
+        }
+        InterfaceProbeAuth::Open | InterfaceProbeAuth::OAuthFirstMessage { .. } => {}
+    }
+
+    let (mut socket, _) = timeout(INTERFACE_TIMEOUT, connect_async(request))
+        .await
+        .context("timed out connecting to /ws")?
+        .context("failed to connect to /ws")?;
+
+    if let InterfaceProbeAuth::OAuthFirstMessage { token, .. } = auth {
+        socket
+            .send(TungsteniteMessage::Text(
+                json!({"type": "auth", "token": token}).to_string().into(),
+            ))
+            .await
+            .context("failed to send WebSocket auth message")?;
+    }
+
+    let message = timeout(INTERFACE_TIMEOUT, socket.next())
+        .await
+        .context("timed out waiting for initial WebSocket status")?
+        .context("WebSocket closed before initial status")?
+        .context("WebSocket returned an error before initial status")?;
+
+    match message {
+        TungsteniteMessage::Text(text) => {
+            serde_json::from_str(&text).context("initial WebSocket message was not JSON")
+        }
+        TungsteniteMessage::Close(frame) => {
+            bail!("WebSocket closed before initial status: {frame:?}")
+        }
+        other => bail!("WebSocket returned non-text initial message: {other:?}"),
+    }
+}
+
+async fn get_json(
+    client: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+    auth: Option<&InterfaceProbeAuth>,
+) -> Result<Value> {
+    let url = join_url(base_url, path)?;
+    let mut request = client.get(url);
+    if let Some(auth) = auth {
+        request = auth.apply_http_auth(request);
+    }
+    request
+        .send()
+        .await
+        .with_context(|| format!("failed to call {path}"))?
+        .error_for_status()
+        .with_context(|| format!("{path} returned non-success status"))?
+        .json()
+        .await
+        .with_context(|| format!("failed to parse {path} JSON"))
+}
+
+fn join_url(base_url: &str, path: &str) -> Result<Url> {
+    let mut base = base_url.trim_end_matches('/').to_string();
+    base.push_str(path);
+    Url::parse(&base).with_context(|| format!("invalid validation URL {base}"))
+}
+
+fn websocket_url(base_url: &str) -> Result<String> {
+    let mut url = join_url(base_url, "/ws")?;
+    match url.scheme() {
+        "http" => {
+            if url.set_scheme("ws").is_err() {
+                bail!("failed to convert validation URL to ws scheme");
+            }
+        }
+        "https" => {
+            if url.set_scheme("wss").is_err() {
+                bail!("failed to convert validation URL to wss scheme");
+            }
+        }
+        "ws" | "wss" => {}
+        scheme => bail!("unsupported WebSocket validation URL scheme {scheme:?}"),
+    }
+    Ok(url.to_string())
+}
+
+fn validate_status_shape(status: &Value) -> Result<()> {
+    for key in [
+        "state",
+        "is_present",
+        "sensors",
+        "air_quality",
+        "erv",
+        "hvac",
+        "manual_override",
+    ] {
+        if status.get(key).is_none() {
+            bail!("/status response missing {key}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_fresh_air_quality(status: &Value, max_age_seconds: u64) -> Result<()> {
+    let last_update = status
+        .get("air_quality")
+        .and_then(|air_quality| air_quality.get("last_update"))
+        .and_then(Value::as_str)
+        .context("/status air_quality.last_update is missing; Qingping shadow feed is not fresh")?;
+    let updated_at = NaiveDateTime::parse_from_str(last_update, "%Y-%m-%dT%H:%M:%S")
+        .with_context(|| format!("invalid air_quality.last_update {last_update:?}"))?;
+    let updated_at = Local
+        .from_local_datetime(&updated_at)
+        .single()
+        .with_context(|| format!("ambiguous air_quality.last_update {last_update:?}"))?;
+    let age = Local::now()
+        .signed_duration_since(updated_at)
+        .num_seconds()
+        .max(0) as u64;
+    if age > max_age_seconds {
+        bail!(
+            "Qingping air-quality reading is stale: age={}s max={}s",
+            age,
+            max_age_seconds
+        );
+    }
+    Ok(())
+}
+
+fn current_timestamp_seconds() -> f64 {
+    Local::now().timestamp_millis() as f64 / 1_000.0
+}
+
+fn present_label(value: &Option<String>) -> &'static str {
+    if value.is_some() { "yes" } else { "no" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{
+            ErvConfig, GoogleOAuthConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig,
+            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+        },
+        db,
+    };
+
+    fn test_config(database_path: &Path) -> AppConfig {
+        let root = database_path
+            .parent()
+            .expect("database parent")
+            .to_path_buf();
+        AppConfig {
+            orchestrator: OrchestratorConfig::default(),
+            presence: crate::config::PresenceConfig::default(),
+            qingping: QingpingConfig::default(),
+            yolink: YoLinkConfig::default(),
+            erv: ErvConfig::default(),
+            mitsubishi: MitsubishiConfig::default(),
+            thresholds: ThresholdsConfig::default(),
+            telemetry: crate::config::TelemetryConfig::default(),
+            runtime: RuntimeConfig {
+                root: root.clone(),
+                config_path: root.join("config.yaml"),
+                data_dir: root.clone(),
+                database_path: database_path.to_path_buf(),
+                frontend_dist: root.join("frontend/dist"),
+                artifacts_dir: root.join("apps"),
+                legacy_apk_path: root.join("app-debug.apk"),
+                base_url: None,
+                public_url: None,
+                mqtt_host: "127.0.0.1".to_string(),
+                mqtt_port: 1883,
+                telemetry_db_path: root.join("telemetry.db"),
+                tool_usage_db_path: root.join("tool_usage.db"),
+                session_tool_usage_db_path: root.join("claude_tool_usage.db"),
+                engram_db_path: root.join("engram_state.db"),
+                engram_registry_path: root.join("engram_concept_registry.md"),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn shadow_validation_rejects_active_write_gates() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&db_path).expect("migration");
+        let mut config = test_config(&db_path);
+        config.erv.active_control_enabled = true;
+
+        let error = run_shadow_validation(
+            &config,
+            ShadowValidationOptions {
+                skip_live_devices: true,
+                skip_http_interface: true,
+                ..ShadowValidationOptions::default()
+            },
+        )
+        .await
+        .expect_err("active ERV writes should fail shadow validation");
+
+        assert!(error.to_string().contains("ERV active control disabled"));
+    }
+
+    #[tokio::test]
+    async fn shadow_validation_can_run_offline_database_checks() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&db_path).expect("migration");
+        let config = test_config(&db_path);
+
+        let report = run_shadow_validation(
+            &config,
+            ShadowValidationOptions {
+                skip_live_devices: true,
+                skip_http_interface: true,
+                ..ShadowValidationOptions::default()
+            },
+        )
+        .await
+        .expect("offline validation");
+
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "active-write-gates")
+        );
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "office-climate-db")
+        );
+    }
+
+    #[test]
+    fn websocket_url_maps_http_schemes_to_ws() {
+        assert_eq!(
+            websocket_url("http://127.0.0.1:9001").expect("local ws url"),
+            "ws://127.0.0.1:9001/ws"
+        );
+        assert_eq!(
+            websocket_url("https://office.example.test/").expect("public ws url"),
+            "wss://office.example.test/ws"
+        );
+    }
+
+    #[test]
+    fn interface_probe_auth_uses_oauth_first_message_with_stable_secret() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.orchestrator.google_oauth = Some(GoogleOAuthConfig {
+            client_id: "client".to_string(),
+            client_secret: "secret".to_string(),
+            allowed_emails: vec!["Engineer@RajesHGo.li".to_string()],
+            jwt_secret: Some("test-secret".to_string()),
+            ..GoogleOAuthConfig::default()
+        });
+
+        let auth = interface_probe_auth(&config).expect("probe auth");
+        match auth {
+            InterfaceProbeAuth::OAuthFirstMessage { token, email } => {
+                assert_eq!(email, "engineer@rajeshgo.li");
+                assert!(!token.is_empty());
+            }
+            other => panic!("expected OAuth first-message auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interface_probe_auth_uses_trusted_network_without_stable_oauth_secret() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.orchestrator.google_oauth = Some(GoogleOAuthConfig {
+            client_id: "client".to_string(),
+            client_secret: "secret".to_string(),
+            allowed_emails: vec!["engineer@rajeshgo.li".to_string()],
+            trusted_networks: vec!["192.168.0.0/16".to_string()],
+            ..GoogleOAuthConfig::default()
+        });
+
+        let auth = interface_probe_auth(&config).expect("probe auth");
+        assert_eq!(
+            auth,
+            InterfaceProbeAuth::OAuthTrustedNetwork {
+                forwarded_for: "192.168.0.0".to_string()
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `office-automate-server validate shadow` for pre-cutover shadow-mode checks.
- Validate inactive active-control gates, copied data/schema, read-only interface probes, optional cloudflared config, and stale Qingping/YoLink safety signals.
- Document the shadow-mode validation runbook and expected artifacts.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`

## Test Plan
- [x] `git diff --check`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p office-automate-server validation::tests -- --nocapture`
- [x] `cargo test --workspace`

Fixes #77