### PR TITLE
Split public edge from LAN controller

### DIFF
--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -7,11 +7,12 @@ The templates live in `scripts/launchd/primary-host/`:
 | Template | Label | Purpose |
 | --- | --- | --- |
 | `com.office-automate.server.plist.template` | `com.office-automate.server` | Runs `office-automate-server serve --config <config>` as the core API, WebSocket, MQTT ingress, presence, and device-client process. |
+| `com.office-automate.edge.plist.template` | `com.office-automate.edge` | Runs `office-automate-server serve-edge --config <edge-config>` as the quarantined public HTTP edge and narrow controller client. |
 | `com.office-automate.telemetry.plist.template` | `com.office-automate.telemetry` | Runs `office-automate-server collect --config <config> telemetry` on an interval. |
 | `com.office-automate.project-leverage.plist.template` | `com.office-automate.project-leverage` | Runs `office-automate-server collect --config <config> leverage` on an interval. |
 | `com.office-automate.tunnel.plist.template` | `com.office-automate.tunnel` | Runs `cloudflared tunnel --no-autoupdate --config <config> run <tunnel>` as the quarantined public transport process. |
 
-LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only; application auth remains owned by `office-automate-server`.
+LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only. `cloudflared` should route to `office-automate-server serve-edge`; the edge then calls the controller over the local authenticated IPC token.
 
 ## Template Values
 
@@ -22,6 +23,9 @@ Render the templates with deployment-specific absolute paths before loading them
 | `__OFFICE_AUTOMATE_ROOT__` | Repository checkout or release directory. |
 | `__OFFICE_AUTOMATE_SERVER_BIN__` | Absolute path to the Rust `office-automate-server` binary. |
 | `__OFFICE_AUTOMATE_CONFIG__` | Absolute path to the deployment config file. |
+| `__OFFICE_AUTOMATE_EDGE_CONFIG__` | Absolute path to the edge-only config file. This file must not contain device, telemetry, repo, or climate database settings. |
+| `__OFFICE_AUTOMATE_EDGE_WORKING_DIRECTORY__` | Working directory for the edge process, usually a release directory readable by the edge user. |
+| `__OFFICE_AUTOMATE_EDGE_LOG_DIR__` | Directory for edge stdout/stderr logs. |
 | `__OFFICE_AUTOMATE_PATH__` | PATH available to launchd jobs, usually including Homebrew and system paths. |
 | `__OFFICE_AUTOMATE_RUST_LOG__` | Rust log filter, for example `info,office_automate_server=info`. |
 | `__OFFICE_AUTOMATE_LOG_DIR__` | Directory for stdout/stderr logs. Create it before loading jobs. |
@@ -33,7 +37,8 @@ Render the templates with deployment-specific absolute paths before loading them
 | `__CLOUDFLARED_WORKING_DIRECTORY__` | Directory where `cloudflared` should run. |
 | `__OFFICE_AUTOMATE_TUNNEL_USER__` | Dedicated low-privilege user that runs only `cloudflared`, for example `_office_tunnel`. |
 | `__OFFICE_AUTOMATE_TUNNEL_GROUP__` | Dedicated group for the tunnel user, for example `_office_tunnel`. |
-| `__OFFICE_AUTOMATE_EDGE_USER__` | Public HTTP edge user for the later edge/controller split. Until that split exists, render this to the same value as `__OFFICE_AUTOMATE_TUNNEL_USER__` in PF templates. |
+| `__OFFICE_AUTOMATE_EDGE_USER__` | Dedicated low-privilege user that runs only the public HTTP edge, for example `_office_edge`. |
+| `__OFFICE_AUTOMATE_EDGE_GROUP__` | Dedicated group for the edge user, for example `_office_edge`. |
 | `__OFFICE_AUTOMATE_ORIGIN_PORTS__` | Loopback origin ports the tunnel/edge users may reach, for example `8080`. |
 
 Keep hostnames, public routes, credentials, and tunnel credential files in the Cloudflare config and deployment secrets, not in these templates.
@@ -46,16 +51,20 @@ plutil -lint rendered/com.office-automate.*.plist
 
 ## Public Edge Quarantine
 
-`cloudflared` is public edge code. Do not run it as the logged-in user. Use a dedicated low-privilege tunnel account with no shell, no repo access, no controller config/data access, and only the tunnel config/credential/log paths it needs.
+`cloudflared` and `serve-edge` are public edge code. Do not run either as the logged-in user. Use dedicated low-privilege tunnel and edge accounts with no shell, no repo access, no controller config/data access, and only the config/credential/log/static paths they need.
 
 Recommended local ownership model:
 
 | Path | Owner | Mode | Purpose |
 | --- | --- | --- | --- |
 | `/Library/LaunchDaemons/com.office-automate.tunnel.plist` | `root:wheel` | `0644` | LaunchDaemon wrapper that switches to the tunnel user. |
+| `/Library/LaunchDaemons/com.office-automate.edge.plist` | `root:wheel` | `0644` | LaunchDaemon wrapper that switches to the edge user. |
 | `/var/lib/office-automate/tunnel/` | `_office_tunnel:_office_tunnel` | `0700` | Cloudflare tunnel config and credential directory. |
+| `/var/lib/office-automate/edge/` | `_office_edge:_office_edge` | `0700` | Edge-only config and controller IPC token. |
 | `/var/log/office-automate/tunnel/` | `_office_tunnel:_office_tunnel` | `0700` | Tunnel stdout/stderr logs. |
-| Controller config, data, repos, telemetry DBs | controller user/group only | `0600` files, `0700` directories | Must be unreadable and non-traversable by `_office_tunnel` and by the later public edge user. |
+| `/var/log/office-automate/edge/` | `_office_edge:_office_edge` | `0700` | Edge stdout/stderr logs. |
+| Frontend static assets | `_office_edge:_office_edge` or release owner with edge read-only access | `0550` dirs, `0440` files | The edge may read static assets only; it does not need repo, DB, telemetry, artifact-write, or device-secret access. |
+| Controller config, data, repos, telemetry DBs | controller user/group only | `0600` files, `0700` directories | Must be unreadable and non-traversable by `_office_tunnel` and `_office_edge`. |
 | Public edge config and credentials | public edge user/group only | `0600` files, `0700` directories | Must be unreadable and non-traversable by `_office_tunnel` unless the tunnel explicitly needs them. |
 
 Create the tunnel account through your normal macOS account-management path or MDM. The account must be non-login and dedicated to Office Automate tunnel transport. The examples below assume `_office_tunnel`.
@@ -63,11 +72,36 @@ Create the tunnel account through your normal macOS account-management path or M
 ```bash
 sudo install -d -o _office_tunnel -g _office_tunnel -m 0700 /var/lib/office-automate/tunnel
 sudo install -d -o _office_tunnel -g _office_tunnel -m 0700 /var/log/office-automate/tunnel
+sudo install -d -o _office_edge -g _office_edge -m 0700 /var/lib/office-automate/edge
+sudo install -d -o _office_edge -g _office_edge -m 0700 /var/log/office-automate/edge
 sudo install -o _office_tunnel -g _office_tunnel -m 0600 "$CLOUDFLARED_CONFIG" /var/lib/office-automate/tunnel/config.yml
 sudo install -o _office_tunnel -g _office_tunnel -m 0600 "$CLOUDFLARED_CREDENTIALS" /var/lib/office-automate/tunnel/credentials.json
+sudo install -o _office_edge -g _office_edge -m 0600 "$OFFICE_AUTOMATE_EDGE_CONFIG" /var/lib/office-automate/edge/config.yaml
 ```
 
