### PR TITLE
Add rollback validation command

### DIFF
--- a/docs/deployment/rollback-validation.md
+++ b/docs/deployment/rollback-validation.md
@@ -1,0 +1,103 @@
+# Rollback Validation
+
+Ticket #79 validates rollback from Rust active control back to the legacy backend described in `docs/working/62_primary_host_modern_stack.md`.
+
+Use this only after a backend/MQTT cutover has started or completed. The goal is to prove the legacy controller is again the only active climate-control path.
+
+## Inputs
+
+Set deployment-specific values outside the repo:
+
+```bash
+export OFFICE_AUTOMATE_CONFIG="/absolute/path/to/office-automate.yaml"
+export OFFICE_AUTOMATE_LEGACY_BASE_URL="http://legacy-host:9001"
+export OFFICE_AUTOMATE_LEGACY_PUBLIC_URL="https://office.example.com"
+export OFFICE_AUTOMATE_CUTOVER_BASE_URL="http://127.0.0.1:9001"
+export OFFICE_AUTOMATE_RUST_PUBLIC_URL="https://rust-office.example.com"
+export OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR="/absolute/path/to/office-automate-precutover-YYYYMMDD-HHMMSS"
+export OFFICE_AUTOMATE_ROLLBACK_LOG="/absolute/path/to/rollback-log.md"
+```
+
+For MQTT rollback state, choose the value that matches the rollback:
+
+- `not-moved`: Qingping never moved off the legacy-compatible MQTT path.
+- `repointed-legacy`: Qingping device or bridge was repointed to the legacy broker.
+- `legacy-mirror`: bridge/mirror forwarding keeps the legacy controller receiving fresh reports.
+
+For snapshot restore verification, choose one:
+
+- `restored-from-snapshot`: copied state was restored from the pre-cutover snapshot.
+- `verified-safe-no-restore`: Rust-written state was reviewed and no restore was required.
+
+## Command Sequence
+
+Stop the Rust backend and primary-host Cloudflare Tunnel:
+
+```bash
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+export OFFICE_AUTOMATE_RUST_STOPPED_AT="$(date -Iseconds)"
+```
+
+Start the legacy backend and legacy Cloudflare Tunnel:
+
+```bash
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.legacy-server.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.legacy-tunnel.plist"
+export OFFICE_AUTOMATE_LEGACY_STARTED_AT="$(date -Iseconds)"
+```
+
+Return Qingping to a legacy-compatible feed path if it moved during cutover, then set:
+
+```bash
+export OFFICE_AUTOMATE_MQTT_ROLLBACK_STATE="repointed-legacy"
+```
+
+Restore data from the pre-cutover snapshot if Rust wrote incompatible state. If no restore is needed after inspection, record that explicitly:
+
+```bash
+export OFFICE_AUTOMATE_RESTORE_VERIFICATION="restored-from-snapshot"
+```
+
+Use `verified-safe-no-restore` only after confirming the legacy backend can read the current state safely.
+
+## Validation Command
+
+Run rollback validation after the legacy backend and legacy Cloudflare Tunnel are active:
+
+```bash
+./target/release/office-automate-server validate \
+  --config "$OFFICE_AUTOMATE_CONFIG" \
+  rollback \
+  --legacy-base-url "$OFFICE_AUTOMATE_LEGACY_BASE_URL" \
+  --legacy-public-url "$OFFICE_AUTOMATE_LEGACY_PUBLIC_URL" \
+  --rust-base-url "$OFFICE_AUTOMATE_CUTOVER_BASE_URL" \
+  --rust-public-url "$OFFICE_AUTOMATE_RUST_PUBLIC_URL" \
+  --rust-stopped-at "$OFFICE_AUTOMATE_RUST_STOPPED_AT" \
+  --legacy-started-at "$OFFICE_AUTOMATE_LEGACY_STARTED_AT" \
+  --mqtt-rollback-state "$OFFICE_AUTOMATE_MQTT_ROLLBACK_STATE" \
+  --snapshot-dir "$OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR" \
+  --restore-verification "$OFFICE_AUTOMATE_RESTORE_VERIFICATION" \
+  --rollback-log "$OFFICE_AUTOMATE_ROLLBACK_LOG" \
+  --max-air-quality-age-seconds 300
+```
+
+If the OAuth config cannot mint a validation JWT, complete browser/PWA and mobile checks against the legacy public URL, then add:
+
+```bash
+--manual-legacy-public-verified-at "$(date -Iseconds)"
+```
+
+The command validates:
+
+- Rust ERV and HVAC active-control flags are disabled.
+- The pre-cutover rollback snapshot manifest exists.
+- Rust local/public `/status` probes no longer respond when URLs are supplied.
+- The Qingping rollback state is recorded against the configured device MAC.
+- The snapshot restore path was tested or explicitly verified safe.
+- Legacy `/status` has the compatibility shape, fresh air-quality data, `safety_interlock`, and healthy ERV local-key state.
+- Legacy `/ws` returns the authenticated initial status frame.
+- Legacy public Cloudflare access reaches OAuth login and fresh `/status`, or manual browser/mobile verification is recorded.
+- A rollback log is written with timestamps, checks, MQTT state, and restore decision.
+
+Do not decommission the primary-host Rust deployment during this ticket. Keep Rust active-control flags disabled before any later shadow-mode follow-up.

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -6,7 +6,10 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use crate::{
     config::AppConfig,
     db, erv, http, hvac, migration, presence, telemetry,
-    validation::{self, CutoverValidationOptions, MqttCutoverStrategy, ShadowValidationOptions},
+    validation::{
+        self, CutoverValidationOptions, MqttCutoverStrategy, MqttRollbackState,
+        RestoreVerification, RollbackValidationOptions, ShadowValidationOptions,
+    },
 };
 
 #[derive(Debug, Parser)]
