### PR TITLE
Finish mainline MQTT and Qingping updates

### DIFF
--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -28,8 +28,6 @@ export OFFICE_AUTOMATE_CUTOVER_LOG="/absolute/path/to/cutover-log.md"
 export OFFICE_AUTOMATE_MQTT_CUTOVER_STRATEGY="atomic-switch"
 ```
 
-Use `bridge-mirror` instead of `atomic-switch` only when the active climate controller continues receiving mirrored fresh Qingping readings for the whole transition.
-
 The Rust config used for the active cutover must have:
 
 ```yaml
@@ -61,7 +59,6 @@ export OFFICE_AUTOMATE_LEGACY_STOPPED_AT="$(date -Iseconds)"
 
 Apply the selected MQTT feed strategy:
 
-- `bridge-mirror`: keep Qingping publishing to the current active path while bridge/mirror forwarding proves Rust receives the same fresh `qingping/{DEVICE_MAC}/up` reports.
 - `atomic-switch`: move Qingping to the Rust embedded broker in the same window that Python active control stops and Rust active control starts.
 
 Start the Rust backend and Cloudflare Tunnel services with launchd or the equivalent foreground commands:

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -21,6 +21,7 @@ Render the templates with deployment-specific absolute paths before loading them
 | Placeholder | Meaning |
 | --- | --- |
 | `__OFFICE_AUTOMATE_ROOT__` | Repository checkout or release directory. |
+| `__OFFICE_AUTOMATE_PYTHON__` | Python interpreter with `paho-mqtt` installed, usually the repo virtualenv Python. |
 | `__OFFICE_AUTOMATE_SERVER_BIN__` | Absolute path to the Rust `office-automate-server` binary. |
 | `__OFFICE_AUTOMATE_CONFIG__` | Absolute path to the deployment config file. |
 | `__OFFICE_AUTOMATE_EDGE_CONFIG__` | Absolute path to the edge-only config file. This file must not contain device, telemetry, repo, or climate database settings. |