-The Cloudflare config in `/var/lib/office-automate/tunnel/config.yml` should reference the credential copy in that same directory and route only to the loopback or Unix-socket origin validated by `office-automate-server validate`.
+The edge config must use the edge-only schema:
+
+```yaml
+orchestrator:
+  host: "127.0.0.1"
+  port: 8080
+  google_oauth:
+    client_id: "<google-client-id>"
+    client_secret: "<google-client-secret>"
+    allowed_emails:
+      - "you@example.com"
+    jwt_secret: "<stable-jwt-secret>"
+    trusted_networks: []
+controller:
+  base_url: "http://127.0.0.1:9001"
+  token: "<same value as controller orchestrator.controller_ipc_token>"
+runtime:
+  frontend_dist: "/opt/office-automate/frontend/dist"
+```
+
+The edge config parser rejects unrelated top-level sections such as `qingping`, `yolink`, `erv`, `mitsubishi`, `telemetry`, or `thresholds`. Keep the controller IPC token out of rendered plists; store it in the edge config and in the controller config or `OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN`.
+
+The Cloudflare config in `/var/lib/office-automate/tunnel/config.yml` should reference the credential copy in that same directory and route only to the loopback edge origin. The edge should then reach only the loopback controller IPC URL.
 
 Render and install the PF anchor template in `scripts/pf/office-automate-edge-anchor.conf.template` after replacing every placeholder:
 
@@ -94,18 +128,20 @@ The anchor must deny the tunnel/edge users outbound RFC1918/LAN traffic while st
 
 ## Install
 
-Use LaunchAgents only for jobs that need the logged-in macOS user session. The server currently owns presence polling, so it remains a LaunchAgent until the public edge/controller split is implemented. The tunnel does not need the user session and must run as a LaunchDaemon under the dedicated tunnel user.
+Use LaunchAgents only for jobs that need the logged-in macOS user session. The controller currently owns presence polling, so `com.office-automate.server` remains a LaunchAgent. The edge and tunnel do not need the user session and must run as LaunchDaemons under their dedicated users.
 
 ```bash
 mkdir -p "$HOME/Library/LaunchAgents" "$OFFICE_AUTOMATE_LOG_DIR"
 cp rendered/com.office-automate.server.plist "$HOME/Library/LaunchAgents/"
 cp rendered/com.office-automate.telemetry.plist "$HOME/Library/LaunchAgents/"
 cp rendered/com.office-automate.project-leverage.plist "$HOME/Library/LaunchAgents/"
+sudo install -o root -g wheel -m 0644 rendered/com.office-automate.edge.plist /Library/LaunchDaemons/com.office-automate.edge.plist
 sudo install -o root -g wheel -m 0644 rendered/com.office-automate.tunnel.plist /Library/LaunchDaemons/com.office-automate.tunnel.plist
 
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
 launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.office-automate.edge.plist
 sudo launchctl bootstrap system /Library/LaunchDaemons/com.office-automate.tunnel.plist
 ```
 
@@ -115,6 +151,7 @@ Validate loaded jobs:
 launchctl print "gui/$(id -u)/com.office-automate.server"
 launchctl print "gui/$(id -u)/com.office-automate.telemetry"
 launchctl print "gui/$(id -u)/com.office-automate.project-leverage"
+sudo launchctl print system/com.office-automate.edge
 sudo launchctl print system/com.office-automate.tunnel
 ```
 
@@ -124,6 +161,7 @@ sudo launchctl print system/com.office-automate.tunnel
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist"
 launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist"
+sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.edge.plist
 sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.tunnel.plist
 ```
 
@@ -133,10 +171,11 @@ sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.tunnel.
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.server"
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.telemetry"
 launchctl kickstart -k "gui/$(id -u)/com.office-automate.project-leverage"
+sudo launchctl kickstart -k system/com.office-automate.edge
 sudo launchctl kickstart -k system/com.office-automate.tunnel
 ```
 
-The server and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The tunnel template passes `--no-autoupdate` so launchd remains the only process supervisor. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
+The server, edge, and tunnel templates use `KeepAlive`; launchd restarts them after crashes or non-manual exits. The tunnel template passes `--no-autoupdate` so launchd remains the only process supervisor. The collector templates use `StartInterval` and `RunAtLoad`; they run once at load and then on their configured interval.
 
 ## Logs
 
@@ -147,6 +186,8 @@ tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.out.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-telemetry.err.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.out.log
 tail -F "$OFFICE_AUTOMATE_LOG_DIR"/office-automate-project-leverage.err.log
+sudo tail -F /var/log/office-automate/edge/office-automate-edge.out.log
+sudo tail -F /var/log/office-automate/edge/office-automate-edge.err.log
 sudo tail -F /var/log/office-automate/tunnel/office-automate-tunnel.out.log
 sudo tail -F /var/log/office-automate/tunnel/office-automate-tunnel.err.log
 ```
@@ -181,8 +222,8 @@ scripts/security/validate-edge-quarantine.sh \
   --tunnel-readable /var/lib/office-automate/tunnel/credentials.json \
   --tunnel-private /var/lib/office-automate/tunnel/config.yml \
   --tunnel-private /var/lib/office-automate/tunnel/credentials.json \
-  --edge-readable "$OFFICE_AUTOMATE_EDGE_CREDENTIALS" \
-  --edge-private "$OFFICE_AUTOMATE_EDGE_CREDENTIALS" \
+  --edge-readable /var/lib/office-automate/edge/config.yaml \
+  --edge-private /var/lib/office-automate/edge/config.yaml \
   --protected-path "$OFFICE_AUTOMATE_CONFIG" \
   --protected-path "$OFFICE_AUTOMATE_DATABASE" \
   --protected-path "$OFFICE_AUTOMATE_REPO_ROOT" \
@@ -196,4 +237,4 @@ The validation passes only if the tunnel/edge users can read the material they n
 
 ## Cloudflare Tunnel Notes
 
-The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward only to the local Rust origin, and the Rust server should continue enforcing OAuth/JWT. Public deployments must not use `trusted_networks`.
+The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward only to the local Rust edge origin, and the edge/controller pair should continue enforcing OAuth/JWT plus the local controller IPC token. Public deployments must not use `trusted_networks`.

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
     config::AppConfig,
