### PR TITLE
Fail closed unsafe HTTP startup configs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,7 +53,7 @@ thresholds:
 
 # Orchestrator network settings (for Mac occupancy detector to report to)
 orchestrator:
-  host: "0.0.0.0"
+  host: "127.0.0.1"
   port: 8080
   # Optional: Enable HTTP Basic Auth for remote access (recommended with Cloudflare Tunnel)
   # auth_username: "admin"

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -64,7 +64,7 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            host: "0.0.0.0".to_string(),
+            host: "127.0.0.1".to_string(),
             port: 8080,
             auth_username: None,
             auth_password: None,
@@ -632,6 +632,14 @@ fn expand_home_relative_path(path: PathBuf, home_dir: Option<&Path>) -> PathBuf 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn orchestrator_default_binds_http_to_loopback() {
+        let config = OrchestratorConfig::default();
+
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
+    }
 
     #[test]
     fn loads_config_and_applies_environment_overrides() {

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -159,14 +159,17 @@ pub(crate) const PUBLIC_ACCESS_PROBES: &[PublicAccessProbe] = &[
 ];
 
 pub(crate) fn validate_http_startup_config(config: &AppConfig) -> Result<()> {
+    validate_http_startup_config_for_public_url(config, config.runtime.public_url.as_deref())
+}
+
+pub(crate) fn validate_http_startup_config_for_public_url(
+    config: &AppConfig,
+    public_url: Option<&str>,
+) -> Result<()> {
     let host = config.orchestrator.host.trim();
     let is_loopback = is_loopback_bind_host(host);
     let auth_mode = configured_http_auth_mode(config);
-    let public_url_configured = config
-        .runtime
-        .public_url
-        .as_deref()
-        .is_some_and(|public_url| !public_url.trim().is_empty());
+    let public_url_configured = public_url.is_some_and(|public_url| !public_url.trim().is_empty());
 
     if !is_loopback && auth_mode == HttpAuthMode::Open {
         anyhow::bail!(

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -158,6 +158,77 @@ pub(crate) const PUBLIC_ACCESS_PROBES: &[PublicAccessProbe] = &[
     },
 ];
 
+pub(crate) fn validate_http_startup_config(config: &AppConfig) -> Result<()> {
+    let host = config.orchestrator.host.trim();
+    let is_loopback = is_loopback_bind_host(host);
+    let auth_mode = configured_http_auth_mode(config);
+    let public_url_configured = config
+        .runtime
+        .public_url
+        .as_deref()
+        .is_some_and(|public_url| !public_url.trim().is_empty());
+
+    if !is_loopback && auth_mode == HttpAuthMode::Open {
+        anyhow::bail!(
+            "HTTP listener host {host:?} is non-loopback while auth is disabled; bind to 127.0.0.1 or configure OAuth"
+        );
+    }
+
+    if public_url_configured {
+        if !is_loopback {
+            anyhow::bail!(
+                "public Cloudflare origin must bind HTTP to loopback; got orchestrator.host={host:?}"
+            );
+        }
+        match auth_mode {
+            HttpAuthMode::OAuth => {}
+            HttpAuthMode::Basic => anyhow::bail!(
+                "public Cloudflare deployment requires Google OAuth/JWT; Basic auth is a compatibility fallback only"
+            ),
+            HttpAuthMode::Open => anyhow::bail!(
+                "public Cloudflare deployment requires Google OAuth/JWT; auth is disabled"
+            ),
+        }
+        if config
+            .orchestrator
+            .google_oauth
+            .as_ref()
+            .is_some_and(|oauth| !oauth.trusted_networks.is_empty())
+        {
+            anyhow::bail!(
+                "public Cloudflare deployment must not configure google_oauth.trusted_networks; cloudflared reaches origin over loopback"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn configured_http_auth_mode(config: &AppConfig) -> HttpAuthMode {
+    if config.orchestrator.google_oauth.is_some() {
+        HttpAuthMode::OAuth
+    } else if matches!(
+        (
+            config.orchestrator.auth_username.as_deref(),
+            config.orchestrator.auth_password.as_deref()
+        ),
+        (Some(username), Some(password)) if !username.trim().is_empty() && !password.trim().is_empty()
+    ) {
+        HttpAuthMode::Basic
+    } else {
+        HttpAuthMode::Open
+    }
+}
+
+fn is_loopback_bind_host(host: &str) -> bool {
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
+}
+
 const HVAC_TEMPERATURE_BANDS_SETTING: &str = "hvac_temperature_bands";
 
 #[derive(Clone)]
@@ -378,6 +449,7 @@ fn router_from_state(state: AppState) -> Router {
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
+    validate_http_startup_config(&config)?;
     let bind_address = format!("{}:{}", config.orchestrator.host, config.orchestrator.port);
     let listener = TcpListener::bind(&bind_address)
         .await
@@ -2388,6 +2460,62 @@ mod tests {
             },
             ..test_config()
         }
+    }
+
+    #[test]
+    fn http_startup_config_allows_default_loopback_local_open_mode() {
+        let config = test_config();
+
+        validate_http_startup_config(&config).expect("default local config should be safe");
+    }
+
+    #[test]
+    fn http_startup_config_rejects_open_non_loopback_listener() {
+        let mut config = test_config();
+        config.orchestrator.host = "0.0.0.0".to_string();
+
+        let error = validate_http_startup_config(&config)
+            .expect_err("open non-loopback listener should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("non-loopback while auth is disabled")
+        );
+    }
+
+    #[test]
+    fn http_startup_config_rejects_public_non_loopback_basic_and_trusted_networks() {
+        let mut non_loopback = oauth_config();
+        non_loopback.runtime.public_url = Some("https://office.example.test".to_string());
+        non_loopback.orchestrator.host = "0.0.0.0".to_string();
+        non_loopback
+            .orchestrator
+            .google_oauth
+            .as_mut()
+            .expect("oauth")
+            .trusted_networks
+            .clear();
+
+        let error = validate_http_startup_config(&non_loopback)
+            .expect_err("public non-loopback origin should fail");
+        assert!(error.to_string().contains("must bind HTTP to loopback"));
+
+        let mut basic = basic_config();
+        basic.runtime.public_url = Some("https://office.example.test".to_string());
+        let error =
+            validate_http_startup_config(&basic).expect_err("public Basic-only auth should fail");
+        assert!(error.to_string().contains("requires Google OAuth/JWT"));
+
+        let mut trusted_network = oauth_config();
+        trusted_network.runtime.public_url = Some("https://office.example.test".to_string());
+        let error = validate_http_startup_config(&trusted_network)
+            .expect_err("public trusted-network bypass should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("must not configure google_oauth.trusted_networks")
+        );
     }
 
     fn configured_erv_config(active_control_enabled: bool) -> AppConfig {

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -207,6 +207,7 @@ pub async fn run_shadow_validation(
 ) -> Result<ShadowValidationReport> {
     let mut report = ShadowValidationReport { checks: Vec::new() };
 
+    validate_http_startup_config(config, &mut report)?;
     validate_active_write_gates(config, &mut report)?;
     validate_database_inputs(config, &mut report)?;
 
@@ -237,6 +238,7 @@ pub async fn run_cutover_validation(
 ) -> Result<ShadowValidationReport> {
     let mut report = ShadowValidationReport { checks: Vec::new() };
 
+    validate_http_startup_config(config, &mut report)?;
     validate_cutover_active_write_gates(config, &mut report)?;
     validate_cutover_snapshot(&options.snapshot_dir, &mut report)?;
     validate_legacy_controller_stopped(&options, &mut report).await?;
@@ -279,6 +281,18 @@ fn validate_active_write_gates(
     report.push_pass(
         "active-write-gates",
         "ERV and HVAC active-control flags are disabled",
+    );
+    Ok(())
+}
+
+fn validate_http_startup_config(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    http::validate_http_startup_config(config)?;
+    report.push_pass(
+        "http-startup-config",
+        "HTTP listener startup config is safe for configured public/local exposure",
     );
     Ok(())
 }
@@ -2070,6 +2084,30 @@ mod tests {
                 .iter()
                 .any(|check| check.name == "office-climate-db")
         );
+    }
+
+    #[test]
+    fn validation_records_http_startup_config_and_rejects_public_basic_mode() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut report = ShadowValidationReport { checks: Vec::new() };
+        let config = test_config(&db_path);
+
+        validate_http_startup_config(&config, &mut report).expect("default config should pass");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "http-startup-config")
+        );
+
+        let mut public_basic = test_config(&db_path);
+        public_basic.runtime.public_url = Some("https://office.example.test".to_string());
+        public_basic.orchestrator.auth_username = Some("user".to_string());
+        public_basic.orchestrator.auth_password = Some("pass".to_string());
+        let error = validate_http_startup_config(&public_basic, &mut report)
+            .expect_err("public Basic-only config should fail validation");
+        assert!(error.to_string().contains("requires Google OAuth/JWT"));
     }
 
     #[test]

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -207,7 +207,7 @@ pub async fn run_shadow_validation(
 ) -> Result<ShadowValidationReport> {
     let mut report = ShadowValidationReport { checks: Vec::new() };
 
-    validate_http_startup_config(config, &mut report)?;
+    validate_http_startup_config(config, options.public_url.as_deref(), &mut report)?;
     validate_active_write_gates(config, &mut report)?;
     validate_database_inputs(config, &mut report)?;
 
@@ -238,7 +238,7 @@ pub async fn run_cutover_validation(
 ) -> Result<ShadowValidationReport> {
     let mut report = ShadowValidationReport { checks: Vec::new() };
 
-    validate_http_startup_config(config, &mut report)?;
+    validate_http_startup_config(config, options.public_url.as_deref(), &mut report)?;
     validate_cutover_active_write_gates(config, &mut report)?;
     validate_cutover_snapshot(&options.snapshot_dir, &mut report)?;
     validate_legacy_controller_stopped(&options, &mut report).await?;
@@ -287,9 +287,11 @@ fn validate_active_write_gates(
 
 fn validate_http_startup_config(
     config: &AppConfig,
+    public_url: Option<&str>,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
-    http::validate_http_startup_config(config)?;
+    let effective_public_url = public_url.or(config.runtime.public_url.as_deref());
+    http::validate_http_startup_config_for_public_url(config, effective_public_url)?;
     report.push_pass(
         "http-startup-config",
         "HTTP listener startup config is safe for configured public/local exposure",
@@ -2093,7 +2095,8 @@ mod tests {
         let mut report = ShadowValidationReport { checks: Vec::new() };
         let config = test_config(&db_path);
 
-        validate_http_startup_config(&config, &mut report).expect("default config should pass");
+        validate_http_startup_config(&config, None, &mut report)
+            .expect("default config should pass");
         assert!(
             report
                 .checks
@@ -2105,8 +2108,64 @@ mod tests {
         public_basic.runtime.public_url = Some("https://office.example.test".to_string());
         public_basic.orchestrator.auth_username = Some("user".to_string());
         public_basic.orchestrator.auth_password = Some("pass".to_string());
-        let error = validate_http_startup_config(&public_basic, &mut report)
+        let error = validate_http_startup_config(&public_basic, None, &mut report)
             .expect_err("public Basic-only config should fail validation");
+        assert!(error.to_string().contains("requires Google OAuth/JWT"));
+    }
+
+    #[tokio::test]
+    async fn shadow_validation_rejects_option_only_public_basic_mode() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.orchestrator.auth_username = Some("user".to_string());
+        config.orchestrator.auth_password = Some("pass".to_string());
+
+        let error = run_shadow_validation(
+            &config,
+            ShadowValidationOptions {
+                public_url: Some("https://office.example.test".to_string()),
+                skip_live_devices: true,
+                skip_http_interface: true,
+                ..ShadowValidationOptions::default()
+            },
+        )
+        .await
+        .expect_err("option-only public Basic mode should fail shadow validation");
+
+        assert!(error.to_string().contains("requires Google OAuth/JWT"));
+    }
+
+    #[tokio::test]
+    async fn cutover_validation_rejects_option_only_public_basic_mode() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        let mut config = test_config(&db_path);
+        config.orchestrator.auth_username = Some("user".to_string());
+        config.orchestrator.auth_password = Some("pass".to_string());
+
+        let error = run_cutover_validation(
+            &config,
+            CutoverValidationOptions {
+                base_url: None,
+                public_url: Some("https://office.example.test".to_string()),
+                legacy_base_url: None,
+                legacy_controller_stopped_at: String::new(),
+                mqtt_strategy: MqttCutoverStrategy::AtomicSwitch,
+                snapshot_dir: temp_dir.path().join("snapshot"),
+                cutover_log: temp_dir.path().join("cutover.md"),
+                manual_public_oauth_verified_at: None,
+                cloudflared_config: None,
+                cloudflare_access_client_id: None,
+                cloudflare_access_client_secret: None,
+                max_air_quality_age_seconds: 300,
+            },
+        )
+        .await
+        .expect_err(
+            "option-only public Basic mode should fail cutover validation before other gates",
+        );
+
         assert!(error.to_string().contains("requires Google OAuth/JWT"));
     }
 


### PR DESCRIPTION
## Summary
- default the Rust HTTP listener to loopback in code and sample config
- fail startup for open auth on non-loopback listeners
- fail public Cloudflare deployments unless the origin is loopback, OAuth/JWT-backed, and has no trusted-network bypass configured
- include the startup safety check in shadow/cutover validation output

## Spec Reference
- docs/working/100_security_threat_model.md

## Test Plan
- [x] cargo fmt --all
- [x] cargo test -p office-automate-server
- [x] git diff --check

Fixes #102