### PR TITLE
Add backend MQTT cutover validation

### DIFF
--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -1,0 +1,128 @@
+# Backend/MQTT Cutover
+
+Ticket #78 executes the backend and Qingping MQTT cutover described in `docs/working/62_primary_host_modern_stack.md`.
+
+This procedure is for the cutover window only. Do not leave Python and Rust running with active climate control at the same time.
+
+## Preconditions
+
+- Ticket #76 snapshot completed and produced a rollback snapshot directory with `manifest.json`.
+- Ticket #77 shadow validation completed against the Rust backend with Python still active.
+- ERV and HVAC active write gates were validated by their earlier tickets.
+- Cloudflare Tunnel config was validated with the deployed `cloudflared` binary.
+- Browser/PWA and mobile OAuth behavior was manually checked against the public Cloudflare URL when automated JWT validation is unavailable.
+
+Cloudflare Tunnel is the public transport. LocalTunnel is not part of this cutover.
+
+## Inputs
+
+Set deployment-specific values outside the repo:
+
+```bash
+export OFFICE_AUTOMATE_CONFIG="/absolute/path/to/office-automate.yaml"
+export OFFICE_AUTOMATE_CUTOVER_BASE_URL="http://127.0.0.1:9001"
+export OFFICE_AUTOMATE_PUBLIC_URL="https://office.example.com"
+export OFFICE_AUTOMATE_LEGACY_BASE_URL="http://legacy-host:9001"
+export OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR="/absolute/path/to/office-automate-precutover-YYYYMMDD-HHMMSS"
+export OFFICE_AUTOMATE_CUTOVER_LOG="/absolute/path/to/cutover-log.md"
+export OFFICE_AUTOMATE_MQTT_CUTOVER_STRATEGY="atomic-switch"
+```
+
+Use `bridge-mirror` instead of `atomic-switch` only when the active climate controller continues receiving mirrored fresh Qingping readings for the whole transition.
+
+The Rust config used for the active cutover must have:
+
+```yaml
+erv:
+  active_control_enabled: true
+
+mitsubishi:
+  active_control_enabled: true
+```
+
+Do not run `office-automate-server serve` with those flags while the Python active controller is still running.
+
+## Cutover Sequence
+
+Build and run final preflight checks:
+
+```bash
+cargo build --manifest-path rust/office-automate-server/Cargo.toml --release
+./target/release/office-automate-server migrate --config "$OFFICE_AUTOMATE_CONFIG"
+./target/release/office-automate-server smoke --config "$OFFICE_AUTOMATE_CONFIG"
+cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"
+```
+
+Stop the legacy Python backend and record the timestamp:
+
+```bash
+export OFFICE_AUTOMATE_LEGACY_STOPPED_AT="$(date -Iseconds)"
+```
+
+Apply the selected MQTT feed strategy:
+
+- `bridge-mirror`: keep Qingping publishing to the current active path while bridge/mirror forwarding proves Rust receives the same fresh `qingping/{DEVICE_MAC}/up` reports.
+- `atomic-switch`: move Qingping to the Rust embedded broker in the same window that Python active control stops and Rust active control starts.
+
+Start the Rust backend and Cloudflare Tunnel services with launchd or the equivalent foreground commands:
+
+```bash
+./target/release/office-automate-server serve --config "$OFFICE_AUTOMATE_CONFIG"
+cloudflared tunnel --config "$CLOUDFLARED_CONFIG" run "$CLOUDFLARED_TUNNEL"
+```
+
+## Validation Command
+
+Run cutover validation after Rust is the only active climate controller:
+
+```bash
+./target/release/office-automate-server validate \
+  --config "$OFFICE_AUTOMATE_CONFIG" \
+  cutover \
+  --base-url "$OFFICE_AUTOMATE_CUTOVER_BASE_URL" \
+  --public-url "$OFFICE_AUTOMATE_PUBLIC_URL" \
+  --legacy-base-url "$OFFICE_AUTOMATE_LEGACY_BASE_URL" \
+  --legacy-controller-stopped-at "$OFFICE_AUTOMATE_LEGACY_STOPPED_AT" \
+  --mqtt-strategy "$OFFICE_AUTOMATE_MQTT_CUTOVER_STRATEGY" \
+  --snapshot-dir "$OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR" \
+  --cutover-log "$OFFICE_AUTOMATE_CUTOVER_LOG" \
+  --max-air-quality-age-seconds 300
+```
+
+If the OAuth config cannot mint a validation JWT, complete browser/PWA and mobile OAuth manually, then add:
+
+```bash
+--manual-public-oauth-verified-at "$(date -Iseconds)"
+```
+
+The command validates:
+
+- Rust ERV and HVAC active-control flags are enabled.
+- The rollback snapshot manifest exists.
+- The operator recorded the legacy stop timestamp.
+- The optional legacy `/status` URL no longer responds.
+- The MQTT cutover strategy and Qingping device identity are recorded.
+- ERV, HVAC, and YoLink live read checks pass.
+- Local `/status` has fresh air-quality readings from the active Rust controller.
+- Local `/ws` returns the authenticated initial status frame.
+- Public `/auth/login` returns a Cloudflare-reachable OAuth start payload.
+- Public `/status` is fresh through Cloudflare when automated auth is possible, or manual OAuth verification is recorded.
+- The cutover log is written with timestamps, checks, and rollback point.
+
+## Cutover Log
+
+Keep `$OFFICE_AUTOMATE_CUTOVER_LOG` with the deployment record. It intentionally records paths, URLs, strategy, check results, and rollback source, not secret values.
+
+The log is the handoff artifact for deciding whether to keep Rust active through the validation window.
+
+## Rollback
+
+If validation fails:
+
+1. Stop `office-automate-server` and the Cloudflare Tunnel service on the primary host.
+2. Start the legacy backend and legacy tunnel.
+3. Repoint Qingping to the legacy broker if it moved.
+4. Restore state from `$OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR` if Rust wrote incompatible data.
+5. Keep Rust active-control flags disabled before starting any shadow-mode follow-up.
+
+Do not decommission the legacy gateway during this ticket. Decommissioning belongs to the later rollback-window and cleanup tickets.

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
     config::AppConfig,
     db, erv, http, hvac, migration, presence, telemetry,
