### PR TITLE
Add Android mTLS device enrollment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ tmp/
 /data/
 client_secret.json
 
+# Local certs / device PKI
+certs/
+
 # tinytuya generated files
 snapshot.json
 tinytuya.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2083,7 +2083,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2810,8 +2810,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3005,6 +3009,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -3267,6 +3273,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -10,6 +12,26 @@ val officeClimateBuildHash = (
         ?: System.getenv("OFFICE_CLIMATE_BUILD_HASH")
         ?: ""
 )
+
+val releaseKeystoreFile = rootProject.file("../certs/android-release.jks")
+val releaseKeystorePropertiesFile = rootProject.file("../certs/android-release.properties")
+val releaseKeystoreProperties = Properties().apply {
+    if (releaseKeystorePropertiesFile.exists()) {
+        releaseKeystorePropertiesFile.inputStream().use { load(it) }
+    }
+}
+val releaseSigningError = when {
+    !releaseKeystoreFile.exists() ->
+        "Missing release keystore at ${releaseKeystoreFile.absolutePath}."
+    !releaseKeystorePropertiesFile.exists() ->
+        "Missing release signing properties at ${releaseKeystorePropertiesFile.absolutePath}."
+    releaseKeystoreProperties.getProperty("storePassword").isNullOrBlank() ->
+        "Missing storePassword in ${releaseKeystorePropertiesFile.absolutePath}."
+    releaseKeystoreProperties.getProperty("keyAlias").isNullOrBlank() ->
+        "Missing keyAlias in ${releaseKeystorePropertiesFile.absolutePath}."
+    else -> null
+}
+val releaseSigningConfigured = releaseSigningError == null
 
 android {
     namespace = "com.rajesh.officeclimate"
@@ -24,10 +46,29 @@ android {
         buildConfigField("String", "APK_HASH", "\"$officeClimateBuildHash\"")
     }
 
+    signingConfigs {
+        if (releaseSigningConfigured) {
+            create("release") {
+                val storePassword = releaseKeystoreProperties.getProperty("storePassword")
+                val keyAlias = releaseKeystoreProperties.getProperty("keyAlias")
+                val keyPassword = releaseKeystoreProperties.getProperty("keyPassword")
+                    ?: storePassword
+
+                storeFile = releaseKeystoreFile
+                this.storePassword = storePassword
+                this.keyAlias = keyAlias
+                this.keyPassword = keyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            if (releaseSigningConfigured) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 
@@ -43,6 +84,18 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+    }
+}
+
+tasks.configureEach {
+    if (name.contains("Release")) {
+        doFirst {
+            if (!releaseSigningConfigured) {
+                throw GradleException(
+                    "$releaseSigningError Create certs/android-release.jks and certs/android-release.properties before building release APKs."
+                )
+            }
+        }
     }
 }
 
@@ -63,6 +116,8 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
+    implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("com.squareup.retrofit2:converter-kotlinx-serialization:2.11.0")

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -1,0 +1,178 @@
+package com.rajesh.officeclimate.data.remote
+
+import android.util.Log
+import kotlinx.coroutines.flow.first
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import java.io.ByteArrayInputStream
+import java.net.Socket
+import java.security.KeyFactory
+import java.security.Principal
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
+
+class HttpClientFactory(
+    private val settingsRepository: com.rajesh.officeclimate.data.repository.SettingsRepository,
+) {
+    suspend fun create(
+        tokenProvider: (() -> String)? = null,
+        includeLogging: Boolean = false,
+        connectTimeoutSeconds: Long = 10,
+        readTimeoutSeconds: Long = 30,
+    ): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .connectTimeout(connectTimeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(readTimeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)
+
+        tokenProvider?.let { provider ->
+            builder.addInterceptor(AuthInterceptor(provider))
+        }
+
+        if (includeLogging) {
+            builder.addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BASIC
+                }
+            )
+        }
+
+        val alias = settingsRepository.deviceCertificateAlias.first().trim()
+        val certificateChainPem = settingsRepository.deviceCertificateChainPem.first().trim()
+        val privateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8.first().trim()
+        if (alias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
+            runCatching { loadClientCertificate(alias, certificateChainPem, privateKeyPkcs8) }
+                .onSuccess { sslConfig ->
+                    sslConfig?.let { (sslSocketFactory, trustManager) ->
+                        builder.sslSocketFactory(sslSocketFactory, trustManager)
+                    }
+                }
+                .onFailure { error ->
+                    Log.w(TAG, "Unable to load enrolled device certificate", error)
+                }
+        }
+
+        return builder.build()
+    }
+
+    private fun loadClientCertificate(
+        alias: String,
+        certificateChainPem: String,
+        privateKeyPkcs8: String,
+    ): Pair<SSLSocketFactory, X509TrustManager>? {
+        val certificateChain = decodeCertificates(certificateChainPem)
+        if (certificateChain.isEmpty()) {
+            return null
+        }
+        val privateKey = decodePrivateKey(privateKeyPkcs8)
+
+        val keyManager = SingleAliasKeyManager(
+            alias = alias,
+            privateKey = privateKey,
+            certificateChain = certificateChain.toTypedArray(),
+        )
+
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+            init(null as KeyStore?)
+        }
+        val trustManager = trustManagerFactory.trustManagers
+            .filterIsInstance<X509TrustManager>()
+            .singleOrNull()
+            ?: return null
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(
+                arrayOf(keyManager),
+                arrayOf(trustManager),
+                SecureRandom(),
+            )
+        }
+
+        return sslContext.socketFactory to trustManager
+    }
+
+    private fun decodeCertificates(certificateChainPem: String): List<X509Certificate> {
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        return certificateFactory.generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+            .filterIsInstance<X509Certificate>()
+    }
+
+    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey {
+        val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8)
+        return KeyFactory.getInstance("EC").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+    }
+
+    private companion object {
+        const val TAG = "HttpClientFactory"
+    }
+
+    private class SingleAliasKeyManager(
+        private val alias: String,
+        private val privateKey: PrivateKey,
+        private val certificateChain: Array<X509Certificate>,
+    ) : X509ExtendedKeyManager() {
+        private val certificateKeyType = certificateChain
+            .firstOrNull()
+            ?.publicKey
+            ?.algorithm
+            ?.uppercase()
+            .orEmpty()
+
+        override fun getClientAliases(keyType: String?, issuers: Array<out Principal>?): Array<String> =
+            if (supportsKeyType(keyType)) arrayOf(alias) else emptyArray()
+
+        override fun chooseClientAlias(
+            keyType: Array<out String>?,
+            issuers: Array<out Principal>?,
+            socket: Socket?,
+        ): String? = alias.takeIf { keyType.orEmpty().any(::supportsKeyType) }
+
+        override fun getServerAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? =
+            null
+
+        override fun chooseServerAlias(
+            keyType: String?,
+            issuers: Array<out Principal>?,
+            socket: Socket?,
+        ): String? = null
+
+        override fun getCertificateChain(requestedAlias: String?): Array<X509Certificate>? =
+            certificateChain.takeIf { requestedAlias == alias }
+
+        override fun getPrivateKey(requestedAlias: String?): PrivateKey? =
+            privateKey.takeIf { requestedAlias == alias }
+
+        override fun chooseEngineClientAlias(
+            keyType: Array<out String>?,
+            issuers: Array<out Principal>?,
+            engine: SSLEngine?,
+        ): String? = alias.takeIf { keyType.orEmpty().any(::supportsKeyType) }
+
+        override fun chooseEngineServerAlias(
+            keyType: String?,
+            issuers: Array<out Principal>?,
+            engine: SSLEngine?,
+        ): String? = null
+
+        private fun supportsKeyType(keyType: String?): Boolean {
+            val requested = keyType?.uppercase().orEmpty()
+            return when (certificateKeyType) {
+                "EC", "ECDSA" -> requested == "EC" || requested == "ECDSA"
+                "RSA" -> requested == "RSA" || requested == "RSASSA-PSS"
+                else -> requested == certificateKeyType
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
@@ -6,12 +6,12 @@ import androidx.core.content.FileProvider
 import com.rajesh.officeclimate.BuildConfig
 import com.rajesh.officeclimate.data.model.AppArtifactMetadata
 import com.rajesh.officeclimate.data.remote.ApiService
+import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import retrofit2.HttpException
 import retrofit2.Retrofit
@@ -19,7 +19,6 @@ import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
 
 data class AvailableAppUpdate(
     val artifactHash: String,
@@ -32,6 +31,7 @@ class AppUpdateRepository(
     private val settingsRepository: SettingsRepository,
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
     @Volatile private var cachedCurrentArtifactHash: String? = null
 
     suspend fun getAvailableUpdate(): AvailableAppUpdate? {
@@ -67,18 +67,21 @@ class AppUpdateRepository(
         val updatesDir = File(context.cacheDir, "updates").apply { mkdirs() }
         val apkFile = File(updatesDir, "office-climate-${update.artifactHash}.apk")
 
-        okHttpClient().newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("Update download failed: HTTP ${response.code}")
-            }
+        httpClientFactory.create(connectTimeoutSeconds = 10, readTimeoutSeconds = 30)
+            .newCall(request)
+            .execute()
+            .use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Update download failed: HTTP ${response.code}")
+                }
 
-            val responseBody = response.body ?: throw IOException("Update download returned no body")
-            responseBody.byteStream().use { input ->
-                apkFile.outputStream().use { output ->
-                    input.copyTo(output)
+                val responseBody = response.body ?: throw IOException("Update download returned no body")
+                responseBody.byteStream().use { input ->
+                    apkFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
                 }
             }
-        }
 
         apkFile
     }
@@ -101,7 +104,11 @@ class AppUpdateRepository(
         try {
             apiService(serverUrl).getAppArtifactMetadata()
         } catch (e: HttpException) {
-            if (e.code() == 404) null else throw e
+            if (e.code() == 404) return@withContext null
+            if (e.code() == 302 || e.code() == 401 || e.code() == 403) {
+                return@withContext null
+            }
+            throw e
         }
     }
 
@@ -136,17 +143,12 @@ class AppUpdateRepository(
             .take(8)
     }
 
-    private fun apiService(serverUrl: String): ApiService {
+    private suspend fun apiService(serverUrl: String): ApiService {
         val retrofit = Retrofit.Builder()
             .baseUrl("$serverUrl/")
-            .client(okHttpClient())
+            .client(httpClientFactory.create(connectTimeoutSeconds = 10, readTimeoutSeconds = 30))
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
         return retrofit.create(ApiService::class.java)
     }
-
-    private fun okHttpClient(): OkHttpClient = OkHttpClient.Builder()
-        .connectTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .build()
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -13,7 +13,7 @@ import com.rajesh.officeclimate.data.model.SessionsResponse
 import com.rajesh.officeclimate.data.model.TemperatureBands
 import com.rajesh.officeclimate.data.model.TemperatureResponse
 import com.rajesh.officeclimate.data.remote.ApiService
-import com.rajesh.officeclimate.data.remote.AuthInterceptor
+import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import com.rajesh.officeclimate.data.remote.WebSocketManager
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.CoroutineScope
@@ -30,11 +30,9 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
-import java.util.concurrent.TimeUnit
 
 class ClimateRepository(
     private val settingsRepository: SettingsRepository,
@@ -48,6 +46,7 @@ class ClimateRepository(
     private lateinit var apiService: ApiService
     private lateinit var wsManager: WebSocketManager
     private var okHttpClient: OkHttpClient? = null
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
 
     private val _status = MutableStateFlow<ApiStatus?>(null)
     val status: StateFlow<ApiStatus?> = _status
@@ -88,18 +87,16 @@ class ClimateRepository(
         if (::wsManager.isInitialized) wsManager.disconnect()
     }
 
-    private fun rebuild(url: String, token: String) {
+    private suspend fun rebuild(url: String, token: String) {
         currentUrl = url
         currentToken = token
 
-        val client = OkHttpClient.Builder()
-            .addInterceptor(AuthInterceptor { currentToken })
-            .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BASIC
-            })
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .build()
+        val client = httpClientFactory.create(
+            tokenProvider = { currentToken },
+            includeLogging = true,
+            connectTimeoutSeconds = 10,
+            readTimeoutSeconds = 10,
+        )
         okHttpClient = client
 
         val retrofit = Retrofit.Builder()
@@ -129,16 +126,23 @@ class ClimateRepository(
                         stop()
                         return@launch
                     }
+                    if (e.code() == 302 || e.code() == 403) {
+                        Log.w(TAG, "Cloudflare Access blocked request (${e.code()})")
+                        _apiConnected.value = false
+                        _error.value = "Cloudflare Access blocked this device. Enroll it with oa register-device."
+                        delay(Defaults.POLL_INTERVAL_MS)
+                        continue
+                    }
                     Log.w(TAG, "Poll failed: ${e.message}")
                     _apiConnected.value = false
                     if (_status.value == null) {
-                        _error.value = e.message ?: "Connection failed"
+                        _error.value = "${e::class.java.simpleName}: ${e.message ?: "Connection failed"}"
                     }
                 } catch (e: Exception) {
                     Log.w(TAG, "Poll failed: ${e.message}")
                     _apiConnected.value = false
                     if (_status.value == null) {
-                        _error.value = e.message ?: "Connection failed"
+                        _error.value = "${e::class.java.simpleName}: ${e.message ?: "Connection failed"}"
                     }
                 }
                 delay(Defaults.POLL_INTERVAL_MS)
@@ -246,11 +250,11 @@ class ClimateRepository(
     }
 
     suspend fun testConnection(url: String, token: String): Result<ApiStatus> = runCatching {
-        val client = OkHttpClient.Builder()
-            .addInterceptor(AuthInterceptor { token })
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.SECONDS)
-            .build()
+        val client = httpClientFactory.create(
+            tokenProvider = { token },
+            connectTimeoutSeconds = 5,
+            readTimeoutSeconds = 5,
+        )
 
         val retrofit = Retrofit.Builder()
             .baseUrl("${url.trimEnd('/')}/")

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -1,0 +1,143 @@
+package com.rajesh.officeclimate.data.repository
+
+import com.rajesh.officeclimate.data.remote.HttpClientFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
+import java.io.StringWriter
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+import java.util.Base64
+import java.util.UUID
+
+@Serializable
+data class DeviceEnrollmentRequest(
+    @SerialName("pairing_code") val pairingCode: String,
+    @SerialName("csr_pem") val csrPem: String,
+    @SerialName("public_key_pem") val publicKeyPem: String,
+)
+
+@Serializable
+data class DeviceEnrollmentResponse(
+    @SerialName("device_id") val deviceId: String,
+    @SerialName("device_name") val deviceName: String,
+    @SerialName("pairing_code") val pairingCode: String,
+    @SerialName("certificate_pem") val certificatePem: String,
+    @SerialName("certificate_chain_pem") val certificateChainPem: String,
+    @SerialName("expires_at") val expiresAt: String,
+)
+
+data class DeviceEnrollmentResult(
+    val alias: String,
+    val deviceId: String,
+    val deviceName: String,
+    val pairingCode: String,
+    val expiresAt: String,
+)
+
+class DeviceEnrollmentRepository(
+    private val settingsRepository: SettingsRepository,
+) {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
+
+    suspend fun enrollDevice(
+        pairingUrl: String,
+        pairingCode: String,
+        deviceName: String,
+    ): DeviceEnrollmentResult = withContext(Dispatchers.IO) {
+        val alias = "office-device-${UUID.randomUUID()}"
+        val keyPair = generateKeyPair()
+        try {
+            val requestBody = DeviceEnrollmentRequest(
+                pairingCode = pairingCode.trim(),
+                csrPem = buildCsrPem(keyPair, deviceName.trim()),
+                publicKeyPem = buildPublicKeyPem(keyPair),
+            )
+            val request = Request.Builder()
+                .url("${pairingUrl.trimEnd('/')}/complete")
+                .post(
+                    json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
+                        .toRequestBody("application/json".toMediaType()),
+                )
+                .build()
+
+            val response = httpClientFactory.create(connectTimeoutSeconds = 10, readTimeoutSeconds = 20)
+                .newCall(request)
+                .execute()
+
+            response.use { result ->
+                val body = result.body?.string().orEmpty()
+                if (!result.isSuccessful) {
+                    val error = runCatching {
+                        json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
+                    }.getOrNull()
+                    throw IllegalStateException(error ?: body.ifBlank { "HTTP ${result.code}" })
+                }
+
+                val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
+                settingsRepository.saveDeviceCertificateChainPem(payload.certificatePem)
+                settingsRepository.saveDevicePrivateKeyPkcs8(encodePrivateKeyPkcs8(keyPair))
+                settingsRepository.saveDeviceCertificateAlias(alias)
+                return@withContext DeviceEnrollmentResult(
+                    alias = alias,
+                    deviceId = payload.deviceId,
+                    deviceName = payload.deviceName,
+                    pairingCode = payload.pairingCode,
+                    expiresAt = payload.expiresAt,
+                )
+            }
+        } catch (e: Exception) {
+            clearDeviceCredential()
+            throw e
+        }
+    }
+
+    private fun generateKeyPair(): KeyPair {
+        val keyPairGenerator = KeyPairGenerator.getInstance("EC")
+        keyPairGenerator.initialize(ECGenParameterSpec("secp256r1"))
+        return keyPairGenerator.generateKeyPair()
+    }
+
+    private fun buildCsrPem(keyPair: KeyPair, deviceName: String): String {
+        val subject = X500Name("CN=${deviceName.ifBlank { "Office Automate Device" }}")
+        val builder = JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
+        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+        val csr: PKCS10CertificationRequest = builder.build(signer)
+        val writer = StringWriter()
+        JcaPEMWriter(writer).use { pemWriter ->
+            pemWriter.writeObject(csr)
+        }
+        return writer.toString()
+    }
+
+    private fun buildPublicKeyPem(keyPair: KeyPair): String {
+        val writer = StringWriter()
+        JcaPEMWriter(writer).use { pemWriter ->
+            pemWriter.writeObject(keyPair.public)
+        }
+        return writer.toString()
+    }
+
+    private fun encodePrivateKeyPkcs8(keyPair: KeyPair): String =
+        Base64.getEncoder().encodeToString(keyPair.private.encoded)
+
+    private suspend fun clearDeviceCredential() {
+        settingsRepository.clearDeviceCertificateAlias()
+        settingsRepository.clearDeviceCertificateChainPem()
+        settingsRepository.clearDevicePrivateKeyPkcs8()
+    }
+}

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -19,6 +19,9 @@ class SettingsRepository(private val context: Context) {
         val SERVER_URL = stringPreferencesKey("server_url")
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_EMAIL = stringPreferencesKey("user_email")
+        val DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("device_certificate_alias")
+        val DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("device_certificate_chain_pem")
+        val DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
         val DISMISSED_APP_NOTIFICATION_IDS = stringSetPreferencesKey("dismissed_app_notification_ids")
     }
@@ -35,8 +38,29 @@ class SettingsRepository(private val context: Context) {
         prefs[Keys.USER_EMAIL] ?: ""
     }
 
+    val deviceCertificateAlias: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DEVICE_CERTIFICATE_ALIAS] ?: ""
+    }
+
+    val deviceCertificateChainPem: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
+    }
+
+    val devicePrivateKeyPkcs8: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] ?: ""
+    }
+
     val isLoggedIn: Flow<Boolean> = context.dataStore.data.map { prefs ->
         !prefs[Keys.JWT_TOKEN].isNullOrBlank()
+    }
+
+    val isAuthenticated: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        !prefs[Keys.JWT_TOKEN].isNullOrBlank() ||
+            (
+                !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
+                    !prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM].isNullOrBlank() &&
+                    !prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8].isNullOrBlank()
+                )
     }
 
     val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->
