### PR TITLE
Add Smart Life local key refresh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,17 @@ config.yaml
 # Rust
 target/
 
+# Tuya local key / Smart Life auth material
+tuya-sharing-auth.json
+.tuya-sharing-auth.json
+.office-automate/
+
+# Python utility caches / local environments
+__pycache__/
+*.py[cod]
+venv/
+.venv/
+
 # Node
 node_modules/
 frontend/node_modules/

--- a/docs/tuya-local-key.md
+++ b/docs/tuya-local-key.md
@@ -260,7 +260,7 @@ This was the old behavior of the script — fixed in-tree. Newer Smart Life vers
 Both the device and Smart Life are stuck on a stale key. See step 4.3 → Path B.
 
 ### Tuya Cloud fallback returns 0 devices
-Tuya cloud projects need devices linked via the IoT Platform asset model. Don't rely on cloud — local-only is the goal. The orchestrator's cloud fallback in `erv_client.py` is best-effort and will likely fail silently here.
+Tuya cloud projects need devices linked via the IoT Platform asset model. Don't rely on cloud for this ERV recovery path — local control is the goal, and the Rust ERV client should use the refreshed local key in `config.yaml`.
 
 ## Prevention
 

--- a/docs/tuya-local-key.md
+++ b/docs/tuya-local-key.md
@@ -224,7 +224,7 @@ Local keys can contain shell-special characters (`$`, `}`, `>`, `^`, etc.). YAML
 Deploy + restart:
 ```sh
 scp config.yaml USER@SERVER_IP:/path/to/office-automate/config.yaml
-ssh USER@SERVER_IP 'U=$(id -u); launchctl kickstart -k gui/$U/com.office-automate.orchestrator'
+ssh USER@SERVER_IP 'U=$(id -u); launchctl kickstart -k gui/$U/com.office-automate.server'
 ssh USER@SERVER_IP 'tail -n 50 /tmp/office-automate.error.log'
 ```
 

--- a/docs/tuya-local-key.md
+++ b/docs/tuya-local-key.md
@@ -2,10 +2,11 @@
 
 This is the repeatable process to restore ERV local control when Tuya local commands start failing (e.g., Err 914 or dashboard control not working). Two paths depending on whether the local key has actually rotated or just gotten out of sync:
 
+- **Preferred: Smart Life sharing API refresh** using `scripts/refresh-erv-key.py`. This avoids the Android emulator and does **not** require a Tuya IoT Platform subscription.
 - **Path A: Re-extract** the cached local key from the Smart Life app. Works if the key in `config.yaml` is wrong but Smart Life still has working local control.
 - **Path B: Re-pair** the ERV through Smart Life. Required when both the device's key AND Smart Life's cached copy are stale (which is what happened on 2026-04-30 — see Troubleshooting).
 
-Always start with Path A. Drop to Path B only if the diagnostic in step 4 says so.
+Start with the preferred path. Use Path A only if Smart Life sharing auth fails, and drop to Path B only if the diagnostic in step 4 says so.
 
 ## When To Run This
 