-    db, erv, http, hvac, migration, presence, telemetry,
+    db, edge, erv, http, hvac, migration, presence, telemetry,
     validation::{
         self, CutoverValidationOptions, MqttCutoverStrategy, MqttRollbackState,
         RestoreVerification, RollbackValidationOptions, ShadowValidationOptions,
@@ -24,6 +24,8 @@ pub struct Cli {
 pub enum Command {
     /// Run the HTTP/API server.
     Serve(ConfigArgs),
+    /// Run the quarantined public HTTP edge.
+    ServeEdge(EdgeConfigArgs),
     /// Create or upgrade the SQLite schema.
     Migrate(ConfigArgs),
     /// Run local dependency checks without changing device state.
@@ -39,6 +41,12 @@ pub enum Command {
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct ConfigArgs {
     #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct EdgeConfigArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_EDGE_CONFIG")]
     pub config: PathBuf,
 }
 
@@ -290,6 +298,10 @@ pub async fn run(cli: Cli) -> Result<()> {
             let config = AppConfig::load(&args.config)?;
             http::serve(config).await
         }
+        Command::ServeEdge(args) => {
+            let config = edge::PublicEdgeConfig::load(&args.config)?;
+            edge::serve(config).await
+        }
         Command::Migrate(args) => {
             let config = AppConfig::load(&args.config)?;
             db::migrate(&config)?;
@@ -482,6 +494,24 @@ mod tests {
         match cli.command {
             Command::Serve(args) => assert_eq!(args.config, PathBuf::from("/tmp/office.yaml")),
             other => panic!("expected serve command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_serve_edge_command_with_config() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "serve-edge",
+            "--config",
+            "/tmp/office-edge.yaml",
+        ])
+        .expect("serve-edge command should parse");
+
+        match cli.command {
+            Command::ServeEdge(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office-edge.yaml"));
+            }
+            other => panic!("expected serve-edge command, got {other:?}"),
         }
     }
 

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -59,6 +59,7 @@ pub struct OrchestratorConfig {
     pub auth_username: Option<String>,
     pub auth_password: Option<String>,
     pub google_oauth: Option<GoogleOAuthConfig>,
+    pub controller_ipc_token: Option<String>,
 }
 
 impl Default for OrchestratorConfig {
@@ -69,6 +70,7 @@ impl Default for OrchestratorConfig {
             auth_username: None,
             auth_password: None,
             google_oauth: None,
+            controller_ipc_token: None,
         }
     }
 }
@@ -474,6 +476,10 @@ impl AppConfig {
             })?;
         }
 
+        if let Some(token) = env_lookup("OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN") {
+            file_config.orchestrator.controller_ipc_token = Some(token);
+        }
+
         if let Some(repos) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_REPOS") {
             file_config.telemetry.repos = repos
                 .split(',')
@@ -743,6 +749,7 @@ thresholds:
             }
             "OFFICE_AUTOMATE_TELEMETRY_DAYS" => Some("14".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
+            "OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN" => Some("edge-ipc-token".to_string()),
             _ => None,
         })
         .expect("load config");
@@ -835,6 +842,10 @@ thresholds:
         assert_eq!(
             config.runtime.public_url.as_deref(),
             Some("https://office.example.com")
+        );
+        assert_eq!(
+            config.orchestrator.controller_ipc_token.as_deref(),
+            Some("edge-ipc-token")
         );
         assert_eq!(config.thresholds.hvac_heat_on_temp_f, 70);
         assert_eq!(config.thresholds.hvac_cool_setpoint_f, 77);

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -21,7 +21,7 @@ use axum::{
     routing::{get, get_service, post},
 };
 use futures_util::{SinkExt, StreamExt};