@@ -57,6 +81,42 @@ class SettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[Keys.JWT_TOKEN] = token
             prefs[Keys.USER_EMAIL] = email
+        }
+    }
+
+    suspend fun saveDeviceCertificateAlias(alias: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DEVICE_CERTIFICATE_ALIAS] = alias.trim()
+        }
+    }
+
+    suspend fun saveDeviceCertificateChainPem(chainPem: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM] = chainPem.trim()
+        }
+    }
+
+    suspend fun saveDevicePrivateKeyPkcs8(privateKeyPkcs8: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
+        }
+    }
+
+    suspend fun clearDeviceCertificateAlias() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
+        }
+    }
+
+    suspend fun clearDeviceCertificateChainPem() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(Keys.DEVICE_CERTIFICATE_CHAIN_PEM)
+        }
+    }
+
+    suspend fun clearDevicePrivateKeyPkcs8() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(Keys.DEVICE_PRIVATE_KEY_PKCS8)
         }
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
@@ -68,9 +68,9 @@ fun AppNavigation(authResult: StateFlow<MainActivity.AuthResult?>) {
     val navController = rememberNavController()
     val context = LocalContext.current
     val settingsRepo = SettingsRepository(context)
-    val isLoggedIn by settingsRepo.isLoggedIn.collectAsState(initial = null)
+    val isAuthenticated by settingsRepo.isAuthenticated.collectAsState(initial = null)
 
-    val startDestination = when (isLoggedIn) {
+    val startDestination = when (isAuthenticated) {
         true -> Routes.DASHBOARD
         false -> Routes.SETTINGS
         null -> return // Still loading

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -46,6 +47,7 @@ fun SettingsScreen(
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     var showServerUrl by remember { mutableStateOf(false) }
+    var showAdvancedEnrollment by remember { mutableStateOf(false) }
 
     val textFieldColors = OutlinedTextFieldDefaults.colors(
         focusedBorderColor = Emerald,
@@ -74,7 +76,11 @@ fun SettingsScreen(
         Spacer(Modifier.height(8.dp))
 
         Text(
-            text = if (state.isLoggedIn) "Signed in as ${state.userEmail}" else "Sign in to your climate server",
+            text = when {
+                state.deviceCertificateAlias.isNotBlank() -> "Device enrolled as ${state.deviceCertificateAlias}"
+                state.isLoggedIn -> "Signed in as ${state.userEmail}"
+                else -> "Sign in to your climate server"
+            },
             style = MaterialTheme.typography.bodyMedium,
             color = if (state.isLoggedIn) Emerald else TextSecondary,
         )
@@ -94,7 +100,67 @@ fun SettingsScreen(
             )
         }
 
+        Spacer(Modifier.height(16.dp))
+
+        TextButton(
+            onClick = { showAdvancedEnrollment = !showAdvancedEnrollment },
+        ) {
+            Text(if (showAdvancedEnrollment) "Hide Advanced" else "Advanced")
+        }
+
+        if (showAdvancedEnrollment) {
+            OutlinedTextField(
+                value = state.pairingUrl,
+                onValueChange = viewModel::updatePairingUrl,
+                label = { Text("Pairing URL") },
+                placeholder = { Text("http://192.168.5.10:19191") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                modifier = Modifier.fillMaxWidth(),
+                colors = textFieldColors,
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = state.pairingCode,
+            onValueChange = viewModel::updatePairingCode,
+            label = { Text("Pairing Code") },
+            placeholder = { Text("ABC123") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            colors = textFieldColors,
+        )
+
         Spacer(Modifier.height(24.dp))
+
+        Button(
+            onClick = viewModel::enrollDevice,
+            enabled = !state.enrolling && state.pairingUrl.isNotBlank() && state.pairingCode.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(containerColor = Emerald),
+        ) {
+            if (state.enrolling) {
+                CircularProgressIndicator(
+                    modifier = Modifier.height(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.background,
+                )
+            } else {
+                Text("Enroll Device", color = MaterialTheme.colorScheme.background)
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        state.enrollmentStatus?.let { message ->
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = Emerald,
+            )
+        }
 
         if (state.isLoggedIn) {
             Button(
@@ -107,12 +173,14 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(12.dp))
 
-            OutlinedButton(
-                onClick = viewModel::logout,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.outlinedButtonColors(contentColor = Red),
-            ) {
-                Text("Sign Out")
+            if (state.userEmail.isNotBlank()) {
+                OutlinedButton(
+                    onClick = viewModel::logout,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Red),
+                ) {
+                    Text("Sign Out")
+                }
             }
         } else {
             Button(
@@ -135,7 +203,7 @@ fun SettingsScreen(
                         color = MaterialTheme.colorScheme.background,
                     )
                 } else {
-                    Text("Sign in with Google", color = MaterialTheme.colorScheme.background)
+                    Text("Browser Sign-In", color = MaterialTheme.colorScheme.background)
                 }
             }
         }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
@@ -3,7 +3,9 @@ package com.rajesh.officeclimate.ui.settings
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.rajesh.officeclimate.data.repository.DeviceEnrollmentRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
+import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,20 +15,25 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import okhttp3.OkHttpClient
 import okhttp3.Request
-import java.util.concurrent.TimeUnit
 
 data class SettingsUiState(
     val serverUrl: String = Defaults.SERVER_URL,
     val userEmail: String = "",
     val isLoggedIn: Boolean = false,
+    val deviceCertificateAlias: String = "",
+    val pairingUrl: String = Defaults.DEVICE_PAIRING_URL,
+    val pairingCode: String = "",
     val loading: Boolean = false,
+    val enrolling: Boolean = false,
     val error: String? = null,
+    val enrollmentStatus: String? = null,
 )
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepo = SettingsRepository(application)
+    private val httpClientFactory = HttpClientFactory(settingsRepo)
+    private val deviceEnrollmentRepository = DeviceEnrollmentRepository(settingsRepo)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -36,7 +43,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             _uiState.value = _uiState.value.copy(
                 serverUrl = settingsRepo.serverUrl.first(),
                 userEmail = settingsRepo.userEmail.first(),
-                isLoggedIn = settingsRepo.jwtToken.first().isNotBlank(),
+                isLoggedIn = settingsRepo.isAuthenticated.first(),
+                deviceCertificateAlias = settingsRepo.deviceCertificateAlias.first(),
+                pairingUrl = Defaults.DEVICE_PAIRING_URL,
             )
         }
     }
@@ -45,9 +54,48 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _uiState.value = _uiState.value.copy(serverUrl = url, error = null)
     }
 
+    fun updatePairingUrl(url: String) {
+        _uiState.value = _uiState.value.copy(pairingUrl = url, error = null, enrollmentStatus = null)
+    }
+
+    fun updatePairingCode(code: String) {
+        _uiState.value = _uiState.value.copy(pairingCode = code.uppercase(), error = null, enrollmentStatus = null)
+    }
+
     fun saveServerUrl() {
         viewModelScope.launch {
             settingsRepo.saveServerUrl(_uiState.value.serverUrl)
+        }
+    }
+
+    fun enrollDevice() {
+        val state = _uiState.value
+        if (state.pairingUrl.isBlank() || state.pairingCode.isBlank()) {
+            _uiState.value = state.copy(error = "Enter a pairing URL and code first.")
+            return
+        }
+
+        _uiState.value = state.copy(enrolling = true, error = null, enrollmentStatus = null)
+        viewModelScope.launch {
+            try {
+                val result = deviceEnrollmentRepository.enrollDevice(
+                    pairingUrl = state.pairingUrl,
+                    pairingCode = state.pairingCode,
+                    deviceName = "Android ${android.os.Build.MODEL}".trim(),
+                )
+                _uiState.value = _uiState.value.copy(
+                    enrolling = false,
+                    deviceCertificateAlias = result.alias,
+                    isLoggedIn = true,
+                    enrollmentStatus = "Device enrolled as ${result.deviceName}.",
+                    error = null,
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    enrolling = false,
+                    error = "Device enrollment failed: ${e.message}",
+                )
+            }
         }
     }
 
@@ -59,18 +107,20 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             try {
                 settingsRepo.saveServerUrl(state.serverUrl)
                 val url = "${state.serverUrl.trimEnd('/')}/auth/login?platform=android"
-                val client = OkHttpClient.Builder()
-                    .connectTimeout(10, TimeUnit.SECONDS)
-                    .followRedirects(false)
-                    .build()
+                val client = httpClientFactory.create(connectTimeoutSeconds = 10, readTimeoutSeconds = 10)
                 val request = Request.Builder().url(url).build()
                 val response = client.newCall(request).execute()
                 val body = response.body?.string() ?: ""
 
-                val json = Json { ignoreUnknownKeys = true }
-                val payload = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull()
-
                 if (!response.isSuccessful) {
+                    val location = response.header("Location").orEmpty()
+                    if (response.code in 300..399 || location.contains("/cdn-cgi/access/login/")) {
+                        throw IllegalStateException(
+                            "Cloudflare Access blocked Android bootstrap. Enroll the device with oa register-device, then retry.",
+                        )
+                    }
+                    val json = Json { ignoreUnknownKeys = true }
+                    val payload = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull()
                     val errorMessage = payload
                         ?.get("error")
                         ?.jsonPrimitive
@@ -79,6 +129,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                     throw IllegalStateException(errorMessage)
                 }
 
+                val json = Json { ignoreUnknownKeys = true }
+                val payload = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull()
                 val authUrl = payload
                     ?.get("authorization_url")
                     ?.jsonPrimitive
@@ -112,9 +164,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun logout() {
         viewModelScope.launch {
             settingsRepo.clearAuth()
+            val deviceCertificateAlias = settingsRepo.deviceCertificateAlias.first()
             _uiState.value = _uiState.value.copy(
                 userEmail = "",
-                isLoggedIn = false,
+                isLoggedIn = deviceCertificateAlias.isNotBlank(),
             )
         }
     }

--- a/android/app/src/main/java/com/rajesh/officeclimate/util/Constants.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/util/Constants.kt
@@ -8,6 +8,7 @@ object Thresholds {
 
 object Defaults {
     const val SERVER_URL = "https://office.rajeshgo.li"
+    const val DEVICE_PAIRING_URL = "http://192.168.5.10:19191"
     const val POLL_INTERVAL_MS = 5000L
     const val WS_RECONNECT_BASE_MS = 3000L
     const val WS_RECONNECT_MAX_MS = 30000L

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -24,13 +24,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-tungstenite = "0.29"
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 urlencoding = "2"
 
 [dev-dependencies]
-tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/rust/office-automate-server/src/artifacts.rs
+++ b/rust/office-automate-server/src/artifacts.rs
@@ -122,6 +122,14 @@ impl ArtifactStore {
             Response::builder()
                 .status(StatusCode::OK)
                 .header(
+                    header::CONTENT_TYPE,
+                    "application/vnd.android.package-archive",
+                )
+                .header(
+                    header::HeaderName::from_static("x-content-type-options"),
+                    "nosniff",
+                )
+                .header(
                     header::CONTENT_DISPOSITION,
                     "attachment; filename=office-climate.apk",
                 )
@@ -150,6 +158,14 @@ impl ArtifactStore {
         Ok(Some(
             Response::builder()
                 .status(StatusCode::OK)
+                .header(
+                    header::CONTENT_TYPE,
+                    "application/vnd.android.package-archive",
+                )
+                .header(
+                    header::HeaderName::from_static("x-content-type-options"),
+                    "nosniff",
+                )
                 .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
                 .header(
                     header::CONTENT_DISPOSITION,

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -10,9 +10,12 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use base64::{Engine, engine::general_purpose};
 use chrono::{TimeDelta, Utc};
 use ipnet::IpNet;
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, decode_header, encode,
+    jwk::JwkSet,
+};
 use rand::{RngCore, rngs::OsRng};
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -99,6 +102,16 @@ struct Claims {
     email: String,
     exp: usize,
     iat: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CloudflareAccessClaims {
+    pub sub: String,
+    pub exp: usize,
+    pub iat: usize,
+    pub iss: String,
+    #[serde(default)]
+    pub common_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -199,6 +212,48 @@ impl AuthManager {
         let token = bearer_token(headers)?;
         self.verify_jwt(token)
             .map(|email| AuthenticatedUser { email })
+    }
+
+    pub async fn verify_cloudflare_access_assertion(
+        &self,
+        token: &str,
+    ) -> Option<CloudflareAccessClaims> {
+        let header = decode_header(token).ok()?;
+        let kid = header.kid.as_deref()?;
+        let untrusted_claims = Self::decode_cloudflare_access_assertion_unverified(token)?;
+        let issuer = cloudflare_access_issuer_url(&untrusted_claims.iss)?;
+        let jwks_url = issuer.join("/cdn-cgi/access/certs").ok()?;
+        let jwks = self
+            .inner
+            .client
+            .get(jwks_url)
+            .send()
+            .await
+            .ok()?
+            .error_for_status()
+            .ok()?
+            .json::<JwkSet>()
+            .await
+            .ok()?;
+        let key = DecodingKey::from_jwk(jwks.find(kid)?).ok()?;
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_aud = false;
+        validation.set_issuer(&[issuer.as_str().trim_end_matches('/')]);
+        decode::<CloudflareAccessClaims>(token, &key, &validation)
+            .ok()
+            .map(|decoded| decoded.claims)
+    }
+
+    fn decode_cloudflare_access_assertion_unverified(
+        token: &str,
+    ) -> Option<CloudflareAccessClaims> {
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.insecure_disable_signature_validation();
+        validation.validate_aud = false;
+        validation.validate_exp = false;
+        decode::<CloudflareAccessClaims>(token, &DecodingKey::from_secret(&[]), &validation)
+            .ok()
+            .map(|decoded| decoded.claims)
     }
 
     pub fn verify_basic_header(&self, headers: &HeaderMap) -> bool {
@@ -670,6 +725,19 @@ fn prune_expired_tokens_at(
     tokens.retain(|_, expires_at| *expires_at > now);
 }
 
+fn cloudflare_access_issuer_url(issuer: &str) -> Option<Url> {
+    let url = Url::parse(issuer).ok()?;
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = url.host_str()?.to_ascii_lowercase();
+    if host == "cloudflareaccess.com" || host.ends_with(".cloudflareaccess.com") {
+        Some(url)
+    } else {
+        None
+    }
+}
+
 fn generate_pkce_pair() -> (String, String) {
     let code_verifier = random_url_token(32);
     let challenge = Sha256::digest(code_verifier.as_bytes());
@@ -784,6 +852,15 @@ mod tests {
         );
 
         assert!(manager.verify_basic_header(&headers));
+    }
+
+    #[test]
+    fn cloudflare_access_issuer_guard_rejects_non_cloudflare_hosts() {
+        assert!(cloudflare_access_issuer_url("https://team.cloudflareaccess.com").is_some());
+        assert!(cloudflare_access_issuer_url("https://rajeshgoli.cloudflareaccess.com").is_some());
+        assert!(cloudflare_access_issuer_url("http://rajeshgoli.cloudflareaccess.com").is_none());
+        assert!(cloudflare_access_issuer_url("https://cloudflareaccess.com.evil.test").is_none());
+        assert!(cloudflare_access_issuer_url("https://example.test").is_none());
     }
 
     #[test]

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
+use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
     config::AppConfig,
-    db, edge, erv, http, hvac, migration, presence, telemetry,
+    db, device, edge, erv, http, hvac, migration, presence, telemetry,
     validation::{
         self, CutoverValidationOptions, MqttCutoverStrategy, MqttRollbackState,
         RestoreVerification, RollbackValidationOptions, ShadowValidationOptions,
@@ -28,6 +28,12 @@ pub enum Command {
     ServeEdge(EdgeConfigArgs),
     /// Create or upgrade the SQLite schema.
     Migrate(ConfigArgs),
+    /// Register a new device pairing code.
+    RegisterDevice(RegisterDeviceArgs),
+    /// List enrolled device registrations.
+    ListDevices(ConfigArgs),
+    /// Revoke an enrolled device registration.
+    RevokeDevice(RevokeDeviceArgs),
     /// Run local dependency checks without changing device state.
     Smoke(SmokeArgs),
     /// Run local telemetry collectors.
@@ -64,6 +70,30 @@ pub struct CollectArgs {
     pub config: Option<PathBuf>,
     #[command(subcommand)]
     pub target: CollectTarget,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct RegisterDeviceArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[arg(long)]
+    pub device_name: String,
+    #[arg(long, default_value_t = 15)]
+    pub expires_in_minutes: i64,
+    #[arg(long, default_value = "0.0.0.0:19191")]
+    pub listen: SocketAddr,
+    #[arg(long, env = "OFFICE_AUTOMATE_DEVICE_CA_CERT")]
+    pub device_ca_cert: Option<PathBuf>,
+    #[arg(long, env = "OFFICE_AUTOMATE_DEVICE_CA_KEY")]
+    pub device_ca_key: Option<PathBuf>,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct RevokeDeviceArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[arg(long)]
+    pub device_id: String,
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -300,6 +330,56 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Migrate(args) => {
             let config = AppConfig::load(&args.config)?;
             db::migrate(&config)?;
+            Ok(())
+        }
+        Command::RegisterDevice(args) => {
+            let config = AppConfig::load(&args.config)?;
+            let device = device::register_device(
+                &config.runtime.database_path,
+                &args.device_name,
+                args.expires_in_minutes,
+            )?;
+            println!(
+                "device registered: device_id={} pairing_code={} expires_at={} listen={}",
+                device.device_id, device.pairing_code, device.expires_at, args.listen
+            );
+            device::serve_pairing_listener(
+                config.runtime.database_path,
+                args.listen,
+                args.device_ca_cert,
+                args.device_ca_key,
+            )
+            .await
+        }
+        Command::ListDevices(args) => {
+            let config = AppConfig::load(&args.config)?;
+            let devices = device::list_devices(&config.runtime.database_path)?;
+            if devices.is_empty() {
+                println!("no device registrations found");
+            } else {
+                for device in devices {
+                    println!(
+                        "device_id={} name={} code={} paired_at={} revoked_at={} expires_at={} fingerprint={}",
+                        device.device_id,
+                        device.device_name,
+                        device.pairing_code,
+                        device.paired_at.as_deref().unwrap_or("-"),
+                        device.revoked_at.as_deref().unwrap_or("-"),
+                        device.expires_at,
+                        device.public_key_fingerprint.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+            Ok(())
+        }
+        Command::RevokeDevice(args) => {
+            let config = AppConfig::load(&args.config)?;
+            let revoked = device::revoke_device(&config.runtime.database_path, &args.device_id)?;
+            if revoked {
+                println!("device revoked: {}", args.device_id);
+            } else {
+                println!("device not found or already revoked: {}", args.device_id);
+            }
             Ok(())
         }
         Command::Smoke(args) => {

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -5,10 +5,13 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use base64::{Engine, engine::general_purpose};
 use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, Timelike};
+use rand::{RngCore, rngs::OsRng};
 use rusqlite::{Connection, OptionalExtension, params, types::ValueRef};
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use crate::{config::AppConfig, qingping::QingpingReading};
 
@@ -141,6 +144,23 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
                 updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
             );
 
+            CREATE TABLE IF NOT EXISTS device_registrations (
+                device_id TEXT PRIMARY KEY,
+                device_name TEXT NOT NULL,
+                pairing_code TEXT NOT NULL UNIQUE,
+                public_key_fingerprint TEXT,
+                common_name TEXT,
+                created_at DATETIME NOT NULL,
+                expires_at DATETIME NOT NULL,
+                paired_at DATETIME,
+                revoked_at DATETIME
+            );
+            CREATE INDEX IF NOT EXISTS idx_device_registrations_created_at ON device_registrations(created_at);
+            CREATE INDEX IF NOT EXISTS idx_device_registrations_expires_at ON device_registrations(expires_at);
+            CREATE INDEX IF NOT EXISTS idx_device_registrations_revoked_at ON device_registrations(revoked_at);
+            CREATE INDEX IF NOT EXISTS idx_device_registrations_common_name ON device_registrations(common_name);
+            CREATE INDEX IF NOT EXISTS idx_device_registrations_device_name ON device_registrations(device_name);
+
             CREATE TABLE IF NOT EXISTS schema_migrations (
                 version INTEGER PRIMARY KEY,
                 name TEXT NOT NULL,
@@ -215,6 +235,341 @@ where
         .with_context(|| format!("failed to write app setting {key}"))?;
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeviceRegistration {
+    pub device_id: String,
+    pub device_name: String,
+    pub pairing_code: String,
+    pub public_key_fingerprint: Option<String>,
+    pub common_name: Option<String>,
+    pub created_at: String,
+    pub expires_at: String,
+    pub paired_at: Option<String>,
+    pub revoked_at: Option<String>,
+}
+
+pub fn create_device_registration(
+    database_path: &Path,
+    device_name: &str,
+    expires_in_minutes: i64,
+) -> Result<DeviceRegistration> {
+    if let Some(parent) = database_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create data directory {}", parent.display()))?;
+    }
+
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let created_at = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let expires_at = (chrono::Local::now() + chrono::Duration::minutes(expires_in_minutes))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    let registration = DeviceRegistration {
+        device_id: random_device_id(),
+        device_name: device_name.trim().to_string(),
+        pairing_code: random_pairing_code(),
+        public_key_fingerprint: None,
+        common_name: None,
+        created_at,
+        expires_at,
+        paired_at: None,
+        revoked_at: None,
+    };
+
+    connection
+        .execute(
+            r#"
+            INSERT INTO device_registrations (
+                device_id, device_name, pairing_code, public_key_fingerprint,
+                common_name, created_at, expires_at, paired_at, revoked_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            params![
+                registration.device_id,
+                registration.device_name,
+                registration.pairing_code,
+                registration.public_key_fingerprint,
+                registration.common_name,
+                registration.created_at,
+                registration.expires_at,
+                registration.paired_at,
+                registration.revoked_at,
+            ],
+        )
+        .context("failed to create device registration")?;
+
+    Ok(registration)
+}
+
+pub fn list_device_registrations(database_path: &Path) -> Result<Vec<DeviceRegistration>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let mut statement = connection
+        .prepare(
+            r#"
+            SELECT device_id, device_name, pairing_code, public_key_fingerprint,
+                   common_name, created_at, expires_at, paired_at, revoked_at
+            FROM device_registrations
+            ORDER BY created_at DESC
+            "#,
+        )
+        .context("failed to prepare device registration list query")?;
+
+    let rows = statement
+        .query_map([], |row| {
+            Ok(DeviceRegistration {
+                device_id: row.get(0)?,
+                device_name: row.get(1)?,
+                pairing_code: row.get(2)?,
+                public_key_fingerprint: row.get(3)?,
+                common_name: row.get(4)?,
+                created_at: row.get(5)?,
+                expires_at: row.get(6)?,
+                paired_at: row.get(7)?,
+                revoked_at: row.get(8)?,
+            })
+        })
+        .context("failed to query device registrations")?;
+
+    let mut devices = Vec::new();
+    for row in rows {
+        devices.push(row.context("failed to read device registration row")?);
+    }
+    Ok(devices)
+}
+
+pub fn pending_device_registration_by_pairing_code(
+    database_path: &Path,
+    pairing_code: &str,
+) -> Result<Option<DeviceRegistration>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    connection
+        .query_row(
+            r#"
+            SELECT device_id, device_name, pairing_code, public_key_fingerprint,
+                   common_name, created_at, expires_at, paired_at, revoked_at
+            FROM device_registrations
+            WHERE pairing_code = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NULL
+              AND expires_at > ?
+            "#,
+            params![pairing_code, now],
+            |row| {
+                Ok(DeviceRegistration {
+                    device_id: row.get(0)?,
+                    device_name: row.get(1)?,
+                    pairing_code: row.get(2)?,
+                    public_key_fingerprint: row.get(3)?,
+                    common_name: row.get(4)?,
+                    created_at: row.get(5)?,
+                    expires_at: row.get(6)?,
+                    paired_at: row.get(7)?,
+                    revoked_at: row.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .context("failed to check device registration eligibility")
+}
+
+pub fn find_active_device_registration_by_common_name(
+    database_path: &Path,
+    common_name: &str,
+) -> Result<Option<DeviceRegistration>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let mut statement = connection
+        .prepare(
+            r#"
+            SELECT device_id, device_name, pairing_code, public_key_fingerprint,
+                   common_name, created_at, expires_at, paired_at, revoked_at
+            FROM device_registrations
+            WHERE common_name = ?
+              AND paired_at IS NOT NULL
+              AND revoked_at IS NULL
+            ORDER BY paired_at DESC
+            LIMIT 2
+            "#,
+        )
+        .context("failed to prepare active device lookup query")?;
+    let rows = statement
+        .query_map(params![common_name], |row| {
+            Ok(DeviceRegistration {
+                device_id: row.get(0)?,
+                device_name: row.get(1)?,
+                pairing_code: row.get(2)?,
+                public_key_fingerprint: row.get(3)?,
+                common_name: row.get(4)?,
+                created_at: row.get(5)?,
+                expires_at: row.get(6)?,
+                paired_at: row.get(7)?,
+                revoked_at: row.get(8)?,
+            })
+        })
+        .with_context(|| format!("failed to look up active device common name {common_name}"))?;
+
+    let mut devices = Vec::new();
+    for row in rows {
+        devices.push(row.context("failed to read active device registration row")?);
+    }
+
+    match devices.len() {
+        0 => Ok(None),
+        1 => Ok(devices.pop()),
+        _ => {
+            anyhow::bail!(
+                "multiple active device registrations share common name {common_name}; revoke stale registrations before accepting mTLS"
+            );
+        }
+    }
+}
+
+pub fn revoke_device_registration(database_path: &Path, device_id: &str) -> Result<bool> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let updated_at = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let changed = connection
+        .execute(
+            r#"
+            UPDATE device_registrations
+            SET revoked_at = ?
+            WHERE device_id = ? AND revoked_at IS NULL
+            "#,
+            params![updated_at, device_id],
+        )
+        .with_context(|| format!("failed to revoke device {device_id}"))?;
+    Ok(changed > 0)
+}
+
+pub fn complete_device_registration(
+    database_path: &Path,
+    pairing_code: &str,
+    public_key: &str,
+    common_name: &str,
+) -> Result<Option<DeviceRegistration>> {
+    if common_name.trim().is_empty() {
+        anyhow::bail!("device certificate common name must not be empty");
+    }
+
+    let fingerprint = fingerprint_public_key(public_key);
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let device_name = match connection
+        .query_row(
+            r#"
+            SELECT device_name
+            FROM device_registrations
+            WHERE pairing_code = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NULL
+              AND expires_at > ?
+            "#,
+            params![pairing_code, now],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .context("failed to check device registration eligibility")?
+    {
+        Some(device_name) => device_name,
+        None => return Ok(None),
+    };
+    connection
+        .execute(
+            r#"
+            UPDATE device_registrations
+            SET revoked_at = ?
+            WHERE device_name = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NOT NULL
+            "#,
+            params![now, device_name],
+        )
+        .with_context(|| {
+            format!("failed to revoke prior registrations for device name {device_name}")
+        })?;
+    let changed = connection
+        .execute(
+            r#"
+            UPDATE device_registrations
+            SET public_key_fingerprint = ?,
+                common_name = ?,
+                paired_at = ?
+            WHERE pairing_code = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NULL
+              AND expires_at > ?
+            "#,
+            params![fingerprint, common_name, now, pairing_code, now],
+        )
+        .with_context(|| {
+            format!("failed to complete registration for pairing code {pairing_code}")
+        })?;
+
+    if changed == 0 {
+        return Ok(None);
+    }
+
+    let registration = connection
+        .query_row(
+            r#"
+            SELECT device_id, device_name, pairing_code, public_key_fingerprint,
+                   common_name, created_at, expires_at, paired_at, revoked_at
+            FROM device_registrations
+            WHERE pairing_code = ?
+            "#,
+            params![pairing_code],
+            |row| {
+                Ok(DeviceRegistration {
+                    device_id: row.get(0)?,
+                    device_name: row.get(1)?,
+                    pairing_code: row.get(2)?,
+                    public_key_fingerprint: row.get(3)?,
+                    common_name: row.get(4)?,
+                    created_at: row.get(5)?,
+                    expires_at: row.get(6)?,
+                    paired_at: row.get(7)?,
+                    revoked_at: row.get(8)?,
+                })
+            },
+        )
+        .context("failed to reload completed device registration")?;
+
+    Ok(Some(registration))
+}
+
+fn random_device_id() -> String {
+    random_url_token(16)
+}
+
+fn random_pairing_code() -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    let mut bytes = [0_u8; 6];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|byte| ALPHABET[(*byte as usize) % ALPHABET.len()] as char)
+        .collect()
+}
+
+fn fingerprint_public_key(public_key: &str) -> String {
+    let digest = Sha256::digest(public_key.as_bytes());
+    digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn random_url_token(byte_len: usize) -> String {
+    let mut bytes = vec![0_u8; byte_len];
+    OsRng.fill_bytes(&mut bytes);
+    general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) -> Result<()> {
@@ -1909,6 +2264,81 @@ mod tests {
             .expect("read setting")
             .expect("value");
         assert_eq!(stored, value);
+    }
+
+    #[test]
+    fn device_registration_round_trip() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let registration =
+            create_device_registration(&db_path, "phone", 15).expect("create registration");
+        assert_eq!(registration.device_name, "phone");
+        assert_eq!(registration.paired_at, None);
+        assert_eq!(registration.revoked_at, None);
+        assert_eq!(registration.pairing_code.len(), 6);
+
+        let devices = list_device_registrations(&db_path).expect("list devices");
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].device_id, registration.device_id);
+
+        let completed = complete_device_registration(
+            &db_path,
+            &registration.pairing_code,
+            "public-key",
+            "device-1",
+        )
+        .expect("complete registration")
+        .expect("registration completed");
+        assert_eq!(completed.common_name.as_deref(), Some("device-1"));
+
+        let active = find_active_device_registration_by_common_name(&db_path, "device-1")
+            .expect("find active device")
+            .expect("active device");
+        assert_eq!(active.device_id, registration.device_id);
+
+        let replacement =
+            create_device_registration(&db_path, "phone", 15).expect("create replacement");
+        let replacement_completed = complete_device_registration(
+            &db_path,
+            &replacement.pairing_code,
+            "replacement-key",
+            "device-2",
+        )
+        .expect("complete replacement")
+        .expect("replacement completed");
+        assert_eq!(
+            replacement_completed.common_name.as_deref(),
+            Some("device-2")
+        );
+
+        let old_active = find_active_device_registration_by_common_name(&db_path, "device-1")
+            .expect("find active original after replacement");
+        assert!(old_active.is_none());
+
+        let active = find_active_device_registration_by_common_name(&db_path, "device-2")
+            .expect("find active replacement")
+            .expect("active replacement");
+        assert_eq!(active.device_id, replacement.device_id);
+
+        let devices = list_device_registrations(&db_path).expect("list devices after replacement");
+        let replaced = devices
+            .iter()
+            .find(|device| device.device_id == registration.device_id)
+            .expect("original device");
+        assert!(replaced.revoked_at.is_some());
+
+        let revoked =
+            revoke_device_registration(&db_path, &replacement.device_id).expect("revoke device");
+        assert!(revoked);
+
+        let devices = list_device_registrations(&db_path).expect("list devices after revoke");
+        assert!(devices.iter().all(|device| device.revoked_at.is_some()));
+        let active_after_revoke =
+            find_active_device_registration_by_common_name(&db_path, "device-2")
+                .expect("find active device after revoke");
+        assert!(active_after_revoke.is_none());
     }
 
     #[test]

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -1,0 +1,240 @@
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+
+use crate::db::{self, DeviceRegistration};
+
+const DEFAULT_DEVICE_CA_CERT: &str = "/Users/rajesh/.office-automate/device-ca/device-ca.pem";
+const DEFAULT_DEVICE_CA_KEY: &str = "/Users/rajesh/.office-automate/device-ca/device-ca.key";
+
+#[derive(Debug, Clone)]
+struct PairingState {
+    database_path: PathBuf,
+    ca_cert_path: PathBuf,
+    ca_key_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompleteDeviceRequest {
+    pub pairing_code: String,
+    pub csr_pem: String,
+    pub public_key_pem: String,
+    #[serde(default)]
+    pub common_name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompleteDeviceResponse {
+    pub device_id: String,
+    pub device_name: String,
+    pub pairing_code: String,
+    pub common_name: Option<String>,
+    pub certificate_pem: String,
+    pub certificate_chain_pem: String,
+    pub expires_at: String,
+}
+
+pub fn register_device(
+    database_path: &Path,
+    device_name: &str,
+    expires_in_minutes: i64,
+) -> Result<DeviceRegistration> {
+    if device_name.trim().is_empty() {
+        bail!("device name must not be empty");
+    }
+    db::create_device_registration(database_path, device_name, expires_in_minutes)
+}
+
+pub fn list_devices(database_path: &Path) -> Result<Vec<DeviceRegistration>> {
+    db::list_device_registrations(database_path)
+}
+
+pub fn revoke_device(database_path: &Path, device_id: &str) -> Result<bool> {
+    db::revoke_device_registration(database_path, device_id)
+}
+
+pub async fn serve_pairing_listener(
+    database_path: PathBuf,
+    bind_addr: SocketAddr,
+    ca_cert_path: Option<PathBuf>,
+    ca_key_path: Option<PathBuf>,
+) -> Result<()> {
+    let state = PairingState {
+        database_path,
+        ca_cert_path: ca_cert_path.unwrap_or_else(default_device_ca_cert_path),
+        ca_key_path: ca_key_path.unwrap_or_else(default_device_ca_key_path),
+    };
+
+    let app = Router::new()
+        .route("/health", get(pairing_health))
+        .route("/complete", post(complete_device_pairing))
+        .with_state(state);
+
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .with_context(|| format!("failed to bind pairing listener at {bind_addr}"))?;
+    axum::serve(listener, app)
+        .await
+        .context("pairing listener exited with an error")
+}
+
+pub fn default_device_ca_cert_path() -> PathBuf {
+    PathBuf::from(DEFAULT_DEVICE_CA_CERT)
+}
+
+pub fn default_device_ca_key_path() -> PathBuf {
+    PathBuf::from(DEFAULT_DEVICE_CA_KEY)
+}
+
+async fn pairing_health() -> impl IntoResponse {
+    (StatusCode::OK, Json(serde_json::json!({"ok": true})))
+}
+
+async fn complete_device_pairing(
+    State(state): State<PairingState>,
+    Json(payload): Json<CompleteDeviceRequest>,
+) -> Response {
+    let pairing_code = payload.pairing_code.trim();
+    if pairing_code.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Missing pairing_code"})),
+        )
+            .into_response();
+    }
+    let pending_registration =
+        match db::pending_device_registration_by_pairing_code(&state.database_path, pairing_code) {
+            Ok(Some(registration)) => registration,
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "Unknown, expired, or already paired code"})),
+                )
+                    .into_response();
+            }
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": error.to_string()})),
+                )
+                    .into_response();
+            }
+        };
+    let certificate_common_name = pending_registration.device_id.clone();
+    let certificate_pem = match sign_csr_with_openssl(
+        &state.ca_cert_path,
+        &state.ca_key_path,
+        &payload.csr_pem,
+        &certificate_common_name,
+    ) {
+        Ok(pem) => pem,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
+    match db::complete_device_registration(
+        &state.database_path,
+        pairing_code,
+        &payload.public_key_pem,
+        &certificate_common_name,
+    ) {
+        Ok(Some(registration)) => Json(CompleteDeviceResponse {
+            device_id: registration.device_id,
+            device_name: registration.device_name,
+            pairing_code: registration.pairing_code,
+            common_name: registration.common_name,
+            certificate_pem: certificate_pem.clone(),
+            certificate_chain_pem: certificate_pem.clone(),
+            expires_at: registration.expires_at,
+        })
+        .into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Unknown, expired, or already paired code"})),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": error.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+fn sign_csr_with_openssl(
+    ca_cert_path: &Path,
+    ca_key_path: &Path,
+    csr_pem: &str,
+    common_name: &str,
+) -> Result<String> {
+    let temp_dir = tempfile::tempdir().context("failed to create temporary signing directory")?;
+    let csr_path = temp_dir.path().join("device.csr.pem");
+    let cert_path = temp_dir.path().join("device.cert.pem");
+    let ext_path = temp_dir.path().join("client.ext");
+    let serial_path = temp_dir.path().join("device.srl");
+
+    fs::write(&csr_path, csr_pem).context("failed to write CSR")?;
+    fs::write(
+        &ext_path,
+        r#"
+[client_cert]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+"#,
+    )
+    .context("failed to write client certificate extension file")?;
+
+    let status = Command::new("openssl")
+        .arg("x509")
+        .arg("-req")
+        .arg("-in")
+        .arg(&csr_path)
+        .arg("-CA")
+        .arg(ca_cert_path)
+        .arg("-CAkey")
+        .arg(ca_key_path)
+        .arg("-CAcreateserial")
+        .arg("-CAserial")
+        .arg(&serial_path)
+        .arg("-out")
+        .arg(&cert_path)
+        .arg("-subj")
+        .arg(format!("/CN={common_name}"))
+        .arg("-days")
+        .arg("3650")
+        .arg("-sha256")
+        .arg("-extfile")
+        .arg(&ext_path)
+        .arg("-extensions")
+        .arg("client_cert")
+        .status()
+        .context("failed to invoke openssl for CSR signing")?;
+
+    if !status.success() {
+        bail!("openssl failed to sign CSR");
+    }
+
+    fs::read_to_string(&cert_path).context("failed to read signed certificate")
+}

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -701,9 +701,7 @@ fn validate_loopback_controller_base_url(base_url: &str) -> Result<()> {
         anyhow::bail!("controller.base_url must include a hostname");
     };
     if !is_loopback_bind_host(host) {
-        anyhow::bail!(
-            "public edge controller.base_url must stay on loopback; got host={host:?}"
-        );
+        anyhow::bail!("public edge controller.base_url must stay on loopback; got host={host:?}");
     }
     Ok(())
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -555,10 +555,6 @@ async fn auth_middleware(
     next: Next,
 ) -> Response {
     let auth_mode = state.auth.mode();
-    if should_skip_auth(request.method(), request.uri().path(), auth_mode) {
-        return next.run(request).await;
-    }
-
     let remote_addr = request
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()
@@ -569,6 +565,25 @@ async fn auth_middleware(
         request.extensions_mut().insert(AuthenticatedUser {
             email: "edge_ipc".to_string(),
         });
+        return next.run(request).await;
+    }
+
+    match cloudflare_access_service_auth(&state, &headers, remote_addr).await {
+        CloudflareAccessServiceAuth::Authenticated(user) => {
+            request.extensions_mut().insert(user);
+            return next.run(request).await;
+        }
+        CloudflareAccessServiceAuth::Rejected => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Cloudflare mTLS device is not enrolled"})),
+            )
+                .into_response();
+        }
+        CloudflareAccessServiceAuth::AbsentOrUserAccess => {}
+    }
+
+    if should_skip_auth(request.method(), request.uri().path(), auth_mode) {
         return next.run(request).await;
     }
 
@@ -689,6 +704,56 @@ fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
         .trim()
         .parse()
         .ok()
+}
+
+enum CloudflareAccessServiceAuth {
+    Authenticated(AuthenticatedUser),
+    Rejected,
+    AbsentOrUserAccess,
+}
+
+async fn cloudflare_access_service_auth(
+    state: &AppState,
+    headers: &HeaderMap,
+    remote_addr: Option<SocketAddr>,
+) -> CloudflareAccessServiceAuth {
+    if !remote_addr.is_some_and(|address| address.ip().is_loopback()) {
+        return CloudflareAccessServiceAuth::AbsentOrUserAccess;
+    }
+
+    let Some(assertion) = headers
+        .get("cf-access-jwt-assertion")
+        .and_then(|value| value.to_str().ok())
+    else {
+        return CloudflareAccessServiceAuth::AbsentOrUserAccess;
+    };
+    let Some(claims) = state
+        .auth
+        .verify_cloudflare_access_assertion(assertion)
+        .await
+    else {
+        return CloudflareAccessServiceAuth::Rejected;
+    };
+    let Some(identity) = claims
+        .common_name
+        .filter(|common_name| !common_name.trim().is_empty())
+    else {
+        return CloudflareAccessServiceAuth::AbsentOrUserAccess;
+    };
+    let device = match db::find_active_device_registration_by_common_name(
+        &state.config.runtime.database_path,
+        &identity,
+    ) {
+        Ok(Some(device)) => device,
+        Ok(None) => return CloudflareAccessServiceAuth::Rejected,
+        Err(error) => {
+            tracing::warn!("failed to validate Cloudflare mTLS device registration: {error:#}");
+            return CloudflareAccessServiceAuth::Rejected;
+        }
+    };
+    CloudflareAccessServiceAuth::Authenticated(AuthenticatedUser {
+        email: format!("cloudflare_mtls:{}", device.device_id),
+    })
 }
 
 async fn status(State(state): State<AppState>) -> Json<Status> {
@@ -5412,6 +5477,14 @@ mod tests {
         assert_eq!(
             response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
             "attachment; filename=office-climate.apk"
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.android.package-archive"
+        );
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
         );
     }
 

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod automation;
 pub mod cli;
 pub mod config;
 pub mod db;
+pub mod device;
 pub mod edge;
 pub mod erv;
 pub mod http;


### PR DESCRIPTION
## Summary
- add local `register-device` / `list-devices` / `revoke-device` commands and device registration persistence
- add Android local pairing, device cert enrollment, shared mTLS HTTP client, and release signing support
- accept signed Cloudflare Access mTLS service-auth assertions at the loopback origin
- preserve APK download headers so Android receives installable artifacts

## Validation
- `cargo test -p office-automate-server --lib`
- `./gradlew :app:assembleRelease`
- `git diff --check`
- host-side Cloudflare mTLS probe returned `HTTP 200` for `/status` through `https://office.rajeshgo.li`

## Notes
- local certs and Android signing material live under ignored `certs/`
- `.agent-os/pr_review_process.md` is not present in this repo; using the Agent OS PR review workflow from `/Users/rajesh/projects/fractal-quant-algo/.agent-os/workflows/pr_review_process.md`