@@ -22,6 +23,45 @@ Always start with Path A. Drop to Path B only if the diagnostic in step 4 says s
   - Slow flash = AP mode (fallback if EZ doesn't work).
 - **Wi-Fi:** 2.4 GHz only. 5 GHz networks won't pair.
 - **Smart Life category:** Small Home Appliances → Ventilation System.
+
+## Preferred Path: Refresh From Smart Life Sharing API
+
+This path uses Tuya's Home Assistant / Smart Life device-sharing API. It stores a refreshable token cache at `~/.office-automate/tuya-sharing-auth.json` with `0600` permissions. It does not store Tuya account credentials in `config.yaml`.
+
+Install/update dependencies:
+
+```sh
+source venv/bin/activate
+python -m pip install -r scripts/refresh-erv-key-requirements.txt
+```
+
+First-time authorization:
+
+```sh
+scripts/refresh-erv-key.py --init-auth --user-code <SMART_LIFE_USER_CODE>
+```
+
+The script prints a QR code. Scan it with Smart Life or Tuya Smart. In Smart Life, the user code is under **Me → Settings → Account and Security → User Code**.
+
+After authorization, print the current key:
+
+```sh
+scripts/refresh-erv-key.py
+```
+
+Update `config.yaml` if the key rotated:
+
+```sh
+scripts/refresh-erv-key.py --update-config
+```
+
+Update `config.yaml` and restart the launchd orchestrator:
+
+```sh
+scripts/refresh-erv-key.py --update-config --restart
+```
+
+If the API returns the same key that is already in `config.yaml`, the script prints `no rotation needed` and exits 0 without editing or restarting.
 
 ## Prereqs
 

--- a/scripts/refresh-erv-key-requirements.txt
+++ b/scripts/refresh-erv-key-requirements.txt
@@ -1,0 +1,3 @@
+qrcode>=8.0
+ruamel.yaml>=0.18.0
+tuya-device-sharing-sdk>=0.2.9

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -28,6 +28,7 @@ CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
 SCHEMA = "haauthorize"
 DEFAULT_AUTH_FILE = Path.home() / ".office-automate" / "tuya-sharing-auth.json"
 DEFAULT_CONFIG_FILE = Path("config.yaml")
+REQUIREMENTS_FILE = "scripts/refresh-erv-key-requirements.txt"
 SERVICE_LABEL = "com.office-automate.server"
 
 
@@ -53,7 +54,7 @@ def load_roundtrip_yaml():
         from ruamel.yaml import YAML
     except ImportError as exc:  # pragma: no cover - depends on local env
         raise RefreshError(
-            "ruamel.yaml is required. Run: python3 -m pip install -r requirements.txt"
+            f"ruamel.yaml is required. Run: python3 -m pip install -r {REQUIREMENTS_FILE}"
         ) from exc
 
     yaml = YAML()
@@ -347,7 +348,10 @@ def print_qr(payload: str, stderr: TextIO) -> None:
     try:
         import qrcode
     except ImportError:
-        print("qrcode is not installed; install requirements.txt to render the QR.", file=stderr)
+        print(
+            f"qrcode is not installed; install {REQUIREMENTS_FILE} to render the QR.",
+            file=stderr,
+        )
         return
 
     qr = qrcode.QRCode(border=1)
@@ -456,7 +460,7 @@ def restart_orchestrator() -> None:
 def ensure_tuya_sdk() -> None:
     if LoginControl is None or Manager is None:
         raise RefreshError(
-            "tuya-device-sharing-sdk is required. Run: python3 -m pip install -r requirements.txt"
+            f"tuya-device-sharing-sdk is required. Run: python3 -m pip install -r {REQUIREMENTS_FILE}"
         )
 
 
@@ -499,7 +503,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--restart",
         action="store_true",
-        help="kickstart the launchctl orchestrator service after --update-config changes the key",
+        help=f"kickstart the launchctl {SERVICE_LABEL} service after --update-config changes the key",
     )
     return parser
 

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -28,7 +28,7 @@ CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
 SCHEMA = "haauthorize"
 DEFAULT_AUTH_FILE = Path.home() / ".office-automate" / "tuya-sharing-auth.json"
 DEFAULT_CONFIG_FILE = Path("config.yaml")
