### PR TITLE
Quarantine Cloudflare tunnel deployment

### DIFF
--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -9,7 +9,7 @@ The templates live in `scripts/launchd/primary-host/`:
 | `com.office-automate.server.plist.template` | `com.office-automate.server` | Runs `office-automate-server serve --config <config>` as the core API, WebSocket, MQTT ingress, presence, and device-client process. |
 | `com.office-automate.telemetry.plist.template` | `com.office-automate.telemetry` | Runs `office-automate-server collect --config <config> telemetry` on an interval. |
 | `com.office-automate.project-leverage.plist.template` | `com.office-automate.project-leverage` | Runs `office-automate-server collect --config <config> leverage` on an interval. |
-| `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --no-autoupdate --config <config> run <tunnel>` as the public transport process. |
+| `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --no-autoupdate --config <config> run <tunnel>` as the quarantined public transport process. |
 
 LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only; application auth remains owned by `office-automate-server`.
 
@@ -31,6 +31,10 @@ Render the templates with deployment-specific absolute paths before loading them
 | `__CLOUDFLARED_CONFIG__` | Absolute path to the Cloudflare Tunnel config file. |
 | `__CLOUDFLARED_TUNNEL__` | Cloudflare Tunnel name or UUID. |
 | `__CLOUDFLARED_WORKING_DIRECTORY__` | Directory where `cloudflared` should run. |
+| `__OFFICE_AUTOMATE_TUNNEL_USER__` | Dedicated low-privilege user that runs only `cloudflared`, for example `_office_tunnel`. |
+| `__OFFICE_AUTOMATE_TUNNEL_GROUP__` | Dedicated group for the tunnel user, for example `_office_tunnel`. |
+| `__OFFICE_AUTOMATE_EDGE_USER__` | Public HTTP edge user for the later edge/controller split. Until that split exists, render this to the same value as `__OFFICE_AUTOMATE_TUNNEL_USER__` in PF templates. |
+| `__OFFICE_AUTOMATE_ORIGIN_PORTS__` | Loopback origin ports the tunnel/edge users may reach, for example `8080`. |
 
 Keep hostnames, public routes, credentials, and tunnel credential files in the Cloudflare config and deployment secrets, not in these templates.
 
@@ -40,18 +44,69 @@ Raw `.plist.template` files are not loadable plists. Render every placeholder, i
 plutil -lint rendered/com.office-automate.*.plist
 ```
 
+## Public Edge Quarantine
+
+`cloudflared` is public edge code. Do not run it as the logged-in user. Use a dedicated low-privilege tunnel account with no shell, no repo access, no controller config/data access, and only the tunnel config/credential/log paths it needs.
+
+Recommended local ownership model:
+
+| Path | Owner | Mode | Purpose |
+| --- | --- | --- | --- |
+| `/Library/LaunchDaemons/com.office-automate.tunnel.plist` | `root:wheel` | `0644` | LaunchDaemon wrapper that switches to the tunnel user. |
+| `/var/lib/office-automate/tunnel/` | `_office_tunnel:_office_tunnel` | `0700` | Cloudflare tunnel config and credential directory. |
+| `/var/log/office-automate/tunnel/` | `_office_tunnel:_office_tunnel` | `0700` | Tunnel stdout/stderr logs. |
+| Controller config, data, repos, telemetry DBs | controller user/group only | `0600` files, `0700` directories | Must be unreadable and non-traversable by `_office_tunnel` and by the later public edge user. |
+| Public edge config and credentials | public edge user/group only | `0600` files, `0700` directories | Must be unreadable and non-traversable by `_office_tunnel` unless the tunnel explicitly needs them. |
+
+Create the tunnel account through your normal macOS account-management path or MDM. The account must be non-login and dedicated to Office Automate tunnel transport. The examples below assume `_office_tunnel`.
+
+```bash
+sudo install -d -o _office_tunnel -g _office_tunnel -m 0700 /var/lib/office-automate/tunnel
+sudo install -d -o _office_tunnel -g _office_tunnel -m 0700 /var/log/office-automate/tunnel
+sudo install -o _office_tunnel -g _office_tunnel -m 0600 "$CLOUDFLARED_CONFIG" /var/lib/office-automate/tunnel/config.yml
+sudo install -o _office_tunnel -g _office_tunnel -m 0600 "$CLOUDFLARED_CREDENTIALS" /var/lib/office-automate/tunnel/credentials.json
+```
+
+The Cloudflare config in `/var/lib/office-automate/tunnel/config.yml` should reference the credential copy in that same directory and route only to the loopback or Unix-socket origin validated by `office-automate-server validate`.
+
+Render and install the PF anchor template in `scripts/pf/office-automate-edge-anchor.conf.template` after replacing every placeholder:
+
+```bash
+sudo install -o root -g wheel -m 0644 rendered/office-automate-edge-anchor.conf /etc/pf.anchors/office-automate-edge
+```
+
+Then include the anchor from `/etc/pf.conf`:
+
+```pf
+anchor "office-automate-edge"
+load anchor "office-automate-edge" from "/etc/pf.anchors/office-automate-edge"
+```
+
+Load and inspect PF:
+
+```bash
+sudo pfctl -f /etc/pf.conf
+sudo pfctl -E
+sudo pfctl -sr | rg office-automate -A5
+```
+
+The anchor must deny the tunnel/edge users outbound RFC1918/LAN traffic while still allowing loopback origin access. A compromised `cloudflared` process must not be able to connect to ERV/HVAC/MQTT/LAN addresses or read controller secrets.
+
 ## Install
 
-Use LaunchAgents when the service needs the logged-in macOS user session, which is the target for internal presence polling.
+Use LaunchAgents only for jobs that need the logged-in macOS user session. The server currently owns presence polling, so it remains a LaunchAgent until the public edge/controller split is implemented. The tunnel does not need the user session and must run as a LaunchDaemon under the dedicated tunnel user.
 
 ```bash
 mkdir -p "$HOME/Library/LaunchAgents" "$OFFICE_AUTOMATE_LOG_DIR"