@@ -234,6 +235,10 @@ scripts/security/validate-edge-quarantine.sh \
 ```
 
 The validation passes only if the tunnel/edge users can read the material they need, cannot read or traverse controller config/data/repos/telemetry, cannot read or traverse each other's private credentials unless explicitly required, can reach the approved loopback origin, and cannot connect to LAN/RFC1918 endpoints that the control user can reach.
+
+## Qingping MQTT
+
+`com.office-automate.server` owns the embedded MQTT broker for Qingping. Configure the physical Qingping device's Private Access MQTT host to the primary host LAN address and port from `qingping.mqtt_broker` and `qingping.mqtt_port`. The Rust server subscribes to `qingping/<device_mac>/up` and publishes interval commands to `qingping/<device_mac>/down`; no separate MQTT bridge or legacy broker is part of the target deployment.
 
 ## Cloudflare Tunnel Notes
 

--- a/docs/deployment/rollback-validation.md
+++ b/docs/deployment/rollback-validation.md
@@ -21,8 +21,7 @@ export OFFICE_AUTOMATE_ROLLBACK_LOG="/absolute/path/to/rollback-log.md"
 For MQTT rollback state, choose the value that matches the rollback:
 
 - `not-moved`: Qingping never moved off the legacy-compatible MQTT path.
-- `repointed-legacy`: Qingping device or bridge was repointed to the legacy broker.
-- `legacy-mirror`: bridge/mirror forwarding keeps the legacy controller receiving fresh reports.
+- `repointed-legacy`: Qingping device was repointed to the legacy broker.
 
 For snapshot restore verification, choose one:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -839,9 +838,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
       "cpu": [
         "arm"
       ],
@@ -853,9 +852,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
       "cpu": [
         "arm64"
       ],
@@ -867,9 +866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
       "cpu": [
         "arm64"
       ],
@@ -881,9 +880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
       "cpu": [
         "x64"
       ],
@@ -895,9 +894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
       "cpu": [
         "arm64"
       ],
@@ -909,9 +908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
       "cpu": [
         "x64"
       ],
@@ -923,13 +922,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -937,13 +939,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,13 +956,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -965,13 +973,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,13 +990,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,13 +1007,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,13 +1024,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,13 +1041,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,13 +1058,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1049,13 +1075,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,13 +1092,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,13 +1109,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,13 +1126,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1105,9 +1143,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
       "cpu": [
         "x64"
       ],
@@ -1119,9 +1157,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
       "cpu": [
         "arm64"
       ],
@@ -1133,9 +1171,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
       "cpu": [
         "arm64"
       ],
@@ -1147,9 +1185,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
       "cpu": [
         "ia32"
       ],
@@ -1161,9 +1199,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
       "cpu": [
         "x64"
       ],
@@ -1175,9 +1213,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
       "cpu": [
         "x64"
       ],
@@ -1309,9 +1347,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1321,7 +1359,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1383,7 +1420,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1778,9 +1814,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1811,12 +1847,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1825,9 +1860,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1845,7 +1880,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1858,7 +1893,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1868,7 +1902,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1888,7 +1921,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -1951,8 +1983,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -1970,13 +2001,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1986,31 +2017,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.55.1",
-        "@rollup/rollup-android-arm64": "4.55.1",
-        "@rollup/rollup-darwin-arm64": "4.55.1",
-        "@rollup/rollup-darwin-x64": "4.55.1",
-        "@rollup/rollup-freebsd-arm64": "4.55.1",
-        "@rollup/rollup-freebsd-x64": "4.55.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
-        "@rollup/rollup-linux-arm64-musl": "4.55.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
-        "@rollup/rollup-linux-loong64-musl": "4.55.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
-        "@rollup/rollup-linux-x64-gnu": "4.55.1",
-        "@rollup/rollup-linux-x64-musl": "4.55.1",
-        "@rollup/rollup-openbsd-x64": "4.55.1",
-        "@rollup/rollup-openharmony-arm64": "4.55.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
-        "@rollup/rollup-win32-x64-gnu": "4.55.1",
-        "@rollup/rollup-win32-x64-msvc": "4.55.1",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -2147,12 +2178,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -225,14 +225,12 @@ pub struct RollbackValidationArgs {
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum MqttCutoverStrategyArg {
-    BridgeMirror,
     AtomicSwitch,
 }
 
 impl From<MqttCutoverStrategyArg> for MqttCutoverStrategy {
     fn from(value: MqttCutoverStrategyArg) -> Self {
         match value {
-            MqttCutoverStrategyArg::BridgeMirror => Self::BridgeMirror,
             MqttCutoverStrategyArg::AtomicSwitch => Self::AtomicSwitch,
         }
     }
@@ -242,10 +240,8 @@ impl From<MqttCutoverStrategyArg> for MqttCutoverStrategy {
 pub enum MqttRollbackStateArg {
     /// Qingping never moved off the legacy-compatible MQTT path.
     NotMoved,
-    /// Qingping device or bridge was repointed to the legacy broker.
+    /// Qingping device was repointed to the legacy broker.
     RepointedLegacy,
-    /// Bridge/mirror forwarding keeps the legacy controller receiving fresh reports.
-    LegacyMirror,
 }
 
 impl From<MqttRollbackStateArg> for MqttRollbackState {
@@ -253,7 +249,6 @@ impl From<MqttRollbackStateArg> for MqttRollbackState {
         match value {
             MqttRollbackStateArg::NotMoved => Self::NotMoved,
             MqttRollbackStateArg::RepointedLegacy => Self::RepointedLegacy,
-            MqttRollbackStateArg::LegacyMirror => Self::LegacyMirror,
         }
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1713,7 +1713,10 @@ struct QingpingIntervalRequest {
     interval: i64,
 }
 
-async fn qingping_interval(Json(payload): Json<QingpingIntervalRequest>) -> Response {
+async fn qingping_interval(
+    State(state): State<AppState>,
+    Json(payload): Json<QingpingIntervalRequest>,
+) -> Response {
     if payload.interval < 15 {
         return (
             StatusCode::BAD_REQUEST,
@@ -1722,11 +1725,26 @@ async fn qingping_interval(Json(payload): Json<QingpingIntervalRequest>) -> Resp
             .into_response();
     }
 
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({"ok": false, "error": "MQTT command path is not enabled yet"})),
-    )
-        .into_response()
+    match mqtt::publish_qingping_interval(&state.config, payload.interval).await {
+        Ok(()) => {
+            state.qingping.mark_interval_configured();
+            broadcast_status(&state);
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "interval": payload.interval,
+                    "message": format!("Device configured to report every {} seconds", payload.interval),
+                })),
+            )
+                .into_response()
+        }
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response(),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -4,17 +4,23 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
     thread::{self, JoinHandle},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, anyhow};
+use rumqttc::{AsyncClient, Event, MqttOptions, Outgoing, QoS};
 use rumqttd::{
     Broker, Config as BrokerConfig, ConnectionSettings, Notification, RouterConfig, ServerSettings,
 };
+use tokio::time;
 
 use crate::{
     config::AppConfig,
     db,
-    qingping::{QingpingState, parse_qingping_payload, qingping_up_topic},
+    qingping::{
+        QingpingState, parse_qingping_payload, qingping_down_topic, qingping_interval_payload,
+        qingping_up_topic,
+    },
 };
 
 pub struct MqttRuntime {
@@ -23,6 +29,64 @@ pub struct MqttRuntime {
 }
 
 pub type SensorIngressHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
+pub async fn publish_qingping_interval(config: &AppConfig, interval_seconds: i64) -> Result<()> {
+    let device_mac = config
+        .qingping
+        .device_mac
+        .as_deref()
+        .context("qingping.device_mac is required to publish interval commands")?;
+    let topic = qingping_down_topic(device_mac);
+    let payload = serde_json::to_vec(&qingping_interval_payload(interval_seconds))
+        .context("failed to serialize Qingping interval command")?;
+    publish_local_qingping_command(
+        &config.runtime.mqtt_host,
+        config.runtime.mqtt_port,
+        &topic,
+        payload,
+    )
+    .await
+    .with_context(|| format!("failed to publish Qingping interval command to {topic}"))?;
+    Ok(())
+}
+
+async fn publish_local_qingping_command(
+    host: &str,
+    port: u16,
+    topic: &str,
+    payload: Vec<u8>,
+) -> Result<()> {
+    let client_id = format!(
+        "office-automate-qingping-command-{}",
+        chrono::Local::now().timestamp_millis()
+    );
+    let mut options = MqttOptions::new(client_id, host.trim(), port);
+    options.set_keep_alive(Duration::from_secs(5));
+
+    let (client, mut event_loop) = AsyncClient::new(options, 10);
+    client
+        .publish(topic, QoS::AtMostOnce, false, payload)
+        .await
+        .context("failed to queue MQTT publish")?;
+
+    time::timeout(Duration::from_secs(5), async {
+        loop {
+            match event_loop
+                .poll()
+                .await
+                .context("MQTT publish poll failed")?
+            {
+                Event::Outgoing(Outgoing::Publish(_)) => return Ok::<_, anyhow::Error>(()),
+                Event::Incoming(_) | Event::Outgoing(_) => {}
+            }
+        }
+    })
+    .await
+    .context("timed out waiting for MQTT publish")??;
+
+    let _ = client.disconnect().await;
+    Ok(())
+}
 
 pub fn start_qingping_ingress(
     config: &AppConfig,

--- a/rust/office-automate-server/src/qingping.rs
+++ b/rust/office-automate-server/src/qingping.rs
@@ -1,8 +1,11 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{
+    Arc, RwLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use chrono::Local;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::status::Status;
 
@@ -30,6 +33,7 @@ impl QingpingReading {
 #[derive(Debug, Clone, Default)]
 pub struct QingpingState {
     latest: Arc<RwLock<Option<QingpingReading>>>,
+    interval_configured: Arc<AtomicBool>,
 }
 
 impl QingpingState {
@@ -44,7 +48,13 @@ impl QingpingState {
             .clone()
     }
 
+    pub fn mark_interval_configured(&self) {
+        self.interval_configured.store(true, Ordering::SeqCst);
+    }
+
     pub fn overlay_status(&self, status: &mut Status) {
+        status.air_quality.interval_configured = self.interval_configured.load(Ordering::SeqCst);
+
         let Some(reading) = self.latest() else {
             return;
         };
@@ -75,6 +85,24 @@ pub fn normalize_device_mac(device_mac: &str) -> String {
 
 pub fn qingping_up_topic(device_mac: &str) -> String {
     format!("qingping/{}/up", normalize_device_mac(device_mac))
+}
+
+pub fn qingping_down_topic(device_mac: &str) -> String {
+    format!("qingping/{}/down", normalize_device_mac(device_mac))
+}
+
+pub fn qingping_interval_payload(interval_seconds: i64) -> Value {
+    json!({
+        "id": 1,
+        "need_ack": 1,
+        "type": "17",
+        "setting": {
+            "report_interval": interval_seconds,
+            "collect_interval": interval_seconds,
+            "co2_sampling_interval": interval_seconds,
+            "pm_sampling_interval": interval_seconds,
+        }
+    })
 }
 
 pub fn parse_qingping_payload(
@@ -230,5 +258,50 @@ mod tests {
 
         assert!(error.is_syntax());
         assert_eq!(state.latest(), Some(existing));
+    }
+
+    #[test]
+    fn interval_configured_overlays_status_after_successful_command() {
+        let state = QingpingState::default();
+        let mut status = Status {
+            state: "away".to_string(),
+            is_present: false,
+            presence_signal_active: false,
+            safety_interlock: false,
+            erv_should_run: false,
+            verifying_departure: false,
+            in_door_open_mode: false,
+            sensors: crate::status::SensorsStatus::default(),
+            air_quality: crate::status::AirQualityStatus::default(),
+            erv: crate::status::ErvStatus::default(),
+            hvac: crate::status::HvacStatus::default(),
+            manual_override: crate::status::ManualOverrideStatus::default(),
+            notifications: Vec::new(),
+        };
+
+        state.overlay_status(&mut status);
+        assert!(!status.air_quality.interval_configured);
+
+        state.mark_interval_configured();
+        state.overlay_status(&mut status);
+        assert!(status.air_quality.interval_configured);
+    }
+
+    #[test]
+    fn interval_command_matches_qingping_down_topic_contract() {
+        assert_eq!(
+            qingping_down_topic("aa:bb-cc:dd:ee:ff"),
+            "qingping/AABBCCDDEEFF/down"
+        );
+
+        let payload = qingping_interval_payload(30);
+
+        assert_eq!(payload["id"], 1);
+        assert_eq!(payload["need_ack"], 1);
+        assert_eq!(payload["type"], "17");
+        assert_eq!(payload["setting"]["report_interval"], 30);
+        assert_eq!(payload["setting"]["collect_interval"], 30);
+        assert_eq!(payload["setting"]["co2_sampling_interval"], 30);
+        assert_eq!(payload["setting"]["pm_sampling_interval"], 30);
     }
 }

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -100,14 +100,12 @@ pub struct RollbackValidationOptions {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MqttCutoverStrategy {
-    BridgeMirror,
     AtomicSwitch,
 }
 
 impl MqttCutoverStrategy {
     fn as_str(self) -> &'static str {
         match self {
-            Self::BridgeMirror => "bridge-mirror",
             Self::AtomicSwitch => "atomic-switch",
         }
     }
@@ -117,7 +115,6 @@ impl MqttCutoverStrategy {
 pub enum MqttRollbackState {
     NotMoved,
     RepointedLegacy,
-    LegacyMirror,
 }
 
 impl MqttRollbackState {
@@ -125,7 +122,6 @@ impl MqttRollbackState {
         match self {
             Self::NotMoved => "not-moved",
             Self::RepointedLegacy => "repointed-legacy",
-            Self::LegacyMirror => "legacy-mirror",
         }
     }
 }
@@ -408,7 +404,7 @@ async fn validate_legacy_controller_stopped(
 
 fn validate_mqtt_cutover_strategy(
     config: &AppConfig,
-    strategy: MqttCutoverStrategy,
+    _strategy: MqttCutoverStrategy,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
     let device_mac = config
@@ -420,14 +416,7 @@ fn validate_mqtt_cutover_strategy(
             "cutover validation requires qingping.device_mac so the active feed can be audited",
         )?;
 
-    let detail = match strategy {
-        MqttCutoverStrategy::BridgeMirror => {
-            "bridge/mirror strategy recorded; active controller must continue receiving mirrored fresh readings"
-        }
-        MqttCutoverStrategy::AtomicSwitch => {
-            "atomic switch strategy recorded; Qingping feed moves in the same window as active-controller cutover"
-        }
-    };
+    let detail = "atomic switch strategy recorded; Qingping feed moves in the same window as active-controller cutover";
     report.push_pass(
         "mqtt-feed-strategy",
         format!(
@@ -864,12 +853,7 @@ fn validate_mqtt_rollback_state(
 
     let detail = match state {
         MqttRollbackState::NotMoved => "Qingping feed never moved off the legacy-compatible path",
-        MqttRollbackState::RepointedLegacy => {
-            "Qingping device or bridge was repointed to the legacy broker"
-        }
-        MqttRollbackState::LegacyMirror => {
-            "bridge/mirror forwarding keeps the legacy controller receiving fresh reports"
-        }
+        MqttRollbackState::RepointedLegacy => "Qingping device was repointed to the legacy broker",
     };
     report.push_pass(
         "mqtt-feed-rollback",
@@ -2291,12 +2275,12 @@ mod tests {
         let mut report = ShadowValidationReport { checks: Vec::new() };
 
         let error =
-            validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::BridgeMirror, &mut report)
+            validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::AtomicSwitch, &mut report)
                 .expect_err("missing device mac should fail");
         assert!(error.to_string().contains("qingping.device_mac"));
 
         config.qingping.device_mac = Some("AA:BB:CC:DD:EE:FF".to_string());
-        validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::BridgeMirror, &mut report)
+        validate_mqtt_cutover_strategy(&config, MqttCutoverStrategy::AtomicSwitch, &mut report)
             .expect("strategy passes");
         let detail = report
             .checks
@@ -2305,7 +2289,7 @@ mod tests {
             .expect("mqtt check")
             .detail
             .as_str();
-        assert!(detail.contains("bridge/mirror strategy"));
+        assert!(detail.contains("atomic switch strategy"));
         assert!(detail.contains("127.0.0.1:1883"));
     }
 


### PR DESCRIPTION
## Summary
- tighten the mainline MQTT and Qingping deployment wiring
- update launchd and cutover docs for the embedded Qingping broker path
- align server, validation, and frontend lockfile changes with the current Rust deployment

## Verification
- rebased onto the latest `origin/main`
- no code changes beyond the committed mainline updates

## Notes
- This PR carries the rebased local `main` commit `fe47400` onto current upstream history.