-SERVICE_LABEL = "com.office-automate.orchestrator"
+SERVICE_LABEL = "com.office-automate.server"
 
 
 class RefreshError(Exception):

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Refresh the configured ERV Tuya local key from Smart Life sharing APIs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, TextIO
+from urllib.parse import parse_qs, urlparse
+
+try:
+    from tuya_sharing import LoginControl, Manager, SharingTokenListener
+except ImportError:  # pragma: no cover - exercised by users without deps installed
+    LoginControl = None
+    Manager = None
+    SharingTokenListener = object
+
+
+CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
+SCHEMA = "haauthorize"
+DEFAULT_AUTH_FILE = Path.home() / ".office-automate" / "tuya-sharing-auth.json"
+DEFAULT_CONFIG_FILE = Path("config.yaml")
+SERVICE_LABEL = "com.office-automate.orchestrator"
+
+
+class RefreshError(Exception):
+    """User-facing failure for the refresh command."""
+
+
+class AuthCacheTokenListener(SharingTokenListener):
+    """Persist refreshed Smart Life access tokens back to the local cache."""
+
+    def __init__(self, auth_file: Path, auth_cache: dict[str, Any]):
+        self.auth_file = auth_file
+        self.auth_cache = auth_cache
+
+    def update_token(self, token_info: dict[str, Any]):
+        self.auth_cache["token_info"] = token_info
+        self.auth_cache["updated_at"] = int(time.time())
+        save_auth_cache(self.auth_file, self.auth_cache)
+
+
+def load_roundtrip_yaml():
+    try:
+        from ruamel.yaml import YAML
+    except ImportError as exc:  # pragma: no cover - depends on local env
+        raise RefreshError(
+            "ruamel.yaml is required. Run: python3 -m pip install -r requirements.txt"
+        ) from exc
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml
+
+
+def load_config_data(config_file: Path) -> tuple[Any, Any]:
+    if not config_file.exists():
+        raise RefreshError(f"config file not found: {config_file}")
+
+    yaml = load_roundtrip_yaml()
+    try:
+        with config_file.open() as fh:
+            data = yaml.load(fh)
+    except Exception as exc:
+        raise RefreshError(f"failed to parse {config_file}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise RefreshError(f"{config_file} must contain a YAML mapping")
+    return yaml, data
+
+
+def read_erv_config(config_file: Path) -> tuple[str, str | None]:
+    _, data = load_config_data(config_file)
+    erv = data.get("erv")
+    if not isinstance(erv, dict):
+        raise RefreshError(f"{config_file} is missing an erv mapping")
+
+    device_id = erv.get("device_id")
+    if not isinstance(device_id, str) or not device_id.strip():
+        raise RefreshError(f"{config_file} is missing erv.device_id")
+
+    local_key = erv.get("local_key")
+    if local_key is not None and not isinstance(local_key, str):
+        raise RefreshError(f"{config_file} has a non-string erv.local_key")
+
+    return device_id.strip(), local_key
+
+
+def update_config_local_key(config_file: Path, new_local_key: str) -> None:
+    yaml, data = load_config_data(config_file)
+    erv = data.get("erv")
+    if not isinstance(erv, dict):
+        raise RefreshError(f"{config_file} is missing an erv mapping")
+
+    old_value = erv.get("local_key")
+    erv["local_key"] = preserve_scalar_style(old_value, new_local_key)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{config_file.name}.",
+        suffix=".tmp",
+        dir=str(config_file.parent or Path(".")),
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            yaml.dump(data, fh)
+        try:
+            mode = config_file.stat().st_mode & 0o777
+            tmp_path.chmod(mode)
+        except OSError:
+            pass
+        os.replace(tmp_path, config_file)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def preserve_scalar_style(old_value: Any, new_value: str) -> str:
+    try:
+        from ruamel.yaml.scalarstring import ScalarString
+    except ImportError:  # pragma: no cover
+        return new_value
+
+    if isinstance(old_value, ScalarString):
+        return old_value.__class__(new_value)
+    return new_value
+
+
+def load_auth_cache(auth_file: Path) -> dict[str, Any]:
+    if not auth_file.exists():
+        raise RefreshError(
+            f"auth cache not found: {auth_file}. Run with --init-auth --user-code <code> first."
+        )
+
+    try:
+        with auth_file.open() as fh:
+            auth_cache = json.load(fh)
+    except Exception as exc:
+        raise RefreshError(f"failed to read auth cache {auth_file}: {exc}") from exc
+
+    require_keys(auth_cache, ["user_code", "terminal_id", "endpoint", "token_info"])
+    require_keys(
+        auth_cache["token_info"],
+        ["t", "expire_time", "uid", "access_token", "refresh_token"],
+    )
+    return auth_cache
+
+
+def save_auth_cache(auth_file: Path, auth_cache: dict[str, Any]) -> None:
+    auth_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        auth_file.parent.chmod(0o700)
+    except OSError:
+        pass
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{auth_file.name}.",
+        suffix=".tmp",
+        dir=str(auth_file.parent),
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(auth_cache, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        tmp_path.chmod(0o600)
+        os.replace(tmp_path, auth_file)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def require_keys(data: Any, keys: list[str]) -> None:
+    if not isinstance(data, dict):
+        raise RefreshError("auth cache has an invalid shape")
+    missing = [key for key in keys if not data.get(key)]
+    if missing:
+        raise RefreshError(f"auth cache is missing: {', '.join(missing)}")
+
+
+def init_auth(
+    user_code: str,
+    auth_file: Path,
+    timeout_seconds: int,
+    poll_interval: float,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> dict[str, Any]:
+    ensure_tuya_sdk()
+    login = LoginControl()
+
+    response = login.qr_code(CLIENT_ID, SCHEMA, user_code)
+    if not response.get("success"):
+        raise RefreshError(format_tuya_error("failed to create Smart Life QR token", response))
+
+    result = response.get("result", {})
+    token = extract_login_token(result)
+    qr_payload = extract_qr_payload(result, token)
+
+    print("Scan this QR with Smart Life or Tuya Smart to authorize this daemon.", file=stderr)
+    print("Smart Life path: Me -> Settings -> Account and Security -> User Code.", file=stderr)
+    print("", file=stderr)
+    print_qr(qr_payload, stderr)
+    print("", file=stderr)
+    print(f"QR payload: {qr_payload}", file=stderr)
+    print(f"Waiting up to {timeout_seconds}s for authorization...", file=stderr)
+
+    deadline = time.monotonic() + timeout_seconds
+    last_error = None
+    while time.monotonic() < deadline:
+        ok, login_response = login.login_result(token, CLIENT_ID, user_code)
+        if ok:
+            auth_cache = build_auth_cache(user_code, login_response)
+            save_auth_cache(auth_file, auth_cache)
+            print(f"saved Smart Life auth cache to {auth_file}", file=stderr)
+            return auth_cache
+
+        last_error = login_response
+        code = str(login_response.get("code", ""))
+        msg = str(login_response.get("msg", "")).lower()
+        if (
+            code
+            and code not in {"1001", "1106", "1110", "E0020003"}
+            and "pending" not in msg
+            and "scan and try again" not in msg
+        ):
+            raise RefreshError(format_tuya_error("Smart Life QR authorization failed", login_response))
+        print(".", end="", file=stderr, flush=True)
+        time.sleep(poll_interval)
+
+    if last_error:
+        raise RefreshError(format_tuya_error("Smart Life QR authorization timed out", last_error))
+    raise RefreshError("Smart Life QR authorization timed out")
+
+
+def build_auth_cache(user_code: str, login_response: dict[str, Any]) -> dict[str, Any]:
+    token_info = {
+        "t": require_token_value(login_response, "t"),
+        "expire_time": require_token_value(login_response, "expire_time", "expireTime"),
+        "uid": require_token_value(login_response, "uid"),
+        "access_token": require_token_value(login_response, "access_token", "accessToken"),
+        "refresh_token": require_token_value(login_response, "refresh_token", "refreshToken"),
+    }
+    return {
+        "client_id": CLIENT_ID,
+        "schema": SCHEMA,
+        "user_code": user_code,
+        "terminal_id": require_token_value(login_response, "terminal_id", "terminalId"),
+        "endpoint": normalize_endpoint(require_token_value(login_response, "endpoint", "endPoint")),
+        "token_info": token_info,
+        "created_at": int(time.time()),
+    }
+
+
+def require_token_value(data: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, ""):
+            return value
+    raise RefreshError(f"Smart Life auth response did not include {'/'.join(keys)}")
+
+
+def normalize_endpoint(endpoint: str) -> str:
+    endpoint = endpoint.rstrip("/")
+    if endpoint.startswith("http://") or endpoint.startswith("https://"):
+        return endpoint
+    return f"https://{endpoint}"
+
+
+def extract_login_token(result: Any) -> str:
+    for value in walk_values(result):
+        if not isinstance(value, str):
+            continue
+        token = token_from_string(value)
+        if token:
+            return token
+    raise RefreshError(f"Smart Life QR response did not include a login token: {result!r}")
+
+
+def extract_qr_payload(result: Any, token: str) -> str:
+    if isinstance(result, dict):
+        for key in ("qrcode", "qrCode", "qr_code", "url", "qrCodeUrl", "qrcodeUrl"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip().startswith("tuyaSmart--qrLogin?"):
+                return value.strip()
+    return f"tuyaSmart--qrLogin?token={token}"
+
+
+def walk_values(value: Any) -> Iterable[Any]:
+    if isinstance(value, dict):
+        priority_keys = (
+            "token",
+            "qrCodeToken",
+            "qrcodeToken",
+            "loginToken",
+            "qrcode",
+            "qrCode",
+            "url",
+        )
+        for key in priority_keys:
+            if key in value:
+                yield value[key]
+        for key, item in value.items():
+            if key not in priority_keys:
+                yield from walk_values(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from walk_values(item)
+    else:
+        yield value
+
+
+def token_from_string(value: str) -> str | None:
+    value = value.strip()
+    if not value:
+        return None
+
+    parsed = urlparse(value)
+    if parsed.query:
+        query = parse_qs(parsed.query)
+        for key in ("token", "code", "qrcode", "qrCode"):
+            values = query.get(key)
+            if values and values[0]:
+                return values[0]
+
+    match = re.search(r"/tokens/([^/?#]+)", value)
+    if match:
+        return match.group(1)
+
+    if re.fullmatch(r"[A-Za-z0-9._:-]{8,}", value) and not parsed.scheme:
+        return value
+    return None
+
+
+def print_qr(payload: str, stderr: TextIO) -> None:
+    try:
+        import qrcode
+    except ImportError:
+        print("qrcode is not installed; install requirements.txt to render the QR.", file=stderr)
+        return
+
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(payload)
+    qr.make(fit=True)
+    qr.print_ascii(out=stderr)
+
+
+def fetch_current_local_key(
+    auth_file: Path,
+    auth_cache: dict[str, Any],
+    device_id: str,
+) -> tuple[str, str | None]:
+    ensure_tuya_sdk()
+    listener = AuthCacheTokenListener(auth_file, auth_cache)
+    manager = Manager(
+        CLIENT_ID,
+        auth_cache["user_code"],
+        auth_cache["terminal_id"],
+        auth_cache["endpoint"],
+        auth_cache["token_info"],
+        listener,
+    )
+
+    device = fetch_device_detail(manager, device_id)
+    if device is None:
+        device = fetch_device_from_cache(manager, device_id)
+    if device is None:
+        raise RefreshError(f"device {device_id} was not returned by Smart Life")
+
+    local_key = get_device_field(device, "local_key", "localKey")
+    if not isinstance(local_key, str) or not local_key:
+        raise RefreshError(
+            f"Smart Life returned device {device_id}, but no localKey/local_key field"
+        )
+    name = get_device_field(device, "name")
+    return local_key, name if isinstance(name, str) else None
+
+
+def fetch_device_detail(manager: Any, device_id: str) -> Any | None:
+    customer_api = getattr(manager, "customer_api", None)
+    if customer_api is None or not hasattr(customer_api, "get"):
+        return None
+
+    try:
+        response = customer_api.get("/v1.0/m/life/ha/devices/detail", {"devIds": device_id})
+    except Exception:
+        return None
+
+    result = response.get("result") if isinstance(response, dict) else None
+    for device in normalize_device_results(result):
+        if get_device_field(device, "id", "devId", "device_id") == device_id:
+            return device
+    return None
+
+
+def fetch_device_from_cache(manager: Any, device_id: str) -> Any | None:
+    try:
+        manager.update_device_cache()
+    except Exception as exc:
+        raise RefreshError(f"failed to list Smart Life devices: {exc}") from exc
+
+    device_map = getattr(manager, "device_map", {})
+    if isinstance(device_map, dict):
+        if device_id in device_map:
+            return device_map[device_id]
+        for device in device_map.values():
+            if get_device_field(device, "id", "devId", "device_id") == device_id:
+                return device
+    return None
+
+
+def normalize_device_results(result: Any) -> list[Any]:
+    if isinstance(result, list):
+        return result
+    if isinstance(result, dict):
+        for key in ("devices", "list", "data"):
+            value = result.get(key)
+            if isinstance(value, list):
+                return value
+        return [result]
+    return []
+
+
+def get_device_field(device: Any, *names: str) -> Any:
+    if isinstance(device, dict):
+        for name in names:
+            if name in device:
+                return device[name]
+        return None
+
+    for name in names:
+        if hasattr(device, name):
+            return getattr(device, name)
+    return None
+
+
+def restart_orchestrator() -> None:
+    uid = os.getuid()
+    subprocess.run(
+        ["launchctl", "kickstart", "-k", f"gui/{uid}/{SERVICE_LABEL}"],
+        check=True,
+    )
+
+
+def ensure_tuya_sdk() -> None:
+    if LoginControl is None or Manager is None:
+        raise RefreshError(
+            "tuya-device-sharing-sdk is required. Run: python3 -m pip install -r requirements.txt"
+        )
+
+
+def format_tuya_error(prefix: str, response: dict[str, Any]) -> str:
+    code = response.get("code")
+    msg = response.get("msg") or response.get("message")
+    if code or msg:
+        return f"{prefix}: code={code} msg={msg}"
+    return f"{prefix}: {response}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fetch the current ERV Tuya local key via the Smart Life HA sharing API.",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_FILE)
+    parser.add_argument("--auth-file", type=Path, default=DEFAULT_AUTH_FILE)
+    parser.add_argument(
+        "--init-auth",
+        action="store_true",
+        help="authorize the daemon with a Smart Life QR scan before fetching the key",
+    )
+    parser.add_argument(
+        "--user-code",
+        help="Smart Life user code for QR authorization",
+    )
+    parser.add_argument("--auth-timeout", type=int, default=180)
+    parser.add_argument("--poll-interval", type=float, default=3.0)
+    parser.add_argument(
+        "--print",
+        dest="print_key",
+        action="store_true",
+        help="print the current local key (default unless --update-config is used)",
+    )
+    parser.add_argument(
+        "--update-config",
+        action="store_true",
+        help="replace erv.local_key in config.yaml if it changed",
+    )
+    parser.add_argument(
+        "--restart",
+        action="store_true",
+        help="kickstart the launchctl orchestrator service after --update-config changes the key",
+    )
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.print_key and args.update_config:
+        parser.error("--print and --update-config are mutually exclusive")
+    if args.restart and not args.update_config:
+        parser.error("--restart requires --update-config")
+    if args.init_auth and not args.user_code:
+        parser.error("--init-auth requires --user-code")
+
+    try:
+        device_id, configured_key = read_erv_config(args.config)
+
+        if args.init_auth:
+            auth_cache = init_auth(
+                args.user_code,
+                args.auth_file,
+                args.auth_timeout,
+                args.poll_interval,
+                stdout,
+                stderr,
+            )
+        else:
+            auth_cache = load_auth_cache(args.auth_file)
+
+        current_key, device_name = fetch_current_local_key(
+            args.auth_file,
+            auth_cache,
+            device_id,
+        )
+
+        if current_key == configured_key:
+            print("no rotation needed", file=stdout)
+            return 0
+
+        if args.update_config:
+            update_config_local_key(args.config, current_key)
+            suffix = f" for {device_name}" if device_name else ""
+            print(f"updated {args.config}: erv.local_key refreshed{suffix}", file=stdout)
+            if args.restart:
+                restart_orchestrator()
+                print(f"restarted {SERVICE_LABEL}", file=stdout)
+            return 0
+
+        print(current_key, file=stdout)
+        return 0
+
+    except RefreshError as exc:
+        print(f"error: {exc}", file=stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"error: launchctl restart failed: {exc}", file=stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -544,11 +544,11 @@ def main(
             device_id,
         )
 
-        if current_key == configured_key:
-            print("no rotation needed", file=stdout)
-            return 0
-
         if args.update_config:
+            if current_key == configured_key:
+                print("no rotation needed", file=stdout)
+                return 0
+
             update_config_local_key(args.config, current_key)
             suffix = f" for {device_name}" if device_name else ""
             print(f"updated {args.config}: erv.local_key refreshed{suffix}", file=stdout)

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -158,16 +158,19 @@ def load_auth_cache(auth_file: Path) -> dict[str, Any]:
 
 
 def save_auth_cache(auth_file: Path, auth_cache: dict[str, Any]) -> None:
-    auth_file.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        auth_file.parent.chmod(0o700)
-    except OSError:
-        pass
+    parent = auth_file.parent
+    parent_preexisted = parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if should_chmod_auth_parent(auth_file, parent_preexisted):
+        try:
+            parent.chmod(0o700)
+        except OSError:
+            pass
 
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{auth_file.name}.",
         suffix=".tmp",
-        dir=str(auth_file.parent),
+        dir=str(parent),
         text=True,
     )
     tmp_path = Path(tmp_name)
@@ -180,6 +183,12 @@ def save_auth_cache(auth_file: Path, auth_cache: dict[str, Any]) -> None:
     finally:
         if tmp_path.exists():
             tmp_path.unlink()
+
+
+def should_chmod_auth_parent(auth_file: Path, parent_preexisted: bool) -> bool:
+    if not parent_preexisted:
+        return True
+    return auth_file.expanduser().resolve().parent == DEFAULT_AUTH_FILE.parent.resolve()
 
 
 def require_keys(data: Any, keys: list[str]) -> None:

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -42,11 +42,20 @@ class AuthCacheTokenListener(SharingTokenListener):
     def __init__(self, auth_file: Path, auth_cache: dict[str, Any]):
         self.auth_file = auth_file
         self.auth_cache = auth_cache
+        self.persist_error: Exception | None = None
 
     def update_token(self, token_info: dict[str, Any]):
         self.auth_cache["token_info"] = token_info
         self.auth_cache["updated_at"] = int(time.time())
-        save_auth_cache(self.auth_file, self.auth_cache)
+        try:
+            save_auth_cache(self.auth_file, self.auth_cache)
+        except Exception as exc:  # pragma: no cover - exact SDK behavior varies
+            self.persist_error = exc
+            raise
+
+    def raise_if_persist_failed(self) -> None:
+        if self.persist_error is not None:
+            raise RefreshError(f"failed to persist refreshed Smart Life token: {self.persist_error}")
 
 
 def load_roundtrip_yaml():
@@ -388,6 +397,7 @@ def fetch_current_local_key(
     device = fetch_device_detail(manager, device_id)
     if device is None:
         device = fetch_device_from_cache(manager, device_id)
+    listener.raise_if_persist_failed()
     if device is None:
         raise RefreshError(f"device {device_id} was not returned by Smart Life")
 

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -114,6 +114,39 @@ def test_update_config_preserves_comments_and_auth_refresh(tmp_path, monkeypatch
     assert auth_data["token_info"]["refresh_token"] == "new-refresh-token"
 
 
+def test_custom_auth_file_parent_is_not_chmodded(tmp_path, monkeypatch):
+    module = load_script_module()
+    chmod_calls = []
+    original_chmod = module.Path.chmod
+
+    def recording_chmod(path, mode):
+        chmod_calls.append((Path(path), mode))
+        return original_chmod(path, mode)
+
+    monkeypatch.setattr(module.Path, "chmod", recording_chmod)
+
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o755)
+    auth = parent / "auth.json"
+
+    module.save_auth_cache(auth, {"token_info": {"access_token": "secret"}})
+
+    assert (parent, 0o700) not in chmod_calls
+    assert any(path == auth or path.parent == parent for path, mode in chmod_calls if mode == 0o600)
+
+
+def test_default_auth_file_parent_is_chmodded_when_preexisting(tmp_path, monkeypatch):
+    module = load_script_module()
+    default_parent = tmp_path / ".office-automate"
+    auth = default_parent / "tuya-sharing-auth.json"
+    default_parent.mkdir(mode=0o755)
+    monkeypatch.setattr(module, "DEFAULT_AUTH_FILE", auth)
+
+    module.save_auth_cache(auth, {"token_info": {"access_token": "secret"}})
+
+    assert (default_parent.stat().st_mode & 0o777) == 0o700
+
+
 def test_same_key_reports_no_rotation_and_does_not_restart(tmp_path, monkeypatch):
     module = load_script_module()
     monkeypatch.setattr(module, "Manager", FakeManager)

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -1,0 +1,185 @@
+"""Tests for the Smart Life ERV local key refresh script."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def load_script_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "refresh-erv-key.py"
+    spec = importlib.util.spec_from_file_location("refresh_erv_key", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_config(path: Path, local_key: str = "old-local-key") -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Office Climate Automation Configuration",
+                "erv:",
+                '  type: "tuya"',
+                '  device_id: "erv-device-id"',
+                f'  local_key: "{local_key}"  # keep this comment',
+                '  ip: "192.0.2.25"',
+                "",
+            ]
+        )
+    )
+
+
+def write_auth(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "user_code": "us-user-code",
+                "terminal_id": "terminal-id",
+                "endpoint": "https://example.tuyaus.com",
+                "token_info": {
+                    "t": 1770000000000,
+                    "expire_time": 7200,
+                    "uid": "uid",
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                },
+            }
+        )
+    )
+
+
+class FakeManager:
+    latest_listener = None
+
+    def __init__(self, client_id, user_code, terminal_id, endpoint, token_info, listener):
+        self.customer_api = None
+        self.device_map = {
+            "erv-device-id": SimpleNamespace(
+                id="erv-device-id",
+                name="ERVQ-H-F-BM",
+                local_key="new-local-key",
+            )
+        }
+        FakeManager.latest_listener = listener
+
+    def update_device_cache(self):
+        FakeManager.latest_listener.update_token(
+            {
+                "t": 1770000001000,
+                "expire_time": 7200,
+                "uid": "uid",
+                "access_token": "new-access-token",
+                "refresh_token": "new-refresh-token",
+            }
+        )
+
+
+def test_update_config_preserves_comments_and_auth_refresh(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    auth = tmp_path / "auth.json"
+    write_config(config)
+    write_auth(auth)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+            "--update-config",
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 0
+    assert "updated" in stdout.getvalue()
+    assert "new-local-key" in config.read_text()
+    assert "# keep this comment" in config.read_text()
+
+    auth_data = json.loads(auth.read_text())
+    assert auth_data["token_info"]["access_token"] == "new-access-token"
+    assert auth_data["token_info"]["refresh_token"] == "new-refresh-token"
+
+
+def test_same_key_reports_no_rotation_and_does_not_restart(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+    monkeypatch.setattr(
+        module,
+        "restart_orchestrator",
+        lambda: (_ for _ in ()).throw(AssertionError("restart should not be called")),
+    )
+
+    config = tmp_path / "config.yaml"
+    auth = tmp_path / "auth.json"
+    write_config(config, local_key="new-local-key")
+    write_auth(auth)
+    before = config.read_text()
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+            "--update-config",
+            "--restart",
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 0
+    assert stdout.getvalue().strip() == "no rotation needed"
+    assert config.read_text() == before
+
+
+def test_print_mode_outputs_key_without_updating_config(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    auth = tmp_path / "auth.json"
+    write_config(config)
+    write_auth(auth)
+    before = config.read_text()
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        ["--config", str(config), "--auth-file", str(auth)],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 0
+    assert stdout.getvalue().strip() == "new-local-key"
+    assert config.read_text() == before
+
+
+def test_qr_payload_wraps_home_assistant_qrcode_token():
+    module = load_script_module()
+
+    result = {"qrcode": "qr-token-value"}
+
+    assert module.extract_login_token(result) == "qr-token-value"
+    assert (
+        module.extract_qr_payload(result, "qr-token-value")
+        == "tuyaSmart--qrLogin?token=qr-token-value"
+    )

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -183,3 +184,30 @@ def test_qr_payload_wraps_home_assistant_qrcode_token():
         module.extract_qr_payload(result, "qr-token-value")
         == "tuyaSmart--qrLogin?token=qr-token-value"
     )
+
+
+def test_restart_uses_current_launchd_server_label(monkeypatch):
+    module = load_script_module()
+    calls = []
+
+    monkeypatch.setattr(module.os, "getuid", lambda: 501)
+
+    def fake_run(command, check):
+        calls.append((command, check))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module.restart_orchestrator()
+
+    assert calls == [
+        (
+            [
+                "launchctl",
+                "kickstart",
+                "-k",
+                "gui/501/com.office-automate.server",
+            ],
+            True,
+        )
+    ]

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -150,6 +150,35 @@ def test_same_key_reports_no_rotation_and_does_not_restart(tmp_path, monkeypatch
     assert config.read_text() == before
 
 
+def test_same_key_print_mode_still_outputs_key(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    auth = tmp_path / "auth.json"
+    write_config(config, local_key="new-local-key")
+    write_auth(auth)
+    before = config.read_text()
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 0
+    assert stdout.getvalue().strip() == "new-local-key"
+    assert config.read_text() == before
+
+
 def test_print_mode_outputs_key_without_updating_config(tmp_path, monkeypatch):
     module = load_script_module()
     monkeypatch.setattr(module, "Manager", FakeManager)

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -80,6 +80,22 @@ class FakeManager:
         )
 
 
+class SwallowingRefreshErrorManager(FakeManager):
+    def update_device_cache(self):
+        try:
+            FakeManager.latest_listener.update_token(
+                {
+                    "t": 1770000001000,
+                    "expire_time": 7200,
+                    "uid": "uid",
+                    "access_token": "new-access-token",
+                    "refresh_token": "new-refresh-token",
+                }
+            )
+        except OSError:
+            pass
+
+
 def test_update_config_preserves_comments_and_auth_refresh(tmp_path, monkeypatch):
     module = load_script_module()
     monkeypatch.setattr(module, "Manager", FakeManager)
@@ -112,6 +128,38 @@ def test_update_config_preserves_comments_and_auth_refresh(tmp_path, monkeypatch
     auth_data = json.loads(auth.read_text())
     assert auth_data["token_info"]["access_token"] == "new-access-token"
     assert auth_data["token_info"]["refresh_token"] == "new-refresh-token"
+
+
+def test_token_refresh_persistence_error_fails_fetch(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", SwallowingRefreshErrorManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    def failing_save_auth_cache(auth_file, auth_cache):
+        raise OSError("read-only auth file")
+
+    monkeypatch.setattr(module, "save_auth_cache", failing_save_auth_cache)
+
+    config = tmp_path / "config.yaml"
+    auth = tmp_path / "auth.json"
+    write_config(config)
+    write_auth(auth)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 1
+    assert "failed to persist refreshed Smart Life token" in stderr.getvalue()
 
 
 def test_custom_auth_file_parent_is_not_chmodded(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `scripts/refresh-erv-key.py` to authorize via the Smart Life/Home Assistant sharing flow and fetch the ERV local key without the Android emulator path
- preserve `config.yaml` formatting/comments when updating `erv.local_key`, with optional launchctl restart
- add mocked tests for config updates, no-op same-key handling, print mode, QR payload parsing, and token refresh persistence
- add required dependencies and ignore local Smart Life auth/token cache files
- update the Tuya local-key runbook to document the preferred API refresh path

## Safety
- no Tuya account password, access token, refresh token, device ID, or local key is committed
- the script stores auth material only in `~/.office-automate/tuya-sharing-auth.json` with `0600` permissions
- tests mock the Tuya API and do not hit the real Smart Life service
- backup-manager config already includes `~/.office-automate/tuya-sharing-auth.json`

## Tests
- `python3 -m py_compile scripts/refresh-erv-key.py`
- `python3 -m pytest tests/test_refresh_erv_key.py`
- `python3 -m pytest` -> 89 passed outside the sandbox; sandboxed run failed only because `tests/test_artifact_server.py` cannot bind localhost under sandbox restrictions
- `git diff --check`