-cp rendered/com.office-automate.*.plist "$HOME/Library/LaunchAgents/"
+cp rendered/com.office-automate.server.plist "$HOME/Library/LaunchAgents/"
+cp rendered/com.office-automate.telemetry.plist "$HOME/Library/LaunchAgents/"
+cp rendered/com.office-automate.project-leverage.plist "$HOME/Library/LaunchAgents/"
+sudo install -o root -g wheel -m 0644 rendered/com.office-automate.tunnel.plist /Library/LaunchDaemons/com.office-automate.tunnel.plist
 
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
-launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.office-automate.tunnel.plist
 ```
 
 Validate loaded jobs:
@@ -60,7 +115,7 @@ Validate loaded jobs:
 launchctl print "gui/$(id -u)/com.office-automate.server"
 launchctl print "gui/$(id -u)/com.office-automate.telemetry"
 launchctl print "gui/$(id -u)/com.office-automate.project-leverage"
-launchctl print "gui/$(id -u)/com.office-automate.tunnel"
+sudo launchctl print system/com.office-automate.tunnel
 ```
 
 ## Unload
@@ -69,7 +124,7 @@ launchctl print "gui/$(id -u)/com.office-automate.tunnel"
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
-launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.tunnel.plist
 ```
 
 ## Restart
@@ -78,7 +133,7 @@ launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.server"
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.telemetry"
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.project-leverage"
-launchctl kickstart -k "gui/$(id -u)/com.office-automate.tunnel"
+sudo launchctl kickstart -k system/com.office-automate.tunnel
 ```
 
 The server and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The tunnel template passes `--no-autoupdate` so launchd remains the only process supervisor. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