@@ -97,6 +100,8 @@ pub enum ValidateTarget {
     Shadow(ShadowValidationArgs),
     /// Validate backend/MQTT cutover with Rust as the only active controller.
     Cutover(CutoverValidationArgs),
+    /// Validate rollback from Rust active control to the legacy controller.
+    Rollback(RollbackValidationArgs),
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -149,6 +154,46 @@ pub struct CutoverValidationArgs {
     pub max_air_quality_age_seconds: u64,
 }
 
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct RollbackValidationArgs {
+    /// Local legacy backend URL after rollback, for example http://legacy-host:9001.
+    #[arg(long, env = "OFFICE_AUTOMATE_LEGACY_BASE_URL")]
+    pub legacy_base_url: Option<String>,
+    /// Public Cloudflare URL after rollback routes to the legacy backend.
+    #[arg(long, env = "OFFICE_AUTOMATE_LEGACY_PUBLIC_URL")]
+    pub legacy_public_url: Option<String>,
+    /// Optional local Rust server URL; validation fails if it still responds.
+    #[arg(long, env = "OFFICE_AUTOMATE_CUTOVER_BASE_URL")]
+    pub rust_base_url: Option<String>,
+    /// Optional primary-host public URL; validation fails if it still responds.
+    #[arg(long, env = "OFFICE_AUTOMATE_RUST_PUBLIC_URL")]
+    pub rust_public_url: Option<String>,
+    /// Operator-recorded timestamp proving Rust active control was stopped.
+    #[arg(long, env = "OFFICE_AUTOMATE_RUST_STOPPED_AT")]
+    pub rust_stopped_at: String,
+    /// Operator-recorded timestamp proving the legacy backend/tunnel started.
+    #[arg(long, env = "OFFICE_AUTOMATE_LEGACY_STARTED_AT")]
+    pub legacy_started_at: String,
+    /// Qingping feed state after rollback.
+    #[arg(long, env = "OFFICE_AUTOMATE_MQTT_ROLLBACK_STATE", value_enum)]
+    pub mqtt_rollback_state: MqttRollbackStateArg,
+    /// Pre-cutover rollback snapshot directory from ticket #76.
+    #[arg(long, env = "OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR")]
+    pub snapshot_dir: PathBuf,
+    /// Restore verification result for copied state from the snapshot.
+    #[arg(long, env = "OFFICE_AUTOMATE_RESTORE_VERIFICATION", value_enum)]
+    pub restore_verification: RestoreVerificationArg,
+    /// Markdown log file to write with rollback checks and restore decision.
+    #[arg(long, env = "OFFICE_AUTOMATE_ROLLBACK_LOG")]
+    pub rollback_log: PathBuf,
+    /// Manual browser/mobile public legacy verification timestamp when no validation JWT can be minted.
+    #[arg(long, env = "OFFICE_AUTOMATE_MANUAL_LEGACY_PUBLIC_VERIFIED_AT")]
+    pub manual_legacy_public_verified_at: Option<String>,
+    /// Maximum accepted age for legacy /status air_quality.last_update.
+    #[arg(long, default_value_t = 300)]
+    pub max_air_quality_age_seconds: u64,
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum MqttCutoverStrategyArg {
     BridgeMirror,
@@ -160,6 +205,43 @@ impl From<MqttCutoverStrategyArg> for MqttCutoverStrategy {
         match value {
             MqttCutoverStrategyArg::BridgeMirror => Self::BridgeMirror,
             MqttCutoverStrategyArg::AtomicSwitch => Self::AtomicSwitch,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum MqttRollbackStateArg {
+    /// Qingping never moved off the legacy-compatible MQTT path.
+    NotMoved,
+    /// Qingping device or bridge was repointed to the legacy broker.
+    RepointedLegacy,
+    /// Bridge/mirror forwarding keeps the legacy controller receiving fresh reports.
+    LegacyMirror,
+}
+
+impl From<MqttRollbackStateArg> for MqttRollbackState {
+    fn from(value: MqttRollbackStateArg) -> Self {
+        match value {
+            MqttRollbackStateArg::NotMoved => Self::NotMoved,
+            MqttRollbackStateArg::RepointedLegacy => Self::RepointedLegacy,
+            MqttRollbackStateArg::LegacyMirror => Self::LegacyMirror,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum RestoreVerificationArg {
+    /// State was restored from the pre-cutover snapshot.
+    RestoredFromSnapshot,
+    /// Rust-written state was reviewed and no restore was required.
+    VerifiedSafeNoRestore,
+}
+
+impl From<RestoreVerificationArg> for RestoreVerification {
+    fn from(value: RestoreVerificationArg) -> Self {
+        match value {
+            RestoreVerificationArg::RestoredFromSnapshot => Self::RestoredFromSnapshot,
+            RestoreVerificationArg::VerifiedSafeNoRestore => Self::VerifiedSafeNoRestore,
         }
     }
 }
@@ -322,6 +404,30 @@ async fn run_validate(config: &AppConfig, target: ValidateTarget) -> Result<()> 
             )
             .await?;
             println!("Cutover validation complete: checks={}", report.len());
+            for check in report.checks {
+                println!("- {:?}: {} - {}", check.status, check.name, check.detail);
+            }
+        }
+        ValidateTarget::Rollback(args) => {
+            let report = validation::run_rollback_validation(
+                config,
+                RollbackValidationOptions {
+                    legacy_base_url: args.legacy_base_url,
+                    legacy_public_url: args.legacy_public_url,
+                    rust_base_url: args.rust_base_url,
+                    rust_public_url: args.rust_public_url,
+                    rust_stopped_at: args.rust_stopped_at,
+                    legacy_started_at: args.legacy_started_at,
+                    mqtt_rollback_state: args.mqtt_rollback_state.into(),
+                    snapshot_dir: args.snapshot_dir,
+                    restore_verification: args.restore_verification.into(),
+                    rollback_log: args.rollback_log,
+                    manual_legacy_public_verified_at: args.manual_legacy_public_verified_at,
+                    max_air_quality_age_seconds: args.max_air_quality_age_seconds,
+                },
+            )
+            .await?;
+            println!("Rollback validation complete: checks={}", report.len());
             for check in report.checks {
                 println!("- {:?}: {} - {}", check.status, check.name, check.detail);
             }
@@ -640,6 +746,73 @@ mod tests {
                         assert_eq!(cutover.cutover_log, PathBuf::from("/tmp/cutover.md"));
                     }
                     other => panic!("expected cutover validation target, got {other:?}"),
+                }
+            }
+            other => panic!("expected validate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_validate_rollback_command() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "validate",
+            "--config",
+            "/tmp/office.yaml",
+            "rollback",
+            "--legacy-base-url",
+            "http://legacy-host:9001",
+            "--legacy-public-url",
+            "https://office.example.test",
+            "--rust-base-url",
+            "http://127.0.0.1:9001",
+            "--rust-stopped-at",
+            "2026-06-06T04:00:00-07:00",
+            "--legacy-started-at",
+            "2026-06-06T04:05:00-07:00",
+            "--mqtt-rollback-state",
+            "repointed-legacy",
+            "--snapshot-dir",
+            "/tmp/snapshot",
+            "--restore-verification",
+            "restored-from-snapshot",
+            "--rollback-log",
+            "/tmp/rollback.md",
+            "--max-air-quality-age-seconds",
+            "120",
+        ])
+        .expect("validate rollback command should parse");
+
+        match cli.command {
+            Command::Validate(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                match args.target {
+                    ValidateTarget::Rollback(rollback) => {
+                        assert_eq!(
+                            rollback.legacy_base_url.as_deref(),
+                            Some("http://legacy-host:9001")
+                        );
+                        assert_eq!(
+                            rollback.legacy_public_url.as_deref(),
+                            Some("https://office.example.test")
+                        );
+                        assert_eq!(
+                            rollback.rust_base_url.as_deref(),
+                            Some("http://127.0.0.1:9001")
+                        );
+                        assert_eq!(
+                            rollback.mqtt_rollback_state,
+                            MqttRollbackStateArg::RepointedLegacy
+                        );
+                        assert_eq!(
+                            rollback.restore_verification,
+                            RestoreVerificationArg::RestoredFromSnapshot
+                        );
+                        assert_eq!(rollback.snapshot_dir, PathBuf::from("/tmp/snapshot"));
+                        assert_eq!(rollback.rollback_log, PathBuf::from("/tmp/rollback.md"));
+                        assert_eq!(rollback.max_air_quality_age_seconds, 120);
+                    }
+                    other => panic!("expected rollback validation target, got {other:?}"),
                 }
             }
             other => panic!("expected validate command, got {other:?}"),

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -70,6 +70,22 @@ pub struct CutoverValidationOptions {
     pub max_air_quality_age_seconds: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackValidationOptions {
+    pub legacy_base_url: Option<String>,
+    pub legacy_public_url: Option<String>,
+    pub rust_base_url: Option<String>,
+    pub rust_public_url: Option<String>,
+    pub rust_stopped_at: String,
+    pub legacy_started_at: String,
+    pub mqtt_rollback_state: MqttRollbackState,
+    pub snapshot_dir: PathBuf,
+    pub restore_verification: RestoreVerification,
+    pub rollback_log: PathBuf,
+    pub manual_legacy_public_verified_at: Option<String>,
+    pub max_air_quality_age_seconds: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MqttCutoverStrategy {
     BridgeMirror,
@@ -81,6 +97,38 @@ impl MqttCutoverStrategy {
         match self {
             Self::BridgeMirror => "bridge-mirror",
             Self::AtomicSwitch => "atomic-switch",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqttRollbackState {
+    NotMoved,
+    RepointedLegacy,
+    LegacyMirror,
+}
+
+impl MqttRollbackState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotMoved => "not-moved",
+            Self::RepointedLegacy => "repointed-legacy",
+            Self::LegacyMirror => "legacy-mirror",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreVerification {
+    RestoredFromSnapshot,
+    VerifiedSafeNoRestore,
+}
+
+impl RestoreVerification {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RestoredFromSnapshot => "restored-from-snapshot",
+            Self::VerifiedSafeNoRestore => "verified-safe-no-restore",
         }
     }
 }
@@ -188,6 +236,23 @@ pub async fn run_cutover_validation(
     Ok(report)
 }
 
+pub async fn run_rollback_validation(
+    config: &AppConfig,
+    options: RollbackValidationOptions,
+) -> Result<ShadowValidationReport> {
+    let mut report = ShadowValidationReport { checks: Vec::new() };
+
+    validate_rollback_active_write_gates(config, &mut report)?;
+    validate_cutover_snapshot(&options.snapshot_dir, &mut report)?;
+    validate_rust_controller_stopped(&options, &mut report).await?;
+    validate_mqtt_rollback_state(config, options.mqtt_rollback_state, &mut report)?;
+    validate_restore_verification(options.restore_verification, &mut report)?;
+    validate_legacy_recovered_http_interfaces(config, &options, &mut report).await?;
+    write_rollback_log(config, &options, &report)?;
+
+    Ok(report)
+}
+
 fn validate_active_write_gates(
     config: &AppConfig,
     report: &mut ShadowValidationReport,
@@ -202,6 +267,24 @@ fn validate_active_write_gates(
     report.push_pass(
         "active-write-gates",
         "ERV and HVAC active-control flags are disabled",
+    );
+    Ok(())
+}
+
+fn validate_rollback_active_write_gates(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if config.erv.active_control_enabled {
+        bail!("rollback validation requires ERV active control disabled in Rust config");
+    }
+    if config.mitsubishi.active_control_enabled {
+        bail!("rollback validation requires HVAC active control disabled in Rust config");
+    }
+
+    report.push_pass(
+        "rust-active-write-gates-disabled",
+        "ERV and HVAC active-control flags are disabled before any Rust shadow follow-up",
     );
     Ok(())
 }
@@ -602,6 +685,209 @@ async fn validate_cutover_http_interfaces(
     Ok(())
 }
 
+async fn validate_rust_controller_stopped(
+    options: &RollbackValidationOptions,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if options.rust_stopped_at.trim().is_empty() {
+        bail!("rollback requires --rust-stopped-at after stopping office-automate-server");
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .context("failed to create Rust-controller rollback probe client")?;
+    let mut probed = false;
+
+    if let Some(rust_base_url) = options.rust_base_url.as_deref() {
+        validate_endpoint_absent(&client, rust_base_url, "local Rust /status").await?;
+        report.push_pass(
+            "rust-local-controller-stopped",
+            format!(
+                "operator recorded stopped_at={}; local Rust /status did not respond at {}",
+                options.rust_stopped_at, rust_base_url
+            ),
+        );
+        probed = true;
+    }
+
+    if let Some(rust_public_url) = options.rust_public_url.as_deref() {
+        validate_endpoint_absent(&client, rust_public_url, "public Rust /status").await?;
+        report.push_pass(
+            "rust-public-tunnel-stopped",
+            format!(
+                "operator recorded stopped_at={}; public Rust /status did not respond at {}",
+                options.rust_stopped_at, rust_public_url
+            ),
+        );
+        probed = true;
+    }
+
+    if !probed {
+        report.push_pass(
+            "rust-controller-stopped",
+            format!(
+                "operator recorded stopped_at={}; no Rust URL probe supplied",
+                options.rust_stopped_at
+            ),
+        );
+    }
+
+    Ok(())
+}
+
+async fn validate_endpoint_absent(
+    client: &reqwest::Client,
+    base_url: &str,
+    label: &str,
+) -> Result<()> {
+    let url = join_url(base_url, "/status")?;
+    match client.get(url).send().await {
+        Ok(response) => {
+            bail!(
+                "{label} still responded with {}; rollback must not leave Rust active",
+                response.status()
+            );
+        }
+        Err(_) => Ok(()),
+    }
+}
+
+fn validate_mqtt_rollback_state(
+    config: &AppConfig,
+    state: MqttRollbackState,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let device_mac = config
+        .qingping
+        .device_mac
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context(
+            "rollback validation requires qingping.device_mac so the feed rollback can be audited",
+        )?;
+
+    let detail = match state {
+        MqttRollbackState::NotMoved => "Qingping feed never moved off the legacy-compatible path",
+        MqttRollbackState::RepointedLegacy => {
+            "Qingping device or bridge was repointed to the legacy broker"
+        }
+        MqttRollbackState::LegacyMirror => {
+            "bridge/mirror forwarding keeps the legacy controller receiving fresh reports"
+        }
+    };
+    report.push_pass(
+        "mqtt-feed-rollback",
+        format!("{detail}; device_mac={device_mac}"),
+    );
+    Ok(())
+}
+
+fn validate_restore_verification(
+    restore: RestoreVerification,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let detail = match restore {
+        RestoreVerification::RestoredFromSnapshot => {
+            "operator restored copied state from the pre-cutover snapshot"
+        }
+        RestoreVerification::VerifiedSafeNoRestore => {
+            "operator verified Rust-written state is legacy-compatible; no restore required"
+        }
+    };
+    report.push_pass("snapshot-restore-verification", detail);
+    Ok(())
+}
+
+async fn validate_legacy_recovered_http_interfaces(
+    config: &AppConfig,
+    options: &RollbackValidationOptions,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    let legacy_base_url = options
+        .legacy_base_url
+        .as_deref()
+        .context("rollback validation requires --legacy-base-url")?;
+    if options.legacy_started_at.trim().is_empty() {
+        bail!("rollback requires --legacy-started-at after starting the legacy backend/tunnel");
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("failed to create rollback validation HTTP client")?;
+    let auth = interface_probe_auth(config)?;
+
+    let status = get_json(&client, legacy_base_url, "/status", Some(&auth)).await?;
+    validate_status_shape(&status)?;
+    validate_fresh_air_quality(&status, options.max_air_quality_age_seconds)?;
+    validate_legacy_climate_safety(&status)?;
+    report.push_pass(
+        "legacy-status-fresh",
+        format!(
+            "legacy /status recovered at {}; started_at={}",
+            legacy_base_url, options.legacy_started_at
+        ),
+    );
+
+    validate_websocket_interface(legacy_base_url, &auth, report).await?;
+
+    if let Some(legacy_public_url) = options.legacy_public_url.as_deref() {
+        validate_public_oauth_login(config, &client, legacy_public_url, report).await?;
+        if auth.supports_public_http_auth() {
+            let public_status =
+                get_json(&client, legacy_public_url, "/status", Some(&auth)).await?;
+            validate_status_shape(&public_status)?;
+            validate_fresh_air_quality(&public_status, options.max_air_quality_age_seconds)?;
+            validate_legacy_climate_safety(&public_status)?;
+            report.push_pass(
+                "legacy-cloudflare-public-status",
+                format!("legacy public URL returned fresh /status through Cloudflare Tunnel: {legacy_public_url}"),
+            );
+        } else if let Some(verified_at) = options.manual_legacy_public_verified_at.as_deref() {
+            if verified_at.trim().is_empty() {
+                bail!("manual legacy public verification timestamp cannot be empty");
+            }
+            report.push_pass(
+                "legacy-cloudflare-public-status",
+                format!(
+                    "manual browser/mobile legacy public verification recorded at {verified_at}; validation token unavailable"
+                ),
+            );
+        } else {
+            bail!(
+                "OAuth config has no jwt_secret, so protected legacy public /status cannot be authenticated non-interactively; supply --manual-legacy-public-verified-at after browser/mobile verification"
+            );
+        }
+    } else {
+        report.push_skip(
+            "legacy-cloudflare-public-status",
+            "no --legacy-public-url or OFFICE_AUTOMATE_LEGACY_PUBLIC_URL supplied",
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_legacy_climate_safety(status: &Value) -> Result<()> {
+    if !status
+        .get("safety_interlock")
+        .is_some_and(Value::is_boolean)
+    {
+        bail!("legacy /status safety_interlock is missing or not boolean");
+    }
+    let local_key_invalid = status
+        .get("erv")
+        .and_then(|erv| erv.get("control"))
+        .and_then(|control| control.get("local_key_invalid"))
+        .and_then(Value::as_bool)
+        .context("legacy /status missing erv.control.local_key_invalid")?;
+    if local_key_invalid {
+        bail!("legacy ERV local key is invalid after rollback");
+    }
+    Ok(())
+}
+
 async fn validate_public_oauth_login(
     config: &AppConfig,
     client: &reqwest::Client,
@@ -718,6 +1004,85 @@ fn write_cutover_log(
         format!(
             "failed to write cutover log {}",
             options.cutover_log.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn write_rollback_log(
+    config: &AppConfig,
+    options: &RollbackValidationOptions,
+    report: &ShadowValidationReport,
+) -> Result<()> {
+    if let Some(parent) = options
+        .rollback_log
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create rollback log directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let legacy_base_url = options.legacy_base_url.as_deref().unwrap_or("not supplied");
+    let legacy_public_url = options
+        .legacy_public_url
+        .as_deref()
+        .unwrap_or("not supplied");
+    let rust_base_url = options.rust_base_url.as_deref().unwrap_or("not supplied");
+    let rust_public_url = options.rust_public_url.as_deref().unwrap_or("not supplied");
+    let manifest = options.snapshot_dir.join("manifest.json");
+
+    let mut contents = String::new();
+    writeln!(&mut contents, "# Backend/MQTT Rollback Log\n")?;
+    writeln!(
+        &mut contents,
+        "| Field | Value |\n| --- | --- |\n| Generated at | {} |\n| Rust config | {} |\n| Legacy local URL | {} |\n| Legacy Cloudflare public URL | {} |\n| Rust local URL probe | {} |\n| Rust public URL probe | {} |\n| Rust stopped at | {} |\n| Legacy started at | {} |\n| MQTT rollback state | {} |\n| Restore verification | {} |\n| Rollback snapshot | {} |\n| Snapshot manifest | {} |\n| Rollback log | {} |",
+        markdown_cell(&Local::now().format("%Y-%m-%d %H:%M:%S %z").to_string()),
+        markdown_cell(&config.runtime.config_path.display().to_string()),
+        markdown_cell(legacy_base_url),
+        markdown_cell(legacy_public_url),
+        markdown_cell(rust_base_url),
+        markdown_cell(rust_public_url),
+        markdown_cell(&options.rust_stopped_at),
+        markdown_cell(&options.legacy_started_at),
+        options.mqtt_rollback_state.as_str(),
+        options.restore_verification.as_str(),
+        markdown_cell(&options.snapshot_dir.display().to_string()),
+        markdown_cell(&manifest.display().to_string()),
+        markdown_cell(&options.rollback_log.display().to_string()),
+    )?;
+
+    writeln!(&mut contents, "\n## Checks\n")?;
+    writeln!(&mut contents, "| Status | Check | Detail |")?;
+    writeln!(&mut contents, "| --- | --- | --- |")?;
+    for check in &report.checks {
+        writeln!(
+            &mut contents,
+            "| {} | {} | {} |",
+            check.status.as_str(),
+            markdown_cell(&check.name),
+            markdown_cell(&check.detail),
+        )?;
+    }
+
+    writeln!(&mut contents, "\n## Recovery State\n")?;
+    writeln!(
+        &mut contents,
+        "Legacy backend and Cloudflare Tunnel are the active climate-control path after this rollback validation."
+    )?;
+    writeln!(
+        &mut contents,
+        "Keep Rust active-control flags disabled before any later shadow-mode follow-up."
+    )?;
+
+    fs::write(&options.rollback_log, contents).with_context(|| {
+        format!(
+            "failed to write rollback log {}",
+            options.rollback_log.display()
         )
     })?;
     Ok(())
@@ -1049,8 +1414,7 @@ fn validate_fresh_air_quality(status: &Value, max_age_seconds: u64) -> Result<()
         .and_then(|air_quality| air_quality.get("last_update"))
         .and_then(Value::as_str)
         .context("/status air_quality.last_update is missing; Qingping shadow feed is not fresh")?;
-    let updated_at = NaiveDateTime::parse_from_str(last_update, "%Y-%m-%dT%H:%M:%S")
-        .with_context(|| format!("invalid air_quality.last_update {last_update:?}"))?;
+    let updated_at = parse_air_quality_last_update(last_update)?;
     let updated_at = Local
         .from_local_datetime(&updated_at)
         .single()
@@ -1067,6 +1431,15 @@ fn validate_fresh_air_quality(status: &Value, max_age_seconds: u64) -> Result<()
         );
     }
     Ok(())
+}
+
+fn parse_air_quality_last_update(last_update: &str) -> Result<NaiveDateTime> {
+    for format in ["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S"] {
+        if let Ok(parsed) = NaiveDateTime::parse_from_str(last_update, format) {
+            return Ok(parsed);
+        }
+    }
+    bail!("invalid air_quality.last_update {last_update:?}");
 }
 
 fn current_timestamp_seconds() -> f64 {
@@ -1200,6 +1573,29 @@ mod tests {
     }
 
     #[test]
+    fn rollback_validation_requires_inactive_write_gates() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        config.erv.active_control_enabled = true;
+        let error = validate_rollback_active_write_gates(&config, &mut report)
+            .expect_err("active ERV writes should fail rollback validation");
+        assert!(error.to_string().contains("ERV active control disabled"));
+
+        config.erv.active_control_enabled = false;
+        validate_rollback_active_write_gates(&config, &mut report)
+            .expect("inactive gates should pass");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "rust-active-write-gates-disabled")
+        );
+    }
+
+    #[test]
     fn cutover_validation_requires_snapshot_manifest() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let mut report = ShadowValidationReport { checks: Vec::new() };
@@ -1240,6 +1636,31 @@ mod tests {
         assert!(error.to_string().contains("legacy-controller-stopped-at"));
     }
 
+    #[tokio::test]
+    async fn rollback_validation_requires_rust_stop_timestamp() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let options = RollbackValidationOptions {
+            legacy_base_url: Some("http://legacy.example.test".to_string()),
+            legacy_public_url: None,
+            rust_base_url: None,
+            rust_public_url: None,
+            rust_stopped_at: String::new(),
+            legacy_started_at: "2026-06-06T04:05:00-07:00".to_string(),
+            mqtt_rollback_state: MqttRollbackState::RepointedLegacy,
+            snapshot_dir: temp_dir.path().join("snapshot"),
+            restore_verification: RestoreVerification::RestoredFromSnapshot,
+            rollback_log: temp_dir.path().join("rollback.md"),
+            manual_legacy_public_verified_at: None,
+            max_air_quality_age_seconds: 300,
+        };
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error = validate_rust_controller_stopped(&options, &mut report)
+            .await
+            .expect_err("empty timestamp should fail");
+        assert!(error.to_string().contains("rust-stopped-at"));
+    }
+
     #[test]
     fn cutover_validation_records_mqtt_strategy() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -1264,6 +1685,80 @@ mod tests {
             .as_str();
         assert!(detail.contains("bridge/mirror strategy"));
         assert!(detail.contains("127.0.0.1:1883"));
+    }
+
+    #[test]
+    fn rollback_validation_records_mqtt_state_and_restore_decision() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+
+        let error =
+            validate_mqtt_rollback_state(&config, MqttRollbackState::RepointedLegacy, &mut report)
+                .expect_err("missing device mac should fail");
+        assert!(error.to_string().contains("qingping.device_mac"));
+
+        config.qingping.device_mac = Some("AA:BB:CC:DD:EE:FF".to_string());
+        validate_mqtt_rollback_state(&config, MqttRollbackState::RepointedLegacy, &mut report)
+            .expect("mqtt rollback state passes");
+        validate_restore_verification(RestoreVerification::VerifiedSafeNoRestore, &mut report)
+            .expect("restore verification passes");
+
+        let mqtt_detail = report
+            .checks
+            .iter()
+            .find(|check| check.name == "mqtt-feed-rollback")
+            .expect("mqtt check")
+            .detail
+            .as_str();
+        assert!(mqtt_detail.contains("repointed"));
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "snapshot-restore-verification")
+        );
+    }
+
+    #[test]
+    fn legacy_climate_safety_rejects_invalid_erv_key() {
+        let status = json!({
+            "state": "away",
+            "is_present": false,
+            "sensors": {},
+            "air_quality": {"last_update": "2026-06-06T04:00:00"},
+            "erv": {"control": {"local_key_invalid": true}},
+            "hvac": {},
+            "manual_override": {},
+            "safety_interlock": false
+        });
+
+        let error = validate_legacy_climate_safety(&status)
+            .expect_err("invalid ERV key should fail safety check");
+        assert!(error.to_string().contains("local key is invalid"));
+
+        let mut recovered = status;
+        recovered["erv"]["control"]["local_key_invalid"] = json!(false);
+        validate_legacy_climate_safety(&recovered).expect("recovered safety passes");
+    }
+
+    #[test]
+    fn air_quality_freshness_accepts_whole_and_fractional_local_timestamps() {
+        let whole_seconds = Local::now()
+            .naive_local()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string();
+        let fractional_seconds = format!("{whole_seconds}.123456");
+
+        for last_update in [whole_seconds, fractional_seconds] {
+            let status = json!({
+                "air_quality": {"last_update": last_update},
+            });
+
+            validate_fresh_air_quality(&status, 60)
+                .expect("fresh air-quality timestamp should pass");
+        }
     }
 
     #[test]
@@ -1303,6 +1798,48 @@ mod tests {
         assert!(contents.contains("cloudflare-public-status"));
         assert!(contents.contains(&snapshot_dir.display().to_string()));
         assert!(contents.contains("Rollback sequence"));
+    }
+
+    #[test]
+    fn write_rollback_log_records_checks_and_recovery_state() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.runtime.base_url = Some("http://127.0.0.1:9001".to_string());
+        let snapshot_dir = temp_dir.path().join("snapshot");
+        fs::create_dir(&snapshot_dir).expect("snapshot dir");
+        fs::write(snapshot_dir.join("manifest.json"), "{}").expect("manifest");
+        let options = RollbackValidationOptions {
+            legacy_base_url: Some("http://legacy.example.test".to_string()),
+            legacy_public_url: Some("https://office.example.test".to_string()),
+            rust_base_url: Some("http://127.0.0.1:9001".to_string()),
+            rust_public_url: None,
+            rust_stopped_at: "2026-06-06T04:00:00-07:00".to_string(),
+            legacy_started_at: "2026-06-06T04:05:00-07:00".to_string(),
+            mqtt_rollback_state: MqttRollbackState::RepointedLegacy,
+            snapshot_dir: snapshot_dir.clone(),
+            restore_verification: RestoreVerification::RestoredFromSnapshot,
+            rollback_log: temp_dir.path().join("logs").join("rollback.md"),
+            manual_legacy_public_verified_at: Some("2026-06-06T04:10:00-07:00".to_string()),
+            max_air_quality_age_seconds: 300,
+        };
+        let report = ShadowValidationReport {
+            checks: vec![ValidationCheck {
+                name: "legacy-status-fresh".to_string(),
+                status: ValidationStatus::Passed,
+                detail: "legacy /status recovered".to_string(),
+            }],
+        };
+
+        write_rollback_log(&config, &options, &report).expect("write log");
+
+        let contents = fs::read_to_string(&options.rollback_log).expect("log contents");
+        assert!(contents.contains("# Backend/MQTT Rollback Log"));
+        assert!(contents.contains("repointed-legacy"));
+        assert!(contents.contains("restored-from-snapshot"));
+        assert!(contents.contains("legacy-status-fresh"));
+        assert!(contents.contains(&snapshot_dir.display().to_string()));
+        assert!(contents.contains("Legacy backend and Cloudflare Tunnel are the active"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `office-automate-server validate rollback` for Rust-to-legacy rollback verification.
- Validate Rust stop timestamp, inactive Rust write gates, legacy recovery health, MQTT restore state, and snapshot restore decision logging.
- Document the rollback validation command sequence and expected recovery artifacts.

## Spec Reference
- `docs/working/62_primary_host_modern_stack.md`

## Test Plan
- [x] `git diff --check`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p office-automate-server validation::tests -- --nocapture`
- [x] `cargo test --workspace`

Fixes #79