-    validation::{self, ShadowValidationOptions},
+    validation::{self, CutoverValidationOptions, MqttCutoverStrategy, ShadowValidationOptions},
 };
 
 #[derive(Debug, Parser)]
@@ -95,6 +95,8 @@ pub enum CollectTarget {
 pub enum ValidateTarget {
     /// Validate Rust shadow mode before backend/MQTT cutover.
     Shadow(ShadowValidationArgs),
+    /// Validate backend/MQTT cutover with Rust as the only active controller.
+    Cutover(CutoverValidationArgs),
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -114,6 +116,52 @@ pub struct ShadowValidationArgs {
     /// Maximum accepted age for /status air_quality.last_update.
     #[arg(long, default_value_t = 300)]
     pub max_air_quality_age_seconds: u64,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct CutoverValidationArgs {
+    /// Local Rust server URL, for example http://127.0.0.1:9001.
+    #[arg(long, env = "OFFICE_AUTOMATE_CUTOVER_BASE_URL")]
+    pub base_url: Option<String>,
+    /// Public Cloudflare Tunnel URL for the Rust server.
+    #[arg(long, env = "OFFICE_AUTOMATE_PUBLIC_URL")]
+    pub public_url: Option<String>,
+    /// Optional legacy backend URL; validation fails if it still responds.
+    #[arg(long, env = "OFFICE_AUTOMATE_LEGACY_BASE_URL")]
+    pub legacy_base_url: Option<String>,
+    /// Operator-recorded timestamp proving Python active control was stopped.
+    #[arg(long, env = "OFFICE_AUTOMATE_LEGACY_STOPPED_AT")]
+    pub legacy_controller_stopped_at: String,
+    /// Qingping feed cutover strategy used for this window.
+    #[arg(long, env = "OFFICE_AUTOMATE_MQTT_CUTOVER_STRATEGY", value_enum)]
+    pub mqtt_strategy: MqttCutoverStrategyArg,
+    /// Pre-cutover rollback snapshot directory from ticket #76.
+    #[arg(long, env = "OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR")]
+    pub snapshot_dir: PathBuf,
+    /// Markdown log file to write with timestamps, checks, and rollback point.
+    #[arg(long, env = "OFFICE_AUTOMATE_CUTOVER_LOG")]
+    pub cutover_log: PathBuf,
+    /// Manual browser/mobile OAuth verification timestamp when no validation JWT can be minted.
+    #[arg(long, env = "OFFICE_AUTOMATE_MANUAL_PUBLIC_OAUTH_VERIFIED_AT")]
+    pub manual_public_oauth_verified_at: Option<String>,
+    /// Maximum accepted age for /status air_quality.last_update.
+    #[arg(long, default_value_t = 300)]
+    pub max_air_quality_age_seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum MqttCutoverStrategyArg {
+    BridgeMirror,
+    AtomicSwitch,
+}
+
+impl From<MqttCutoverStrategyArg> for MqttCutoverStrategy {
+    fn from(value: MqttCutoverStrategyArg) -> Self {
+        match value {
+            MqttCutoverStrategyArg::BridgeMirror => Self::BridgeMirror,
+            MqttCutoverStrategyArg::AtomicSwitch => Self::AtomicSwitch,
+        }
+    }
 }
 
 #[derive(Debug, Args, Clone, Copy, PartialEq, Eq)]
@@ -253,6 +301,27 @@ async fn run_validate(config: &AppConfig, target: ValidateTarget) -> Result<()> 
             )
             .await?;
             println!("Shadow validation complete: checks={}", report.len());
+            for check in report.checks {
+                println!("- {:?}: {} - {}", check.status, check.name, check.detail);
+            }
+        }
+        ValidateTarget::Cutover(args) => {
+            let report = validation::run_cutover_validation(
+                config,
+                CutoverValidationOptions {
+                    base_url: args.base_url,
+                    public_url: args.public_url,
+                    legacy_base_url: args.legacy_base_url,
+                    legacy_controller_stopped_at: args.legacy_controller_stopped_at,
+                    mqtt_strategy: args.mqtt_strategy.into(),
+                    snapshot_dir: args.snapshot_dir,
+                    cutover_log: args.cutover_log,
+                    manual_public_oauth_verified_at: args.manual_public_oauth_verified_at,
+                    max_air_quality_age_seconds: args.max_air_quality_age_seconds,
+                },
+            )
+            .await?;
+            println!("Cutover validation complete: checks={}", report.len());
             for check in report.checks {
                 println!("- {:?}: {} - {}", check.status, check.name, check.detail);
             }
@@ -526,6 +595,51 @@ mod tests {
                         );
                         assert_eq!(shadow.max_air_quality_age_seconds, 120);
                     }
+                    other => panic!("expected shadow validation target, got {other:?}"),
+                }
+            }
+            other => panic!("expected validate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_validate_cutover_command() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "validate",
+            "--config",
+            "/tmp/office.yaml",
+            "cutover",
+            "--base-url",
+            "http://127.0.0.1:9001",
+            "--public-url",
+            "https://office.example.test",
+            "--legacy-controller-stopped-at",
+            "2026-06-06T03:00:00-07:00",
+            "--mqtt-strategy",
+            "atomic-switch",
+            "--snapshot-dir",
+            "/tmp/snapshot",
+            "--cutover-log",
+            "/tmp/cutover.md",
+        ])
+        .expect("validate cutover command should parse");
+
+        match cli.command {
+            Command::Validate(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                match args.target {
+                    ValidateTarget::Cutover(cutover) => {
+                        assert_eq!(cutover.base_url.as_deref(), Some("http://127.0.0.1:9001"));
+                        assert_eq!(
+                            cutover.public_url.as_deref(),
+                            Some("https://office.example.test")
+                        );
+                        assert_eq!(cutover.mqtt_strategy, MqttCutoverStrategyArg::AtomicSwitch);
+                        assert_eq!(cutover.snapshot_dir, PathBuf::from("/tmp/snapshot"));
+                        assert_eq!(cutover.cutover_log, PathBuf::from("/tmp/cutover.md"));
+                    }
+                    other => panic!("expected cutover validation target, got {other:?}"),
                 }
             }
             other => panic!("expected validate command, got {other:?}"),

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1,5 +1,7 @@
 use std::{
-    path::Path,
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -55,6 +57,34 @@ impl Default for ShadowValidationOptions {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CutoverValidationOptions {
+    pub base_url: Option<String>,
+    pub public_url: Option<String>,
+    pub legacy_base_url: Option<String>,
+    pub legacy_controller_stopped_at: String,
+    pub mqtt_strategy: MqttCutoverStrategy,
+    pub snapshot_dir: PathBuf,
+    pub cutover_log: PathBuf,
+    pub manual_public_oauth_verified_at: Option<String>,
+    pub max_air_quality_age_seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqttCutoverStrategy {
+    BridgeMirror,
+    AtomicSwitch,
+}
+
+impl MqttCutoverStrategy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::BridgeMirror => "bridge-mirror",
+            Self::AtomicSwitch => "atomic-switch",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ShadowValidationReport {
     pub checks: Vec<ValidationCheck>,
@@ -82,6 +112,15 @@ pub struct ValidationCheck {
 pub enum ValidationStatus {
     Passed,
     Skipped,
+}
+
+impl ValidationStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Passed => "passed",
+            Self::Skipped => "skipped",
+        }
+    }
 }
 
 impl ShadowValidationReport {
@@ -132,6 +171,23 @@ pub async fn run_shadow_validation(
     Ok(report)
 }
 
+pub async fn run_cutover_validation(
+    config: &AppConfig,
+    options: CutoverValidationOptions,
+) -> Result<ShadowValidationReport> {
+    let mut report = ShadowValidationReport { checks: Vec::new() };
+
+    validate_cutover_active_write_gates(config, &mut report)?;
+    validate_cutover_snapshot(&options.snapshot_dir, &mut report)?;
+    validate_legacy_controller_stopped(&options, &mut report).await?;
+    validate_mqtt_cutover_strategy(config, options.mqtt_strategy, &mut report)?;
+    validate_live_devices(config, &mut report).await?;
+    validate_cutover_http_interfaces(config, &options, &mut report).await?;
+    write_cutover_log(config, &options, &report)?;
+
+    Ok(report)
+}
+
 fn validate_active_write_gates(
     config: &AppConfig,
     report: &mut ShadowValidationReport,
@@ -146,6 +202,127 @@ fn validate_active_write_gates(
     report.push_pass(
         "active-write-gates",
         "ERV and HVAC active-control flags are disabled",
+    );
+    Ok(())
+}
+
+fn validate_cutover_active_write_gates(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if !config.erv.active_control_enabled {
+        bail!("cutover validation requires ERV active control enabled in Rust config");
+    }
+    if !config.mitsubishi.active_control_enabled {
+        bail!("cutover validation requires HVAC active control enabled in Rust config");
+    }
+
+    report.push_pass(
+        "rust-active-write-gates",
+        "ERV and HVAC active-control flags are enabled for Rust",
+    );
+    Ok(())
+}
+
+fn validate_cutover_snapshot(
+    snapshot_dir: &Path,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if !snapshot_dir.is_dir() {
+        bail!(
+            "cutover snapshot directory is missing: {}",
+            snapshot_dir.display()
+        );
+    }
+    let manifest = snapshot_dir.join("manifest.json");
+    if !manifest.is_file() {
+        bail!(
+            "cutover snapshot manifest is missing: {}",
+            manifest.display()
+        );
+    }
+    report.push_pass(
+        "rollback-snapshot",
+        format!(
+            "pre-cutover rollback snapshot manifest present at {}",
+            manifest.display()
+        ),
+    );
+    Ok(())
+}
+
+async fn validate_legacy_controller_stopped(
+    options: &CutoverValidationOptions,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if options.legacy_controller_stopped_at.trim().is_empty() {
+        bail!(
+            "cutover requires --legacy-controller-stopped-at before Rust active control remains enabled"
+        );
+    }
+
+    if let Some(legacy_base_url) = options.legacy_base_url.as_deref() {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .build()
+            .context("failed to create legacy-controller probe client")?;
+        let url = join_url(legacy_base_url, "/status")?;
+        match client.get(url).send().await {
+            Ok(response) => {
+                bail!(
+                    "legacy controller URL still responded with {}; do not run two active controllers",
+                    response.status()
+                );
+            }
+            Err(error) => report.push_pass(
+                "legacy-controller-disabled",
+                format!(
+                    "operator recorded stopped_at={}; legacy /status did not respond: {}",
+                    options.legacy_controller_stopped_at, error
+                ),
+            ),
+        }
+    } else {
+        report.push_pass(
+            "legacy-controller-disabled",
+            format!(
+                "operator recorded stopped_at={}; no legacy URL probe supplied",
+                options.legacy_controller_stopped_at
+            ),
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_mqtt_cutover_strategy(
+    config: &AppConfig,
+    strategy: MqttCutoverStrategy,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let device_mac = config
+        .qingping
+        .device_mac
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context(
+            "cutover validation requires qingping.device_mac so the active feed can be audited",
+        )?;
+
+    let detail = match strategy {
+        MqttCutoverStrategy::BridgeMirror => {
+            "bridge/mirror strategy recorded; active controller must continue receiving mirrored fresh readings"
+        }
+        MqttCutoverStrategy::AtomicSwitch => {
+            "atomic switch strategy recorded; Qingping feed moves in the same window as active-controller cutover"
+        }
+    };
+    report.push_pass(
+        "mqtt-feed-strategy",
+        format!(
+            "{detail}; rust_broker={}:{} device_mac={device_mac}",
+            config.runtime.mqtt_host, config.runtime.mqtt_port
+        ),
     );
     Ok(())
 }
@@ -364,6 +541,193 @@ async fn validate_http_interfaces(
     validate_websocket_interface(base_url, &auth, report).await?;
 
     Ok(())
+}
+
+async fn validate_cutover_http_interfaces(
+    config: &AppConfig,
+    options: &CutoverValidationOptions,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let base_url = options
+        .base_url
+        .as_deref()
+        .or(config.runtime.base_url.as_deref())
+        .context("cutover validation requires --base-url or OFFICE_AUTOMATE_BASE_URL")?;
+    let public_url = options
+        .public_url
+        .as_deref()
+        .or(config.runtime.public_url.as_deref())
+        .context("cutover validation requires --public-url or OFFICE_AUTOMATE_PUBLIC_URL")?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("failed to create cutover validation HTTP client")?;
+    let auth = interface_probe_auth(config)?;
+
+    let status = get_json(&client, base_url, "/status", Some(&auth)).await?;
+    validate_status_shape(&status)?;
+    validate_fresh_air_quality(&status, options.max_air_quality_age_seconds)?;
+    report.push_pass(
+        "rust-status-fresh",
+        format!("/status returned compatible shape with fresh air-quality reading from {base_url}"),
+    );
+
+    validate_websocket_interface(base_url, &auth, report).await?;
+    validate_public_oauth_login(config, &client, public_url, report).await?;
+
+    if auth.supports_public_http_auth() {
+        let public_status = get_json(&client, public_url, "/status", Some(&auth)).await?;
+        validate_status_shape(&public_status)?;
+        validate_fresh_air_quality(&public_status, options.max_air_quality_age_seconds)?;
+        report.push_pass(
+            "cloudflare-public-status",
+            format!("public URL returned authenticated fresh /status through Cloudflare Tunnel: {public_url}"),
+        );
+    } else if let Some(verified_at) = options.manual_public_oauth_verified_at.as_deref() {
+        if verified_at.trim().is_empty() {
+            bail!("manual public OAuth verification timestamp cannot be empty");
+        }
+        report.push_pass(
+            "cloudflare-public-status",
+            format!(
+                "manual browser/mobile OAuth verification recorded at {verified_at}; validation token unavailable"
+            ),
+        );
+    } else {
+        bail!(
+            "OAuth config has no jwt_secret, so protected public /status cannot be authenticated non-interactively; supply --manual-public-oauth-verified-at after browser/mobile verification"
+        );
+    }
+
+    Ok(())
+}
+
+async fn validate_public_oauth_login(
+    config: &AppConfig,
+    client: &reqwest::Client,
+    public_url: &str,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if config.orchestrator.google_oauth.is_none() {
+        bail!("cutover validation requires Google OAuth config for the Cloudflare public URL");
+    }
+
+    let url = join_url(public_url, "/auth/login")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("failed to call public OAuth login endpoint")?;
+    if response.status() != StatusCode::OK {
+        bail!("public OAuth login endpoint returned {}", response.status());
+    }
+    let payload: Value = response
+        .json()
+        .await
+        .context("failed to parse public OAuth login payload")?;
+    if !payload
+        .get("authorization_url")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.starts_with("https://"))
+        || !payload.get("state").and_then(Value::as_str).is_some()
+    {
+        bail!("public OAuth login payload missing authorization_url or state");
+    }
+    report.push_pass(
+        "cloudflare-oauth-login",
+        format!("/auth/login returned OAuth start payload through {public_url}"),
+    );
+    Ok(())
+}
+
+fn write_cutover_log(
+    config: &AppConfig,
+    options: &CutoverValidationOptions,
+    report: &ShadowValidationReport,
+) -> Result<()> {
+    if let Some(parent) = options
+        .cutover_log
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create cutover log directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let base_url = options
+        .base_url
+        .as_deref()
+        .or(config.runtime.base_url.as_deref())
+        .unwrap_or("not recorded");
+    let public_url = options
+        .public_url
+        .as_deref()
+        .or(config.runtime.public_url.as_deref())
+        .unwrap_or("not recorded");
+    let legacy_url = options.legacy_base_url.as_deref().unwrap_or("not supplied");
+    let manifest = options.snapshot_dir.join("manifest.json");
+
+    let mut contents = String::new();
+    writeln!(&mut contents, "# Backend/MQTT Cutover Log\n")?;
+    writeln!(
+        &mut contents,
+        "| Field | Value |\n| --- | --- |\n| Generated at | {} |\n| Rust config | {} |\n| Local Rust URL | {} |\n| Cloudflare public URL | {} |\n| Legacy backend URL | {} |\n| Legacy controller stopped at | {} |\n| MQTT strategy | {} |\n| Rust MQTT broker | {}:{} |\n| Rollback snapshot | {} |\n| Snapshot manifest | {} |\n| Cutover log | {} |",
+        markdown_cell(&Local::now().format("%Y-%m-%d %H:%M:%S %z").to_string()),
+        markdown_cell(&config.runtime.config_path.display().to_string()),
+        markdown_cell(base_url),
+        markdown_cell(public_url),
+        markdown_cell(legacy_url),
+        markdown_cell(&options.legacy_controller_stopped_at),
+        options.mqtt_strategy.as_str(),
+        markdown_cell(&config.runtime.mqtt_host),
+        config.runtime.mqtt_port,
+        markdown_cell(&options.snapshot_dir.display().to_string()),
+        markdown_cell(&manifest.display().to_string()),
+        markdown_cell(&options.cutover_log.display().to_string()),
+    )?;
+
+    writeln!(&mut contents, "\n## Checks\n")?;
+    writeln!(&mut contents, "| Status | Check | Detail |")?;
+    writeln!(&mut contents, "| --- | --- | --- |")?;
+    for check in &report.checks {
+        writeln!(
+            &mut contents,
+            "| {} | {} | {} |",
+            check.status.as_str(),
+            markdown_cell(&check.name),
+            markdown_cell(&check.detail),
+        )?;
+    }
+
+    writeln!(&mut contents, "\n## Rollback Point\n")?;
+    writeln!(
+        &mut contents,
+        "Use the snapshot at `{}` as the rollback source for this cutover window.",
+        options.snapshot_dir.display()
+    )?;
+    writeln!(
+        &mut contents,
+        "Rollback sequence: stop `office-automate-server` and the Cloudflare Tunnel service, start the legacy backend and legacy tunnel, repoint Qingping to the legacy broker if it moved, then restore copied state from the snapshot if Rust wrote incompatible data."
+    )?;
+
+    fs::write(&options.cutover_log, contents).with_context(|| {
+        format!(
+            "failed to write cutover log {}",
+            options.cutover_log.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn markdown_cell(value: &str) -> String {
+    value
+        .replace('|', "\\|")
+        .replace('\n', "<br>")
+        .replace('\r', "")
 }
 
 async fn validate_artifact_interface(
@@ -751,8 +1115,8 @@ mod tests {
                 mqtt_host: "127.0.0.1".to_string(),
                 mqtt_port: 1883,
                 telemetry_db_path: root.join("telemetry.db"),
+                session_tool_usage_db_path: root.join("claude-tool-usage.db"),
                 tool_usage_db_path: root.join("tool_usage.db"),
-                session_tool_usage_db_path: root.join("claude_tool_usage.db"),
                 engram_db_path: root.join("engram_state.db"),
                 engram_registry_path: root.join("engram_concept_registry.md"),
             },
@@ -811,6 +1175,134 @@ mod tests {
                 .iter()
                 .any(|check| check.name == "office-climate-db")
         );
+    }
+
+    #[test]
+    fn cutover_validation_requires_active_write_gates() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error = validate_cutover_active_write_gates(&config, &mut report)
+            .expect_err("inactive writes should fail cutover validation");
+        assert!(error.to_string().contains("ERV active control enabled"));
+
+        config.erv.active_control_enabled = true;
+        config.mitsubishi.active_control_enabled = true;
+        validate_cutover_active_write_gates(&config, &mut report).expect("active write gates pass");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "rust-active-write-gates")
+        );
+    }
+
+    #[test]
+    fn cutover_validation_requires_snapshot_manifest() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error = validate_cutover_snapshot(temp_dir.path(), &mut report)
+            .expect_err("missing manifest should fail");
+        assert!(error.to_string().contains("manifest is missing"));
+
+        fs::write(temp_dir.path().join("manifest.json"), "{}").expect("manifest");
+        validate_cutover_snapshot(temp_dir.path(), &mut report).expect("snapshot passes");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "rollback-snapshot")
+        );
+    }
+
+    #[tokio::test]
+    async fn cutover_validation_requires_legacy_stop_timestamp() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let options = CutoverValidationOptions {
+            base_url: Some("http://127.0.0.1:9001".to_string()),
+            public_url: Some("https://office.example.test".to_string()),
+            legacy_base_url: None,
+            legacy_controller_stopped_at: String::new(),
+            mqtt_strategy: MqttCutoverStrategy::AtomicSwitch,
+            snapshot_dir: temp_dir.path().join("snapshot"),
+            cutover_log: temp_dir.path().join("cutover.md"),
+            manual_public_oauth_verified_at: None,
+            max_air_quality_age_seconds: 300,
+        };
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error = validate_legacy_controller_stopped(&options, &mut report)
+            .await
+            .expect_err("empty timestamp should fail");
+        assert!(error.to_string().contains("legacy-controller-stopped-at"));
+    }
+
+    #[test]
+    fn cutover_validation_records_mqtt_strategy() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error =
+            validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::BridgeMirror, &mut report)
+                .expect_err("missing device mac should fail");
+        assert!(error.to_string().contains("qingping.device_mac"));
+
+        config.qingping.device_mac = Some("AA:BB:CC:DD:EE:FF".to_string());
+        validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::BridgeMirror, &mut report)
+            .expect("strategy passes");
+        let detail = report
+            .checks
+            .iter()
+            .find(|check| check.name == "mqtt-feed-strategy")
+            .expect("mqtt check")
+            .detail
+            .as_str();
+        assert!(detail.contains("bridge/mirror strategy"));
+        assert!(detail.contains("127.0.0.1:1883"));
+    }
+
+    #[test]
+    fn write_cutover_log_records_checks_and_rollback_point() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.runtime.base_url = Some("http://127.0.0.1:9001".to_string());
+        config.runtime.public_url = Some("https://office.example.test".to_string());
+        let snapshot_dir = temp_dir.path().join("snapshot");
+        fs::create_dir(&snapshot_dir).expect("snapshot dir");
+        fs::write(snapshot_dir.join("manifest.json"), "{}").expect("manifest");
+        let options = CutoverValidationOptions {
+            base_url: None,
+            public_url: None,
+            legacy_base_url: Some("http://legacy.example.test".to_string()),
+            legacy_controller_stopped_at: "2026-06-06T03:00:00-07:00".to_string(),
+            mqtt_strategy: MqttCutoverStrategy::AtomicSwitch,
+            snapshot_dir: snapshot_dir.clone(),
+            cutover_log: temp_dir.path().join("logs").join("cutover.md"),
+            manual_public_oauth_verified_at: Some("2026-06-06T03:10:00-07:00".to_string()),
+            max_air_quality_age_seconds: 300,
+        };
+        let report = ShadowValidationReport {
+            checks: vec![ValidationCheck {
+                name: "cloudflare-public-status".to_string(),
+                status: ValidationStatus::Passed,
+                detail: "public URL returned fresh /status".to_string(),
+            }],
+        };
+
+        write_cutover_log(&config, &options, &report).expect("write log");
+
+        let contents = fs::read_to_string(&options.cutover_log).expect("log contents");
+        assert!(contents.contains("# Backend/MQTT Cutover Log"));
+        assert!(contents.contains("atomic-switch"));
+        assert!(contents.contains("cloudflare-public-status"));
+        assert!(contents.contains(&snapshot_dir.display().to_string()));
+        assert!(contents.contains("Rollback sequence"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `office-automate-server validate cutover` for backend/MQTT cutover readiness and logging.
- Verify exactly one active climate controller, snapshot manifest presence, legacy stop timestamp, MQTT strategy, interface probes, and fresh air-quality inputs.
- Document the backend/MQTT cutover runbook and rollback point capture.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`

## Test Plan
- [x] `git diff --check`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p office-automate-server validation::tests -- --nocapture`
- [x] `cargo test --workspace`

Fixes #78