@@ -92,10 +147,53 @@ tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.out.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.err.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.out.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.err.log
-tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-tunnel.out.log
-tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-tunnel.err.log
+sudo tail -F /var/log/office-automate/tunnel/office-automate-tunnel.out.log
+sudo tail -F /var/log/office-automate/tunnel/office-automate-tunnel.err.log
 ```
+
+## Quarantine Validation
+
+After rendering the tunnel plist and PF anchor, run the quarantine validator as an operator check. Use a LAN probe that is expected to be reachable from the current user or from `--lan-control-user`; the validator requires that positive control before it accepts tunnel/edge denial as evidence. Prefer a numeric LAN IP to avoid treating DNS behavior as firewall evidence.
+
+Before the public edge/controller split exists, render `--edge-user` to the tunnel user and omit edge-private credential checks because there is no separate edge credential owner yet:
+
+```bash
+scripts/security/validate-edge-quarantine.sh \
+  --tunnel-user _office_tunnel \
+  --edge-user _office_tunnel \
+  --tunnel-readable /var/lib/office-automate/tunnel/config.yml \
+  --tunnel-readable /var/lib/office-automate/tunnel/credentials.json \
+  --protected-path "$OFFICE_AUTOMATE_CONFIG" \
+  --protected-path "$OFFICE_AUTOMATE_DATABASE" \
+  --protected-path "$OFFICE_AUTOMATE_REPO_ROOT" \
+  --protected-path "$OFFICE_AUTOMATE_TELEMETRY_DB" \
+  --origin-probe 127.0.0.1:8080 \
+  --lan-probe 192.168.1.1:80
+```
+
+After the public edge/controller split is installed with distinct users, validate reciprocal credential separation explicitly:
+
+```bash
+scripts/security/validate-edge-quarantine.sh \
+  --tunnel-user _office_tunnel \
+  --edge-user _office_edge \
+  --tunnel-readable /var/lib/office-automate/tunnel/config.yml \
+  --tunnel-readable /var/lib/office-automate/tunnel/credentials.json \
+  --tunnel-private /var/lib/office-automate/tunnel/config.yml \
+  --tunnel-private /var/lib/office-automate/tunnel/credentials.json \
+  --edge-readable "$OFFICE_AUTOMATE_EDGE_CREDENTIALS" \
+  --edge-private "$OFFICE_AUTOMATE_EDGE_CREDENTIALS" \
+  --protected-path "$OFFICE_AUTOMATE_CONFIG" \
+  --protected-path "$OFFICE_AUTOMATE_DATABASE" \
+  --protected-path "$OFFICE_AUTOMATE_REPO_ROOT" \
+  --protected-path "$OFFICE_AUTOMATE_TELEMETRY_DB" \
+  --origin-probe 127.0.0.1:8080 \
+  --lan-control-user "$OFFICE_AUTOMATE_CONTROLLER_USER" \
+  --lan-probe 192.168.1.1:80
+```
+
+The validation passes only if the tunnel/edge users can read the material they need, cannot read or traverse controller config/data/repos/telemetry, cannot read or traverse each other's private credentials unless explicitly required, can reach the approved loopback origin, and cannot connect to LAN/RFC1918 endpoints that the control user can reach.
 
 ## Cloudflare Tunnel Notes
 
-The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward to the local Rust server, and the Rust server should continue enforcing OAuth/JWT or trusted-network rules.
+The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward only to the local Rust origin, and the Rust server should continue enforcing OAuth/JWT. Public deployments must not use `trusted_networks`.

--- a/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
@@ -5,6 +5,12 @@
   <key>Label</key>
   <string>com.office-automate.tunnel</string>
 
+  <key>UserName</key>
+  <string>__OFFICE_AUTOMATE_TUNNEL_USER__</string>
+
+  <key>GroupName</key>
+  <string>__OFFICE_AUTOMATE_TUNNEL_GROUP__</string>
+
   <key>ProgramArguments</key>
   <array>
     <string>__CLOUDFLARED_BIN__</string>

--- a/scripts/pf/office-automate-edge-anchor.conf.template
+++ b/scripts/pf/office-automate-edge-anchor.conf.template
@@ -1,0 +1,7 @@
+office_automate_edge_users = "{ __OFFICE_AUTOMATE_TUNNEL_USER__ __OFFICE_AUTOMATE_EDGE_USER__ }"
+office_automate_private_nets = "{ 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 fc00::/7 fe80::/10 }"
+office_automate_origin_ports = "{ __OFFICE_AUTOMATE_ORIGIN_PORTS__ }"
+
+pass out quick on lo0 proto tcp user $office_automate_edge_users to 127.0.0.1 port $office_automate_origin_ports
+pass out quick on lo0 proto tcp user $office_automate_edge_users to ::1 port $office_automate_origin_ports
+block out quick proto { tcp udp } user $office_automate_edge_users to $office_automate_private_nets

--- a/scripts/security/validate-edge-quarantine.sh
+++ b/scripts/security/validate-edge-quarantine.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: validate-edge-quarantine.sh --tunnel-user USER [options]
+
+Validates the local public-edge quarantine boundary by running read and network
+checks as the configured tunnel/edge users.
+
+Required:
+  --tunnel-user USER              Dedicated cloudflared launchd user.
+
+Optional:
+  --edge-user USER                Public HTTP edge user. Defaults to tunnel user.
+  --protected-path PATH           Path tunnel/edge users must not read or traverse. Repeatable.
+  --tunnel-readable PATH          Path tunnel user must read, usually cloudflared config/creds. Repeatable.
+  --tunnel-private PATH           Path edge user must not read or traverse. Repeatable.
+  --edge-readable PATH            Path edge user must read. Repeatable.
+  --edge-private PATH             Path tunnel user must not read or traverse. Repeatable.
+  --lan-probe HOST:PORT           LAN/RFC1918 endpoint tunnel/edge users must not reach. Repeatable.
+  --lan-control-user USER         User that must reach LAN probes before denial checks. Defaults to current user.
+  --origin-probe HOST:PORT        Loopback origin endpoint tunnel/edge users may reach. Repeatable.
+
+The script requires passwordless sudo for `sudo -n -u USER ...` checks.
+USAGE
+}
+
+tunnel_user=""
+edge_user=""
+protected_paths=()
+tunnel_readable_paths=()
+tunnel_private_paths=()
+edge_readable_paths=()
+edge_private_paths=()
+lan_probes=()
+lan_control_user=""
+origin_probes=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tunnel-user)
+      tunnel_user="${2:-}"
+      shift 2
+      ;;
+    --edge-user)
+      edge_user="${2:-}"
+      shift 2
+      ;;
+    --protected-path)
+      protected_paths+=("${2:-}")
+      shift 2
+      ;;
+    --tunnel-readable)
+      tunnel_readable_paths+=("${2:-}")
+      shift 2
+      ;;
+    --tunnel-private)
+      tunnel_private_paths+=("${2:-}")
+      shift 2
+      ;;
+    --edge-readable)
+      edge_readable_paths+=("${2:-}")
+      shift 2
+      ;;
+    --edge-private)
+      edge_private_paths+=("${2:-}")
+      shift 2
+      ;;
+    --lan-probe)
+      lan_probes+=("${2:-}")
+      shift 2
+      ;;
+    --lan-control-user)
+      lan_control_user="${2:-}"
+      shift 2
+      ;;
+    --origin-probe)
+      origin_probes+=("${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$tunnel_user" ]]; then
+  echo "--tunnel-user is required" >&2
+  usage >&2
+  exit 2
+fi
+if [[ -z "$edge_user" ]]; then
+  edge_user="$tunnel_user"
+fi
+
+run_as() {
+  local user="$1"
+  shift
+  sudo -n -u "$user" "$@"
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "required command not found: $command_name" >&2
+    exit 2
+  fi
+}
+
+ensure_user_runnable() {
+  local user="$1"
+  if ! run_as "$user" true; then
+    echo "cannot run checks as user=$user; passwordless sudo may be missing" >&2
+    exit 2
+  fi
+}
+
+expect_readable() {
+  local user="$1"
+  local path="$2"
+  if [[ -z "$path" ]]; then
+    echo "empty readable path" >&2
+    exit 2
+  fi
+  run_as "$user" test -r "$path"
+  echo "PASS readable: user=$user path=$path"
+}
+
+expect_unreadable() {
+  local user="$1"
+  local path="$2"
+  if [[ -z "$path" ]]; then
+    echo "empty protected path" >&2
+    exit 2
+  fi
+  if run_as "$user" test -r "$path"; then
+    echo "FAIL readable by quarantined user: user=$user path=$path" >&2
+    exit 1
+  fi
+  if run_as "$user" test -x "$path"; then
+    echo "FAIL traversable/executable by quarantined user: user=$user path=$path" >&2
+    exit 1
+  fi
+  echo "PASS unreadable and non-traversable: user=$user path=$path"
+}
+
+split_host_port() {
+  local endpoint="$1"
+  local __host_var="$2"
+  local __port_var="$3"
+  if [[ "$endpoint" != *:* ]]; then
+    echo "endpoint must be HOST:PORT: $endpoint" >&2
+    exit 2
+  fi
+  printf -v "$__host_var" '%s' "${endpoint%:*}"
+  printf -v "$__port_var" '%s' "${endpoint##*:}"
+}
+
+expect_connect() {
+  local user="$1"
+  local endpoint="$2"
+  local host port
+  split_host_port "$endpoint" host port
+  run_as "$user" nc -G 2 -z "$host" "$port"
+  echo "PASS connect allowed: user=$user endpoint=$endpoint"
+}
+
+expect_control_connect() {
+  local endpoint="$1"
+  local host port
+  split_host_port "$endpoint" host port
+  if [[ -n "$lan_control_user" ]]; then
+    if ! run_as "$lan_control_user" nc -G 2 -z "$host" "$port"; then
+      echo "FAIL LAN control is not reachable: user=$lan_control_user endpoint=$endpoint" >&2
+      exit 1
+    fi
+    echo "PASS LAN control reachable: user=$lan_control_user endpoint=$endpoint"
+  else
+    if ! nc -G 2 -z "$host" "$port"; then
+      echo "FAIL LAN control is not reachable: user=current endpoint=$endpoint" >&2
+      exit 1
+    fi
+    echo "PASS LAN control reachable: user=current endpoint=$endpoint"
+  fi
+}
+
+expect_no_connect() {
+  local user="$1"
+  local endpoint="$2"
+  local host port
+  split_host_port "$endpoint" host port
+  if run_as "$user" nc -G 2 -z "$host" "$port"; then
+    echo "FAIL LAN/RFC1918 connect allowed: user=$user endpoint=$endpoint" >&2
+    exit 1
+  fi
+  echo "PASS connect denied: user=$user endpoint=$endpoint"
+}
+
+require_command sudo
+require_command nc
+ensure_user_runnable "$tunnel_user"
+ensure_user_runnable "$edge_user"
+if [[ -n "$lan_control_user" ]]; then
+  ensure_user_runnable "$lan_control_user"
+fi
+
+for path in "${protected_paths[@]}"; do
+  expect_unreadable "$tunnel_user" "$path"
+  expect_unreadable "$edge_user" "$path"
+done
+
+for path in "${tunnel_readable_paths[@]}"; do
+  expect_readable "$tunnel_user" "$path"
+done
+
+for path in "${edge_readable_paths[@]}"; do
+  expect_readable "$edge_user" "$path"
+done
+
+for path in "${tunnel_private_paths[@]}"; do
+  expect_unreadable "$edge_user" "$path"
+done
+
+for path in "${edge_private_paths[@]}"; do
+  expect_unreadable "$tunnel_user" "$path"
+done
+
+for endpoint in "${origin_probes[@]}"; do
+  expect_connect "$tunnel_user" "$endpoint"
+  expect_connect "$edge_user" "$endpoint"
+done
+
+for endpoint in "${lan_probes[@]}"; do
+  expect_control_connect "$endpoint"
+  expect_no_connect "$tunnel_user" "$endpoint"
+  expect_no_connect "$edge_user" "$endpoint"
+done


### PR DESCRIPTION
## Summary
- run `cloudflared` as a quarantined LaunchDaemon user instead of a logged-in LaunchAgent
- document tunnel credential/log ownership, controller-data denial, and public edge/tunnel credential separation
- add a PF anchor template that blocks tunnel/edge users from RFC1918/LAN egress while allowing loopback origin ports
- add an operator validation script that proves tunnel/edge users cannot read protected paths or connect to LAN probes

## Spec Reference
- docs/working/100_security_threat_model.md

## Test Plan
- [x] bash -n scripts/security/validate-edge-quarantine.sh
- [x] scripts/security/validate-edge-quarantine.sh --help
- [x] plutil -lint scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
- [x] cargo test -p office-automate-server
- [x] git diff --check
- [ ] shellcheck scripts/security/validate-edge-quarantine.sh (not installed locally)

Fixes #103