-use reqwest::{Client, Url};
+use reqwest::{Client, Url, redirect::Policy};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::{net::TcpListener, time::timeout};
@@ -528,6 +528,7 @@ impl ControllerClient {
         let timeout = Duration::from_secs(config.timeout_seconds.max(1));
         let client = Client::builder()
             .timeout(timeout)
+            .redirect(Policy::none())
             .build()
             .context("failed to build controller IPC client")?;
         Ok(Self {
@@ -1166,5 +1167,62 @@ qingping:
             .expect("body");
         let payload: Value = serde_json::from_slice(&body).expect("json");
         assert_eq!(payload["source"], "controller");
+    }
+
+    #[tokio::test]
+    async fn latest_apk_redirect_is_preserved_by_public_edge() {
+        let controller = Router::new()
+            .route(
+                "/apps/demo/latest.apk",
+                get(|| async move {
+                    (
+                        StatusCode::FOUND,
+                        [
+                            (header::LOCATION, "/apps/demo/abc123.apk"),
+                            (header::CACHE_CONTROL, "no-cache"),
+                        ],
+                    )
+                        .into_response()
+                }),
+            )
+            .route(
+                "/apps/demo/abc123.apk",
+                get(|| async move { (StatusCode::OK, "hashed-apk").into_response() }),
+            );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind controller");
+        let address = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, controller).await.expect("controller");
+        });
+
+        let config = edge_config(format!("http://{address}"));
+        let app = app(config).expect("edge app");
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/demo/latest.apk")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("/apps/demo/abc123.apk")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache")
+        );
     }
 }

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -21,7 +21,7 @@ use axum::{
     routing::{get, get_service, post},
 };
 use futures_util::{SinkExt, StreamExt};
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::{net::TcpListener, time::timeout};
@@ -223,6 +223,7 @@ fn validate_public_edge_config(config: &PublicEdgeConfig) -> Result<()> {
     if config.controller.base_url.trim().is_empty() {
         anyhow::bail!("public edge requires controller.base_url");
     }
+    validate_loopback_controller_base_url(&config.controller.base_url)?;
     if config.controller.token.trim().is_empty() {
         anyhow::bail!("public edge requires controller.token");
     }
@@ -523,6 +524,7 @@ fn tungstenite_to_axum(message: TungsteniteMessage) -> Option<Message> {
 
 impl ControllerClient {
     fn new(config: &ControllerIpcConfig) -> Result<Self> {
+        validate_loopback_controller_base_url(&config.base_url)?;
         let timeout = Duration::from_secs(config.timeout_seconds.max(1));
         let client = Client::builder()
             .timeout(timeout)
@@ -686,6 +688,23 @@ fn websocket_url(base_url: &str) -> Result<String> {
     } else {
         anyhow::bail!("controller.base_url must start with http:// or https://")
     }
+}
+
+fn validate_loopback_controller_base_url(base_url: &str) -> Result<()> {
+    let url = Url::parse(base_url.trim())
+        .with_context(|| format!("invalid controller.base_url {base_url:?}"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!("controller.base_url must start with http:// or https://");
+    }
+    let Some(host) = url.host_str() else {
+        anyhow::bail!("controller.base_url must include a hostname");
+    };
+    if !is_loopback_bind_host(host) {
+        anyhow::bail!(
+            "public edge controller.base_url must stay on loopback; got host={host:?}"
+        );
+    }
+    Ok(())
 }
 
 fn should_skip_auth(method: &Method, path: &str, auth_mode: HttpAuthMode) -> bool {
@@ -1044,6 +1063,15 @@ qingping:
         let error =
             validate_public_edge_config(&config).expect_err("empty controller token should fail");
         assert!(error.to_string().contains("requires controller.token"));
+
+        let config = edge_config("http://192.168.1.10:9001".to_string());
+        let error = validate_public_edge_config(&config)
+            .expect_err("non-loopback controller base url should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("public edge controller.base_url must stay on loopback")
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -1,0 +1,1142 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    env, fs,
+    net::{IpAddr, SocketAddr},
+    path::{Component, Path as FsPath, PathBuf},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    body::{Body, Bytes},
+    extract::{
+        ConnectInfo, OriginalUri, Path, Query, Request, State, WebSocketUpgrade,
+        ws::{CloseFrame, Message, WebSocket},
+    },
+    http::{HeaderMap, HeaderValue, Method, StatusCode, Uri, header},
+    middleware::{self, Next},
+    response::{Html, IntoResponse, Response},
+    routing::{get, get_service, post},
+};
+use futures_util::{SinkExt, StreamExt};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, time::timeout};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Message as TungsteniteMessage, client::IntoClientRequest},
+};
+use tower_http::{
+    cors::{Any, CorsLayer},
+    services::ServeDir,
+    trace::TraceLayer,
+};
+
+use crate::{
+    auth::{AuthManager, HttpAuthMode, WebSocketAuth, bearer_token},
+    config::OrchestratorConfig,
+    http::CONTROLLER_IPC_TOKEN_HEADER,
+};
+
+const CONTROL_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+const CONTROL_RATE_LIMIT_MAX_REQUESTS: usize = 60;
+const MAX_EDGE_POST_BODY_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicEdgeConfig {
+    pub orchestrator: OrchestratorConfig,
+    pub controller: ControllerIpcConfig,
+    pub runtime: PublicEdgeRuntimeConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerIpcConfig {
+    pub base_url: String,
+    pub token: String,
+    pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicEdgeRuntimeConfig {
+    pub frontend_dist: PathBuf,
+    pub public_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublicEdgeFileConfig {
+    #[serde(default)]
+    orchestrator: OrchestratorConfig,
+    controller: ControllerIpcFileConfig,
+    #[serde(default)]
+    runtime: PublicEdgeRuntimeFileConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+struct ControllerIpcFileConfig {
+    base_url: String,
+    token: String,
+    timeout_seconds: u64,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+struct PublicEdgeRuntimeFileConfig {
+    frontend_dist: Option<PathBuf>,
+    public_url: Option<String>,
+}
+
+#[derive(Clone)]
+struct EdgeState {
+    auth: AuthManager,
+    controller: ControllerClient,
+    frontend_dist: PathBuf,
+    rate_limiter: Arc<Mutex<HashMap<String, VecDeque<Instant>>>>,
+}
+
+#[derive(Clone)]
+struct ControllerClient {
+    base_url: String,
+    websocket_url: String,
+    token: String,
+    client: Client,
+}
+
+impl PublicEdgeConfig {
+    pub fn load(path: impl AsRef<FsPath>) -> Result<Self> {
+        Self::load_with_env(path, |key| env::var(key).ok())
+    }
+
+    pub fn load_with_env(
+        path: impl AsRef<FsPath>,
+        env_lookup: impl Fn(&str) -> Option<String>,
+    ) -> Result<Self> {
+        let config_path = path.as_ref();
+        let contents = fs::read_to_string(config_path)
+            .with_context(|| format!("failed to read edge config {}", config_path.display()))?;
+        let mut file_config: PublicEdgeFileConfig = serde_yaml::from_str(&contents)
+            .with_context(|| format!("failed to parse edge config {}", config_path.display()))?;
+
+        if let Some(host) = env_lookup("OFFICE_AUTOMATE_EDGE_HOST") {
+            file_config.orchestrator.host = host;
+        }
+        if let Some(port) = env_lookup("OFFICE_AUTOMATE_EDGE_PORT") {
+            file_config.orchestrator.port = port
+                .parse()
+                .with_context(|| format!("invalid OFFICE_AUTOMATE_EDGE_PORT value {port:?}"))?;
+        }
+        if let Some(url) = env_lookup("OFFICE_AUTOMATE_EDGE_CONTROLLER_URL") {
+            file_config.controller.base_url = url;
+        }
+        if let Some(token) = env_lookup("OFFICE_AUTOMATE_EDGE_CONTROLLER_TOKEN") {
+            file_config.controller.token = token;
+        }
+        if let Some(seconds) = env_lookup("OFFICE_AUTOMATE_EDGE_CONTROLLER_TIMEOUT_SECONDS") {
+            file_config.controller.timeout_seconds = seconds.parse().with_context(|| {
+                format!("invalid OFFICE_AUTOMATE_EDGE_CONTROLLER_TIMEOUT_SECONDS value {seconds:?}")
+            })?;
+        }
+
+        let frontend_dist = env_lookup("OFFICE_AUTOMATE_EDGE_FRONTEND_DIST")
+            .map(PathBuf::from)
+            .or(file_config.runtime.frontend_dist)
+            .or_else(|| {
+                env_lookup("OFFICE_AUTOMATE_ROOT")
+                    .map(PathBuf::from)
+                    .map(|root| root.join("frontend").join("dist"))
+            })
+            .context(
+                "edge config requires runtime.frontend_dist, OFFICE_AUTOMATE_EDGE_FRONTEND_DIST, or OFFICE_AUTOMATE_ROOT",
+            )?;
+        let public_url =
+            env_lookup("OFFICE_AUTOMATE_PUBLIC_URL").or(file_config.runtime.public_url);
+
+        let config = Self {
+            orchestrator: file_config.orchestrator,
+            controller: ControllerIpcConfig {
+                base_url: file_config.controller.base_url,
+                token: file_config.controller.token,
+                timeout_seconds: if file_config.controller.timeout_seconds == 0 {
+                    5
+                } else {
+                    file_config.controller.timeout_seconds
+                },
+            },
+            runtime: PublicEdgeRuntimeConfig {
+                frontend_dist,
+                public_url,
+            },
+        };
+        validate_public_edge_config(&config)?;
+        Ok(config)
+    }
+}
+
+pub fn app(config: PublicEdgeConfig) -> Result<Router> {
+    let state = EdgeState {
+        auth: AuthManager::new(&config.orchestrator)?,
+        controller: ControllerClient::new(&config.controller)?,
+        frontend_dist: config.runtime.frontend_dist.clone(),
+        rate_limiter: Arc::new(Mutex::new(HashMap::new())),
+    };
+    Ok(router_from_state(state))
+}
+
+pub async fn serve(config: PublicEdgeConfig) -> Result<()> {
+    let bind_address = format!("{}:{}", config.orchestrator.host, config.orchestrator.port);
+    let listener = TcpListener::bind(&bind_address)
+        .await
+        .with_context(|| format!("failed to bind public edge listener at {bind_address}"))?;
+    let app = app(config)?;
+
+    tracing::info!("office-automate public edge listening on {}", bind_address);
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await
+    .context("public edge HTTP server failed")
+}
+
+fn validate_public_edge_config(config: &PublicEdgeConfig) -> Result<()> {
+    let host = config.orchestrator.host.trim();
+    if !is_loopback_bind_host(host) {
+        anyhow::bail!("public edge must bind HTTP to loopback; got orchestrator.host={host:?}");
+    }
+    if config.orchestrator.google_oauth.is_none() {
+        anyhow::bail!(
+            "public edge requires Google OAuth/JWT; Open and Basic modes are not allowed"
+        );
+    }
+    if config
+        .orchestrator
+        .google_oauth
+        .as_ref()
+        .is_some_and(|oauth| !oauth.trusted_networks.is_empty())
+    {
+        anyhow::bail!("public edge must not configure google_oauth.trusted_networks");
+    }
+    if config.controller.base_url.trim().is_empty() {
+        anyhow::bail!("public edge requires controller.base_url");
+    }
+    if config.controller.token.trim().is_empty() {
+        anyhow::bail!("public edge requires controller.token");
+    }
+    Ok(())
+}
+
+fn router_from_state(state: EdgeState) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+    let assets_dir = state.frontend_dist.join("assets");
+
+    Router::new()
+        .route("/status", get(forward_get))
+        .route("/ws", get(edge_websocket))
+        .route("/occupancy", post(forward_post))
+        .route("/presence", post(forward_post))
+        .route("/erv", post(forward_post))
+        .route("/hvac", post(forward_post))
+        .route(
+            "/hvac/temperature-bands",
+            get(forward_get).post(forward_post),
+        )
+        .route("/qingping/interval", post(forward_post))
+        .route("/history", get(forward_get))
+        .route("/history/sessions", get(forward_get))
+        .route("/history/co2-ohlc", get(forward_get))
+        .route("/history/temperature", get(forward_get))
+        .route("/history/daily-stats", get(forward_get))
+        .route("/history/openings", get(forward_get))
+        .route("/history/orchestration", get(forward_get))
+        .route("/history/project-focus", get(forward_get))
+        .route("/history/leverage", get(forward_get))
+        .route("/history/project-leverage", get(forward_get))
+        .route("/apps/{app}/latest.apk", get(forward_get))
+        .route("/apps/{app}/{artifact_file}", get(forward_get))
+        .route("/apps/{app}/meta.json", get(forward_get))
+        .route("/apk", get(forward_get))
+        .route("/auth/login", get(auth_login))
+        .route("/auth/callback", get(auth_callback))
+        .route("/auth/logout", post(auth_logout))
+        .route("/auth/device/start", post(auth_device_start))
+        .route("/auth/device/poll", post(auth_device_poll))
+        .route("/localtunnel/password", get(localtunnel_gone))
+        .nest_service("/assets", get_service(ServeDir::new(assets_dir)))
+        .route("/", get(index))
+        .route("/{*path}", get(spa_fallback))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            edge_auth_middleware,
+        ))
+        .with_state(state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http())
+}
+
+async fn edge_auth_middleware(
+    State(state): State<EdgeState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let auth_mode = state.auth.mode();
+    if should_skip_auth(request.method(), request.uri().path(), auth_mode) {
+        return next.run(request).await;
+    }
+
+    let remote_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(remote_addr)| *remote_addr);
+    let headers = auth_headers_with_peer(request.headers(), remote_addr);
+
+    if request.uri().path() == "/ws" && is_websocket_upgrade(&headers) {
+        return next.run(request).await;
+    }
+
+    let Some(user) = state.auth.verify_bearer_header(&headers) else {
+        let missing = bearer_token(&headers).is_none();
+        let message = if missing {
+            "Authentication required"
+        } else {
+            "Invalid or expired token"
+        };
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": message, "login_url": "/auth/login"})),
+        )
+            .into_response();
+    };
+
+    if is_control_route(request.method(), request.uri().path()) {
+        let actor = rate_limit_actor(remote_addr, &user.email, request.uri().path());
+        if !allow_control_request(&state, actor) {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(json!({"ok": false, "error": "Rate limit exceeded"})),
+            )
+                .into_response();
+        }
+    }
+
+    request.extensions_mut().insert(user);
+    next.run(request).await
+}
+
+async fn forward_get(State(state): State<EdgeState>, OriginalUri(uri): OriginalUri) -> Response {
+    state.controller.forward(Method::GET, &uri, None).await
+}
+
+async fn forward_post(
+    State(state): State<EdgeState>,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if body.len() > MAX_EDGE_POST_BODY_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(json!({"ok": false, "error": "Request body too large"})),
+        )
+            .into_response();
+    }
+    let content_type = headers.get(header::CONTENT_TYPE).cloned();
+    state
+        .controller
+        .forward(Method::POST, &uri, Some((body, content_type)))
+        .await
+}
+
+async fn edge_websocket(
+    State(state): State<EdgeState>,
+    ConnectInfo(remote_addr): ConnectInfo<std::net::SocketAddr>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let auth_headers = auth_headers_with_peer(&headers, Some(remote_addr));
+    let mode = state.auth.websocket_auth(&auth_headers);
+    ws.on_upgrade(move |socket| edge_websocket_session(socket, state, mode))
+}
+
+async fn edge_websocket_session(mut socket: WebSocket, state: EdgeState, auth_mode: WebSocketAuth) {
+    if !authenticate_edge_websocket(&mut socket, &state.auth, auth_mode).await {
+        return;
+    }
+
+    let mut request = match state
+        .controller
+        .websocket_url
+        .as_str()
+        .into_client_request()
+    {
+        Ok(request) => request,
+        Err(error) => {
+            tracing::warn!("failed to build controller websocket request: {error}");
+            close_ws(&mut socket, "Controller unavailable").await;
+            return;
+        }
+    };
+    let token = match HeaderValue::from_str(&state.controller.token) {
+        Ok(token) => token,
+        Err(_) => {
+            tracing::error!("controller IPC token is not a valid header value");
+            close_ws(&mut socket, "Controller unavailable").await;
+            return;
+        }
+    };
+    request
+        .headers_mut()
+        .insert(CONTROLLER_IPC_TOKEN_HEADER, token);
+
+    let controller = timeout(Duration::from_secs(5), connect_async(request)).await;
+    let Ok(Ok((mut controller_ws, _))) = controller else {
+        close_ws(&mut socket, "Controller unavailable").await;
+        return;
+    };
+
+    loop {
+        tokio::select! {
+            message = socket.recv() => {
+                match message {
+                    Some(Ok(message)) => {
+                        if let Some(message) = axum_to_tungstenite(message) {
+                            if controller_ws.send(message).await.is_err() {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    Some(Err(error)) => {
+                        tracing::debug!("edge websocket receive error: {error}");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            message = controller_ws.next() => {
+                match message {
+                    Some(Ok(message)) => {
+                        if let Some(message) = tungstenite_to_axum(message) {
+                            if socket.send(message).await.is_err() {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    Some(Err(error)) => {
+                        tracing::debug!("controller websocket receive error: {error}");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+}
+
+async fn authenticate_edge_websocket(
+    socket: &mut WebSocket,
+    auth: &AuthManager,
+    auth_mode: WebSocketAuth,
+) -> bool {
+    match auth_mode {
+        WebSocketAuth::UpgradeBearer | WebSocketAuth::Open => true,
+        WebSocketAuth::FirstMessage => {
+            match timeout(Duration::from_secs(10), socket.recv()).await {
+                Ok(Some(Ok(Message::Text(message)))) => {
+                    let Ok(value) = serde_json::from_str::<Value>(&message) else {
+                        close_ws(socket, "Authentication required").await;
+                        return false;
+                    };
+                    if value.get("type").and_then(Value::as_str) != Some("auth") {
+                        close_ws(socket, "Authentication required").await;
+                        return false;
+                    }
+                    let Some(token) = value.get("token").and_then(Value::as_str) else {
+                        close_ws(socket, "Authentication required").await;
+                        return false;
+                    };
+                    if auth.verify_jwt(token).is_none() {
+                        close_ws(socket, "Invalid token").await;
+                        return false;
+                    }
+                    true
+                }
+                _ => {
+                    close_ws(socket, "Authentication failed").await;
+                    false
+                }
+            }
+        }
+        WebSocketAuth::Reject | WebSocketAuth::TrustedNetwork | WebSocketAuth::UpgradeBasic => {
+            close_ws(socket, "Authentication required").await;
+            false
+        }
+    }
+}
+
+async fn close_ws(socket: &mut WebSocket, reason: &str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: 4001,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
+fn axum_to_tungstenite(message: Message) -> Option<TungsteniteMessage> {
+    match message {
+        Message::Text(text) => Some(TungsteniteMessage::Text(text.to_string().into())),
+        Message::Binary(bytes) => Some(TungsteniteMessage::Binary(bytes)),
+        Message::Ping(bytes) => Some(TungsteniteMessage::Ping(bytes)),
+        Message::Pong(bytes) => Some(TungsteniteMessage::Pong(bytes)),
+        Message::Close(frame) => Some(TungsteniteMessage::Close(frame.map(|frame| {
+            tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason.to_string().into(),
+            }
+        }))),
+    }
+}
+
+fn tungstenite_to_axum(message: TungsteniteMessage) -> Option<Message> {
+    match message {
+        TungsteniteMessage::Text(text) => Some(Message::Text(text.to_string().into())),
+        TungsteniteMessage::Binary(bytes) => Some(Message::Binary(bytes)),
+        TungsteniteMessage::Ping(bytes) => Some(Message::Ping(bytes)),
+        TungsteniteMessage::Pong(bytes) => Some(Message::Pong(bytes)),
+        TungsteniteMessage::Close(frame) => Some(Message::Close(frame.map(|frame| CloseFrame {
+            code: frame.code.into(),
+            reason: frame.reason.to_string().into(),
+        }))),
+        TungsteniteMessage::Frame(_) => None,
+    }
+}
+
+impl ControllerClient {
+    fn new(config: &ControllerIpcConfig) -> Result<Self> {
+        let timeout = Duration::from_secs(config.timeout_seconds.max(1));
+        let client = Client::builder()
+            .timeout(timeout)
+            .build()
+            .context("failed to build controller IPC client")?;
+        Ok(Self {
+            base_url: config.base_url.trim_end_matches('/').to_string(),
+            websocket_url: websocket_url(&config.base_url)?,
+            token: config.token.clone(),
+            client,
+        })
+    }
+
+    async fn forward(
+        &self,
+        method: Method,
+        uri: &Uri,
+        body: Option<(Bytes, Option<HeaderValue>)>,
+    ) -> Response {
+        if !is_allowed_controller_route(&method, uri.path()) {
+            return StatusCode::NOT_FOUND.into_response();
+        }
+
+        let Some(url) = self.controller_url(uri) else {
+            return StatusCode::BAD_REQUEST.into_response();
+        };
+        let mut request = match method {
+            Method::GET => self.client.get(url),
+            Method::POST => self.client.post(url),
+            _ => return StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        }
+        .header(CONTROLLER_IPC_TOKEN_HEADER, self.token.as_str());
+
+        if let Some((body, content_type)) = body {
+            if let Some(content_type) = content_type {
+                request = request.header(header::CONTENT_TYPE.as_str(), content_type.as_bytes());
+            }
+            request = request.body(body.to_vec());
+        }
+
+        match request.send().await {
+            Ok(response) => controller_response_to_axum(response).await,
+            Err(error) => {
+                tracing::warn!("controller IPC request failed: {error:#}");
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({"ok": false, "error": "Controller unavailable"})),
+                )
+                    .into_response()
+            }
+        }
+    }
+
+    fn controller_url(&self, uri: &Uri) -> Option<String> {
+        let path_and_query = uri.path_and_query()?.as_str();
+        Some(format!("{}{}", self.base_url, path_and_query))
+    }
+}
+
+async fn controller_response_to_axum(response: reqwest::Response) -> Response {
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let headers = response.headers().clone();
+    let bytes = match response.bytes().await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!("failed to read controller IPC response body: {error:#}");
+            return StatusCode::BAD_GATEWAY.into_response();
+        }
+    };
+    let mut builder = Response::builder().status(status);
+    for (name, value) in headers.iter() {
+        if is_forwarded_response_header(name.as_str()) {
+            builder = builder.header(name.as_str(), value.as_bytes());
+        }
+    }
+    builder
+        .body(Body::from(bytes))
+        .unwrap_or_else(|_| StatusCode::BAD_GATEWAY.into_response())
+}
+
+fn is_forwarded_response_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "content-type"
+            | "cache-control"
+            | "content-disposition"
+            | "location"
+            | "etag"
+            | "last-modified"
+    )
+}
+
+fn is_allowed_controller_route(method: &Method, path: &str) -> bool {
+    match (method, path) {
+        (&Method::GET, "/status")
+        | (&Method::GET, "/history")
+        | (&Method::GET, "/history/sessions")
+        | (&Method::GET, "/history/co2-ohlc")
+        | (&Method::GET, "/history/temperature")
+        | (&Method::GET, "/history/daily-stats")
+        | (&Method::GET, "/history/openings")
+        | (&Method::GET, "/history/orchestration")
+        | (&Method::GET, "/history/project-focus")
+        | (&Method::GET, "/history/leverage")
+        | (&Method::GET, "/history/project-leverage")
+        | (&Method::GET, "/hvac/temperature-bands")
+        | (&Method::GET, "/apk") => true,
+        (&Method::GET, path) if path.starts_with("/apps/") => true,
+        (&Method::POST, "/occupancy")
+        | (&Method::POST, "/presence")
+        | (&Method::POST, "/erv")
+        | (&Method::POST, "/hvac")
+        | (&Method::POST, "/hvac/temperature-bands")
+        | (&Method::POST, "/qingping/interval") => true,
+        _ => false,
+    }
+}
+
+fn is_control_route(method: &Method, path: &str) -> bool {
+    *method == Method::POST
+        && matches!(
+            path,
+            "/occupancy"
+                | "/presence"
+                | "/erv"
+                | "/hvac"
+                | "/hvac/temperature-bands"
+                | "/qingping/interval"
+        )
+}
+
+fn rate_limit_actor(remote_addr: Option<SocketAddr>, email: &str, path: &str) -> String {
+    let remote = remote_addr
+        .map(|address| address.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("{remote}:{email}:{path}")
+}
+
+fn allow_control_request(state: &EdgeState, actor: String) -> bool {
+    let now = Instant::now();
+    let cutoff = now - CONTROL_RATE_LIMIT_WINDOW;
+    let mut limiter = state.rate_limiter.lock().expect("rate limiter lock");
+    let entries = limiter.entry(actor).or_default();
+    while entries.front().is_some_and(|instant| *instant < cutoff) {
+        entries.pop_front();
+    }
+    if entries.len() >= CONTROL_RATE_LIMIT_MAX_REQUESTS {
+        return false;
+    }
+    entries.push_back(now);
+    true
+}
+
+fn websocket_url(base_url: &str) -> Result<String> {
+    let trimmed = base_url.trim_end_matches('/');
+    if let Some(rest) = trimmed.strip_prefix("http://") {
+        Ok(format!("ws://{rest}/ws"))
+    } else if let Some(rest) = trimmed.strip_prefix("https://") {
+        Ok(format!("wss://{rest}/ws"))
+    } else {
+        anyhow::bail!("controller.base_url must start with http:// or https://")
+    }
+}
+
+fn should_skip_auth(method: &Method, path: &str, auth_mode: HttpAuthMode) -> bool {
+    if *method == Method::OPTIONS {
+        return true;
+    }
+
+    if path == "/apk" || path.starts_with("/apps/") {
+        return true;
+    }
+
+    matches!(auth_mode, HttpAuthMode::OAuth)
+        && (path == "/auth/login"
+            || path == "/auth/callback"
+            || path == "/auth/device/start"
+            || path == "/auth/device/poll"
+            || path == "/"
+            || path == "/index.html"
+            || path.starts_with("/assets/")
+            || path.ends_with(".png")
+            || path.ends_with(".json"))
+}
+
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"))
+}
+
+fn auth_headers_with_peer(headers: &HeaderMap, remote_addr: Option<SocketAddr>) -> HeaderMap {
+    let mut headers = headers.clone();
+    let forwarded_for = forwarded_for_ip(&headers);
+    headers.remove("x-forwarded-for");
+
+    let client_ip = match remote_addr {
+        Some(remote_addr) if remote_addr.ip().is_loopback() => forwarded_for,
+        Some(remote_addr) => Some(remote_addr.ip()),
+        None => None,
+    };
+
+    if let Some(client_ip) = client_ip {
+        if let Ok(value) = client_ip.to_string().parse() {
+            headers.insert("x-forwarded-for", value);
+        }
+    }
+    headers
+}
+
+fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("x-forwarded-for")?
+        .to_str()
+        .ok()?
+        .split(',')
+        .next()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+async fn auth_login(
+    State(state): State<EdgeState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Missing Host header"})),
+        )
+            .into_response();
+    };
+    let platform = query
+        .get("platform")
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty());
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok());
+
+    match state.auth.begin_login(host, forwarded_proto, platform) {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("failed to start OAuth login: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "Failed to start OAuth"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn auth_callback(
+    State(state): State<EdgeState>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if let Some(error) = query.get("error") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html(format!(
+                "<html><body><h1>Login Failed</h1><p>{}</p></body></html>",
+                escape_html_text(error)
+            )),
+        )
+            .into_response();
+    }
+
+    let (Some(code), Some(oauth_state)) = (query.get("code"), query.get("state")) else {
+        return (StatusCode::BAD_REQUEST, "Missing code or state").into_response();
+    };
+
+    match state.auth.finish_callback(code, oauth_state).await {
+        Ok(Some(login)) if login.platform.as_deref() == Some("android") => Response::builder()
+            .status(StatusCode::FOUND)
+            .header(
+                header::LOCATION,
+                format!(
+                    "officeclimate://auth?token={}&email={}",
+                    urlencoding::encode(&login.jwt),
+                    urlencoding::encode(&login.email)
+                ),
+            )
+            .body(Body::empty())
+            .expect("valid android redirect response"),
+        Ok(Some(login)) => {
+            let token = script_json_string(&login.jwt);
+            let email = script_json_string(&login.email);
+            Html(format!(
+                "<html><head><script>localStorage.setItem('auth_token', {token});localStorage.setItem('user_email', {email});window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
+            ))
+            .into_response()
+        }
+        Ok(None) => (
+            StatusCode::FORBIDDEN,
+            Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
+        )
+            .into_response(),
+        Err(error) if error.to_string() == "Invalid state" => {
+            (StatusCode::BAD_REQUEST, "Invalid state").into_response()
+        }
+        Err(error) => {
+            tracing::error!("OAuth callback failed: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "OAuth callback failed").into_response()
+        }
+    }
+}
+
+async fn auth_logout(State(state): State<EdgeState>, headers: HeaderMap) -> Response {
+    let Some(token) = bearer_token(&headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "No token provided"})),
+        )
+            .into_response();
+    };
+
+    state.auth.invalidate_token(token);
+    Json(json!({"ok": true, "message": "Logged out"})).into_response()
+}
+
+async fn auth_device_start(State(state): State<EdgeState>) -> Response {
+    match state.auth.start_device_flow().await {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("device flow start failed: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": error.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicePollRequest {
+    device_code: Option<String>,
+}
+
+async fn auth_device_poll(
+    State(state): State<EdgeState>,
+    Json(payload): Json<DevicePollRequest>,
+) -> Response {
+    let Some(device_code) = payload.device_code.filter(|code| !code.is_empty()) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Missing device_code"})),
+        )
+            .into_response();
+    };
+
+    match state.auth.poll_device_flow(&device_code).await {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => {
+            tracing::error!("device flow poll failed: {error:#}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "error", "message": error.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn localtunnel_gone() -> impl IntoResponse {
+    (
+        StatusCode::GONE,
+        Json(json!({
+            "ok": false,
+            "error": "LocalTunnel is not supported; use Cloudflare Tunnel",
+        })),
+    )
+}
+
+async fn index(State(state): State<EdgeState>) -> Response {
+    serve_static_or_index(&state, "index.html").await
+}
+
+async fn spa_fallback(State(state): State<EdgeState>, Path(path): Path<String>) -> Response {
+    serve_static_or_index(&state, &path).await
+}
+
+async fn serve_static_or_index(state: &EdgeState, path: &str) -> Response {
+    let requested = state.frontend_dist.join(path);
+    let target = if is_safe_spa_path(path) && requested.exists() && requested.is_file() {
+        requested
+    } else {
+        state.frontend_dist.join("index.html")
+    };
+
+    match tokio::fs::read(&target).await {
+        Ok(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(bytes))
+            .expect("static response"),
+        Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn is_safe_spa_path(path: &str) -> bool {
+    std::path::Path::new(path)
+        .components()
+        .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+fn escape_html_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| match character {
+            '&' => "&amp;".to_string(),
+            '<' => "&lt;".to_string(),
+            '>' => "&gt;".to_string(),
+            '"' => "&quot;".to_string(),
+            '\'' => "&#39;".to_string(),
+            _ => character.to_string(),
+        })
+        .collect()
+}
+
+fn script_json_string(value: &str) -> String {
+    serde_json::to_string(value)
+        .expect("string serializes")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026")
+}
+
+fn is_loopback_bind_host(host: &str) -> bool {
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::to_bytes, http::Request as HttpRequest};
+    use tower::ServiceExt;
+
+    fn edge_config(controller_base_url: String) -> PublicEdgeConfig {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.keep();
+        PublicEdgeConfig {
+            orchestrator: OrchestratorConfig {
+                google_oauth: Some(crate::config::GoogleOAuthConfig {
+                    client_id: "client".to_string(),
+                    client_secret: "secret".to_string(),
+                    allowed_emails: vec!["engineer@example.test".to_string()],
+                    jwt_secret: Some("test-secret".to_string()),
+                    trusted_networks: vec![],
+                    ..crate::config::GoogleOAuthConfig::default()
+                }),
+                ..OrchestratorConfig::default()
+            },
+            controller: ControllerIpcConfig {
+                base_url: controller_base_url,
+                token: "controller-token".to_string(),
+                timeout_seconds: 5,
+            },
+            runtime: PublicEdgeRuntimeConfig {
+                frontend_dist: root.join("frontend/dist"),
+                public_url: Some("https://office.example.test".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn edge_config_rejects_device_sections() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_path = temp_dir.path().join("edge.yaml");
+        fs::write(
+            &config_path,
+            r#"
+orchestrator:
+  host: "127.0.0.1"
+controller:
+  base_url: "http://127.0.0.1:9001"
+  token: "controller-token"
+runtime:
+  frontend_dist: "/tmp/frontend"
+qingping:
+  mqtt_broker: "192.168.1.10"
+"#,
+        )
+        .expect("write config");
+
+        let error = PublicEdgeConfig::load_with_env(&config_path, |_| None)
+            .expect_err("edge config must reject device sections");
+
+        assert!(error.to_string().contains("failed to parse edge config"));
+    }
+
+    #[test]
+    fn edge_config_requires_loopback_oauth_and_controller_token() {
+        let mut config = edge_config("http://127.0.0.1:9001".to_string());
+        config.orchestrator.host = "0.0.0.0".to_string();
+        let error =
+            validate_public_edge_config(&config).expect_err("non-loopback edge should fail");
+        assert!(error.to_string().contains("must bind HTTP to loopback"));
+
+        let mut config = edge_config("http://127.0.0.1:9001".to_string());
+        config.orchestrator.google_oauth = None;
+        let error = validate_public_edge_config(&config).expect_err("open edge should fail");
+        assert!(error.to_string().contains("requires Google OAuth/JWT"));
+
+        let mut config = edge_config("http://127.0.0.1:9001".to_string());
+        config.controller.token.clear();
+        let error =
+            validate_public_edge_config(&config).expect_err("empty controller token should fail");
+        assert!(error.to_string().contains("requires controller.token"));
+    }
+
+    #[test]
+    fn controller_allowlist_excludes_deploy_and_unknown_routes() {
+        assert!(is_allowed_controller_route(&Method::GET, "/status"));
+        assert!(is_allowed_controller_route(&Method::POST, "/hvac"));
+        assert!(is_allowed_controller_route(
+            &Method::GET,
+            "/apps/office-climate/meta.json"
+        ));
+        assert!(!is_allowed_controller_route(
+            &Method::POST,
+            "/deploy/office-climate"
+        ));
+        assert!(!is_allowed_controller_route(&Method::GET, "/admin/secrets"));
+    }
+
+    #[tokio::test]
+    async fn deploy_route_is_not_available_on_public_edge() {
+        let config = edge_config("http://127.0.0.1:9".to_string());
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@example.test")
+            .expect("jwt");
+        let app = app(config).expect("edge app");
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert!(
+            matches!(
+                response.status(),
+                StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+            ),
+            "unexpected status: {}",
+            response.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn status_route_forwards_with_controller_token() {
+        let controller = Router::new().route(
+            "/status",
+            get(|headers: HeaderMap| async move {
+                let token = headers
+                    .get(CONTROLLER_IPC_TOKEN_HEADER)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("");
+                if token == "controller-token" {
+                    Json(json!({"ok": true, "source": "controller"})).into_response()
+                } else {
+                    StatusCode::UNAUTHORIZED.into_response()
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind controller");
+        let address = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, controller).await.expect("controller");
+        });
+
+        let config = edge_config(format!("http://{address}"));
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@example.test")
+            .expect("jwt");
+        let app = app(config).expect("edge app");
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("body");
+        let payload: Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(payload["source"], "controller");
+    }
+}

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -233,6 +233,7 @@ fn is_loopback_bind_host(host: &str) -> bool {
 }
 
 const HVAC_TEMPERATURE_BANDS_SETTING: &str = "hvac_temperature_bands";
+pub(crate) const CONTROLLER_IPC_TOKEN_HEADER: &str = "x-office-automate-controller-token";
 
 #[derive(Clone)]
 struct AppState {
@@ -564,6 +565,13 @@ async fn auth_middleware(
         .map(|ConnectInfo(remote_addr)| *remote_addr);
     let headers = auth_headers_with_peer(request.headers(), remote_addr);
 
+    if has_valid_controller_ipc_token(&state.config, &headers, remote_addr) {
+        request.extensions_mut().insert(AuthenticatedUser {
+            email: "edge_ipc".to_string(),
+        });
+        return next.run(request).await;
+    }
+
     if request.uri().path() == "/ws"
         && is_websocket_upgrade(&headers)
         && matches!(auth_mode, HttpAuthMode::OAuth | HttpAuthMode::Basic)
@@ -694,8 +702,35 @@ async fn websocket(
     ws: WebSocketUpgrade,
 ) -> Response {
     let auth_headers = auth_headers_with_peer(&headers, Some(remote_addr));
-    let mode = state.auth.websocket_auth(&auth_headers);
+    let mode = if has_valid_controller_ipc_token(&state.config, &auth_headers, Some(remote_addr)) {
+        WebSocketAuth::Open
+    } else {
+        state.auth.websocket_auth(&auth_headers)
+    };
     ws.on_upgrade(move |socket| websocket_session(socket, state, mode))
+}
+
+fn has_valid_controller_ipc_token(
+    config: &AppConfig,
+    headers: &HeaderMap,
+    remote_addr: Option<SocketAddr>,
+) -> bool {
+    if remote_addr.is_some_and(|address| !address.ip().is_loopback()) {
+        return false;
+    }
+    let Some(expected) = config
+        .orchestrator
+        .controller_ipc_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    else {
+        return false;
+    };
+    headers
+        .get(CONTROLLER_IPC_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|actual| actual == expected)
 }
 
 async fn websocket_session(mut socket: WebSocket, state: AppState, auth_mode: WebSocketAuth) {
@@ -2989,6 +3024,41 @@ mod tests {
             .expect("read body");
         let value: Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(value["login_url"], "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn controller_ipc_token_allows_local_edge_calls() {
+        let mut config = oauth_config();
+        config.orchestrator.controller_ipc_token = Some("edge-token".to_string());
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header(CONTROLLER_IPC_TOKEN_HEADER, "edge-token")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut request = HttpRequest::builder()
+            .uri("/status")
+            .header(CONTROLLER_IPC_TOKEN_HEADER, "edge-token")
+            .body(Body::empty())
+            .expect("request");
+        request.extensions_mut().insert(ConnectInfo(
+            "203.0.113.10:4231"
+                .parse::<SocketAddr>()
+                .expect("socket addr"),
+        ));
+        let mut config = oauth_config();
+        config.orchestrator.controller_ipc_token = Some("edge-token".to_string());
+        let response = app(config).oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod automation;
 pub mod cli;
 pub mod config;
 pub mod db;
+pub mod edge;
 pub mod erv;
 pub mod http;
 pub mod hvac;

--- a/scripts/launchd/primary-host/com.office-automate.edge.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.edge.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.office-automate.edge</string>
+
+  <key>UserName</key>
+  <string>__OFFICE_AUTOMATE_EDGE_USER__</string>
+
+  <key>GroupName</key>
+  <string>__OFFICE_AUTOMATE_EDGE_GROUP__</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__OFFICE_AUTOMATE_SERVER_BIN__</string>
+    <string>serve-edge</string>
+    <string>--config</string>
+    <string>__OFFICE_AUTOMATE_EDGE_CONFIG__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__OFFICE_AUTOMATE_EDGE_WORKING_DIRECTORY__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OFFICE_AUTOMATE_EDGE_CONFIG</key>
+    <string>__OFFICE_AUTOMATE_EDGE_CONFIG__</string>
+    <key>PATH</key>
+    <string>__OFFICE_AUTOMATE_PATH__</string>
+    <key>RUST_LOG</key>
+    <string>__OFFICE_AUTOMATE_RUST_LOG__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>__OFFICE_AUTOMATE_EDGE_LOG_DIR__/office-automate-edge.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__OFFICE_AUTOMATE_EDGE_LOG_DIR__/office-automate-edge.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add `office-automate-server serve-edge` with an edge-only config schema that rejects device/telemetry sections
- keep the controller as the owner of MQTT, presence, device credentials, SQLite, telemetry, and LAN/device clients while the edge forwards only allowlisted typed routes
- authenticate edge-to-controller IPC with a loopback-only controller token and rate-limit public control posts
- make `/deploy` unavailable through the public edge and add an edge LaunchDaemon template plus deployment docs

## Spec Reference
- docs/working/100_security_threat_model.md

## Test Plan
- [x] cargo test -p office-automate-server
- [x] plutil -lint scripts/launchd/primary-host/com.office-automate.edge.plist.template scripts/launchd/primary-host/com.office-automate.tunnel.plist.template
- [x] git diff --check

Fixes #104