### PR TITLE
Harden Android bootstrap pairing

### DIFF
--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -240,6 +240,28 @@ The validation passes only if the tunnel/edge users can read the material they n
 
 `com.office-automate.server` owns the embedded MQTT broker for Qingping. Configure the physical Qingping device's Private Access MQTT host to the primary host LAN address and port from `qingping.mqtt_broker` and `qingping.mqtt_port`. The Rust server subscribes to `qingping/<device_mac>/up` and publishes interval commands to `qingping/<device_mac>/down`; no separate MQTT bridge or legacy broker is part of the target deployment.
 
+## Android Device Enrollment
+
+Use the repo-root `oa` wrapper for local device administration. It executes the same Rust `office-automate-server` binary and defaults `OFFICE_AUTOMATE_CONFIG` to `config.yaml` when run from the checkout:
+
+```bash
+./oa migrate
+./oa register-device --device-name phone
+./oa list-devices
+./oa revoke-device <device-id>
+```
+
+`register-device` starts a short-lived LAN pairing listener, prints a six-character one-time code, and records audit events for registration creation, successful pairing, rejected codes, rejected CSR/proof attempts, and revocation. A pending code is invalidated after five failed CSR/proof attempts. Unknown-code audit entries store a hash of the submitted code, not the raw code.
+
+The default device mTLS CA files are repo-local and gitignored:
+
+| Path | Purpose |
+| --- | --- |
+| `certs/device-ca.pem` | CA certificate uploaded to Cloudflare Access as the client-certificate root. |
+| `certs/device-ca.key` | Local signing key used only by `oa register-device`; do not upload it to Cloudflare. |
+
+Override these paths with `--device-ca-cert`, `--device-ca-key`, `OFFICE_AUTOMATE_DEVICE_CA_CERT`, or `OFFICE_AUTOMATE_DEVICE_CA_KEY` if a deployment keeps private key material elsewhere.
+
 ## Cloudflare Tunnel Notes
 
 The tunnel template only starts `cloudflared`; it does not define DNS, public hostnames, TLS, credentials, or application authorization. Configure those through Cloudflare and the `cloudflared` config file. The tunnel should forward only to the local Rust edge origin, and the edge/controller pair should continue enforcing OAuth/JWT plus the local controller IPC token. Public deployments must not use `trusted_networks`.

--- a/oa
+++ b/oa
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${OFFICE_AUTOMATE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+export OFFICE_AUTOMATE_ROOT="$root"
+manifest="$root/rust/office-automate-server/Cargo.toml"
+
+if [[ -z "${OFFICE_AUTOMATE_CONFIG:-}" && -f "$root/config.yaml" ]]; then
+  export OFFICE_AUTOMATE_CONFIG="$root/config.yaml"
+fi
+
+bin="${OFFICE_AUTOMATE_SERVER_BIN:-$root/target/release/office-automate-server}"
+if [[ ! -x "$bin" ]]; then
+  bin="$root/target/debug/office-automate-server"
+fi
+
+if [[ ! -x "$bin" ]]; then
+  cargo build --manifest-path "$manifest"
+  bin="$root/target/debug/office-automate-server"
+fi
+
+exec "$bin" "$@"

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -92,8 +92,10 @@ pub struct RegisterDeviceArgs {
 pub struct RevokeDeviceArgs {
     #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
     pub config: PathBuf,
-    #[arg(long)]
-    pub device_id: String,
+    #[arg(value_name = "DEVICE_ID")]
+    pub device_id: Option<String>,
+    #[arg(long = "device-id")]
+    pub device_id_flag: Option<String>,
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -359,7 +361,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             } else {
                 for device in devices {
                     println!(
-                        "device_id={} name={} code={} paired_at={} revoked_at={} expires_at={} fingerprint={}",
+                        "device_id={} name={} code={} paired_at={} revoked_at={} expires_at={} fingerprint={} failed_attempts={}/{} last_failed_at={}",
                         device.device_id,
                         device.device_name,
                         device.pairing_code,
@@ -367,6 +369,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                         device.revoked_at.as_deref().unwrap_or("-"),
                         device.expires_at,
                         device.public_key_fingerprint.as_deref().unwrap_or("-"),
+                        device.failed_attempts,
+                        db::DEVICE_PAIRING_MAX_FAILED_ATTEMPTS,
+                        device.last_failed_attempt_at.as_deref().unwrap_or("-"),
                     );
                 }
             }
@@ -374,11 +379,15 @@ pub async fn run(cli: Cli) -> Result<()> {
         }
         Command::RevokeDevice(args) => {
             let config = AppConfig::load(&args.config)?;
-            let revoked = device::revoke_device(&config.runtime.database_path, &args.device_id)?;
+            let device_id = args
+                .device_id
+                .or(args.device_id_flag)
+                .context("revoke-device requires DEVICE_ID or --device-id")?;
+            let revoked = device::revoke_device(&config.runtime.database_path, &device_id)?;
             if revoked {
-                println!("device revoked: {}", args.device_id);
+                println!("device revoked: {device_id}");
             } else {
-                println!("device not found or already revoked: {}", args.device_id);
+                println!("device not found or already revoked: {device_id}");
             }
             Ok(())
         }
@@ -603,6 +612,68 @@ mod tests {
         match cli.command {
             Command::Migrate(args) => assert_eq!(args.config, PathBuf::from("/tmp/office.yaml")),
             other => panic!("expected migrate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_register_device_command_with_config() {
+        let cli = Cli::try_parse_from([
+            "office-automate-server",
+            "register-device",
+            "--config",
+            "/tmp/office.yaml",
+            "--device-name",
+            "phone",
+        ])
+        .expect("register-device command should parse");
+
+        match cli.command {
+            Command::RegisterDevice(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.device_name, "phone");
+                assert_eq!(args.expires_in_minutes, 15);
+            }
+            other => panic!("expected register-device command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_revoke_device_positional_and_flag_forms() {
+        let positional = Cli::try_parse_from([
+            "office-automate-server",
+            "revoke-device",
+            "--config",
+            "/tmp/office.yaml",
+            "device-1",
+        ])
+        .expect("revoke-device positional command should parse");
+
+        match positional.command {
+            Command::RevokeDevice(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.device_id.as_deref(), Some("device-1"));
+                assert_eq!(args.device_id_flag, None);
+            }
+            other => panic!("expected revoke-device command, got {other:?}"),
+        }
+
+        let flagged = Cli::try_parse_from([
+            "office-automate-server",
+            "revoke-device",
+            "--config",
+            "/tmp/office.yaml",
+            "--device-id",
+            "device-2",
+        ])
+        .expect("revoke-device flag command should parse");
+
+        match flagged.command {
+            Command::RevokeDevice(args) => {
+                assert_eq!(args.config, PathBuf::from("/tmp/office.yaml"));
+                assert_eq!(args.device_id, None);
+                assert_eq!(args.device_id_flag.as_deref(), Some("device-2"));
+            }
+            other => panic!("expected revoke-device command, got {other:?}"),
         }
     }
 

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -15,6 +15,8 @@ use sha2::{Digest, Sha256};
 
 use crate::{config::AppConfig, qingping::QingpingReading};
 
+pub const DEVICE_PAIRING_MAX_FAILED_ATTEMPTS: i64 = 5;
+
 const SESSION_OUTPUT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS session_output (
     session_id TEXT PRIMARY KEY,
@@ -153,13 +155,28 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
                 created_at DATETIME NOT NULL,
                 expires_at DATETIME NOT NULL,
                 paired_at DATETIME,
-                revoked_at DATETIME
+                revoked_at DATETIME,
+                failed_attempts INTEGER NOT NULL DEFAULT 0,
+                last_failed_attempt_at DATETIME
             );
             CREATE INDEX IF NOT EXISTS idx_device_registrations_created_at ON device_registrations(created_at);
             CREATE INDEX IF NOT EXISTS idx_device_registrations_expires_at ON device_registrations(expires_at);
             CREATE INDEX IF NOT EXISTS idx_device_registrations_revoked_at ON device_registrations(revoked_at);
             CREATE INDEX IF NOT EXISTS idx_device_registrations_common_name ON device_registrations(common_name);
             CREATE INDEX IF NOT EXISTS idx_device_registrations_device_name ON device_registrations(device_name);
+
+            CREATE TABLE IF NOT EXISTS device_registration_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp DATETIME NOT NULL,
+                device_id TEXT,
+                device_name TEXT,
+                event TEXT NOT NULL,
+                remote_addr TEXT,
+                details TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_device_registration_audit_timestamp ON device_registration_audit(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_device_registration_audit_device_id ON device_registration_audit(device_id);
+            CREATE INDEX IF NOT EXISTS idx_device_registration_audit_event ON device_registration_audit(event);
 
             CREATE TABLE IF NOT EXISTS schema_migrations (
                 version INTEGER PRIMARY KEY,
@@ -178,6 +195,18 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
         "sensor_readings",
         "noise_db",
         "ALTER TABLE sensor_readings ADD COLUMN noise_db INTEGER",
+    )?;
+    ensure_column(
+        &connection,
+        "device_registrations",
+        "failed_attempts",
+        "ALTER TABLE device_registrations ADD COLUMN failed_attempts INTEGER NOT NULL DEFAULT 0",
+    )?;
+    ensure_column(
+        &connection,
+        "device_registrations",
+        "last_failed_attempt_at",
+        "ALTER TABLE device_registrations ADD COLUMN last_failed_attempt_at DATETIME",
     )?;
 
     Ok(())
@@ -248,6 +277,27 @@ pub struct DeviceRegistration {
     pub expires_at: String,
     pub paired_at: Option<String>,
     pub revoked_at: Option<String>,
+    pub failed_attempts: i64,
+    pub last_failed_attempt_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeviceRegistrationAuditEvent {
+    pub id: i64,
+    pub timestamp: String,
+    pub device_id: Option<String>,
+    pub device_name: Option<String>,
+    pub event: String,
+    pub remote_addr: Option<String>,
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DevicePairingFailure {
+    pub device_id: String,
+    pub device_name: String,
+    pub failed_attempts: i64,
+    pub exhausted: bool,
 }
 
 pub fn create_device_registration(
@@ -276,6 +326,8 @@ pub fn create_device_registration(
         expires_at,
         paired_at: None,
         revoked_at: None,
+        failed_attempts: 0,
+        last_failed_attempt_at: None,
     };
 
     connection
@@ -283,9 +335,10 @@ pub fn create_device_registration(
             r#"
             INSERT INTO device_registrations (
                 device_id, device_name, pairing_code, public_key_fingerprint,
-                common_name, created_at, expires_at, paired_at, revoked_at
+                common_name, created_at, expires_at, paired_at, revoked_at,
+                failed_attempts, last_failed_attempt_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             params![
                 registration.device_id,
@@ -297,9 +350,23 @@ pub fn create_device_registration(
                 registration.expires_at,
                 registration.paired_at,
                 registration.revoked_at,
+                registration.failed_attempts,
+                registration.last_failed_attempt_at,
             ],
         )
         .context("failed to create device registration")?;
+    insert_device_registration_audit_event(
+        &connection,
+        &registration.created_at,
+        Some(&registration.device_id),
+        Some(&registration.device_name),
+        "registration_created",
+        None,
+        Some(&json!({
+            "expires_at": registration.expires_at,
+            "max_failed_attempts": DEVICE_PAIRING_MAX_FAILED_ATTEMPTS,
+        })),
+    )?;
 
     Ok(registration)
 }
@@ -311,7 +378,8 @@ pub fn list_device_registrations(database_path: &Path) -> Result<Vec<DeviceRegis
         .prepare(
             r#"
             SELECT device_id, device_name, pairing_code, public_key_fingerprint,
-                   common_name, created_at, expires_at, paired_at, revoked_at
+                   common_name, created_at, expires_at, paired_at, revoked_at,
+                   failed_attempts, last_failed_attempt_at
             FROM device_registrations
             ORDER BY created_at DESC
             "#,
@@ -330,6 +398,8 @@ pub fn list_device_registrations(database_path: &Path) -> Result<Vec<DeviceRegis
                 expires_at: row.get(6)?,
                 paired_at: row.get(7)?,
                 revoked_at: row.get(8)?,
+                failed_attempts: row.get(9)?,
+                last_failed_attempt_at: row.get(10)?,
             })
         })
         .context("failed to query device registrations")?;
@@ -352,14 +422,16 @@ pub fn pending_device_registration_by_pairing_code(
         .query_row(
             r#"
             SELECT device_id, device_name, pairing_code, public_key_fingerprint,
-                   common_name, created_at, expires_at, paired_at, revoked_at
+                   common_name, created_at, expires_at, paired_at, revoked_at,
+                   failed_attempts, last_failed_attempt_at
             FROM device_registrations
             WHERE pairing_code = ?
               AND revoked_at IS NULL
               AND paired_at IS NULL
               AND expires_at > ?
+              AND failed_attempts < ?
             "#,
-            params![pairing_code, now],
+            params![pairing_code, now, DEVICE_PAIRING_MAX_FAILED_ATTEMPTS],
             |row| {
                 Ok(DeviceRegistration {
                     device_id: row.get(0)?,
@@ -371,6 +443,8 @@ pub fn pending_device_registration_by_pairing_code(
                     expires_at: row.get(6)?,
                     paired_at: row.get(7)?,
                     revoked_at: row.get(8)?,
+                    failed_attempts: row.get(9)?,
+                    last_failed_attempt_at: row.get(10)?,
                 })
             },
         )
@@ -388,7 +462,8 @@ pub fn find_active_device_registration_by_common_name(
         .prepare(
             r#"
             SELECT device_id, device_name, pairing_code, public_key_fingerprint,
-                   common_name, created_at, expires_at, paired_at, revoked_at
+                   common_name, created_at, expires_at, paired_at, revoked_at,
+                   failed_attempts, last_failed_attempt_at
             FROM device_registrations
             WHERE common_name = ?
               AND paired_at IS NOT NULL
@@ -410,6 +485,8 @@ pub fn find_active_device_registration_by_common_name(
                 expires_at: row.get(6)?,
                 paired_at: row.get(7)?,
                 revoked_at: row.get(8)?,
+                failed_attempts: row.get(9)?,
+                last_failed_attempt_at: row.get(10)?,
             })
         })
         .with_context(|| format!("failed to look up active device common name {common_name}"))?;
@@ -434,6 +511,14 @@ pub fn revoke_device_registration(database_path: &Path, device_id: &str) -> Resu
     let connection = Connection::open(database_path)
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
     let updated_at = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let device_name = connection
+        .query_row(
+            "SELECT device_name FROM device_registrations WHERE device_id = ?",
+            params![device_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .context("failed to look up device before revoke")?;
     let changed = connection
         .execute(
             r#"
@@ -444,6 +529,17 @@ pub fn revoke_device_registration(database_path: &Path, device_id: &str) -> Resu
             params![updated_at, device_id],
         )
         .with_context(|| format!("failed to revoke device {device_id}"))?;
+    if changed > 0 {
+        insert_device_registration_audit_event(
+            &connection,
+            &updated_at,
+            Some(device_id),
+            device_name.as_deref(),
+            "device_revoked",
+            None,
+            None,
+        )?;
+    }
     Ok(changed > 0)
 }
 
@@ -452,35 +548,40 @@ pub fn complete_device_registration(
     pairing_code: &str,
     public_key: &str,
     common_name: &str,
+    remote_addr: Option<&str>,
 ) -> Result<Option<DeviceRegistration>> {
     if common_name.trim().is_empty() {
         anyhow::bail!("device certificate common name must not be empty");
     }
 
     let fingerprint = fingerprint_public_key(public_key);
-    let connection = Connection::open(database_path)
+    let mut connection = Connection::open(database_path)
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let transaction = connection
+        .transaction()
+        .context("failed to start device registration transaction")?;
     let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-    let device_name = match connection
+    let (device_id, device_name) = match transaction
         .query_row(
             r#"
-            SELECT device_name
+            SELECT device_id, device_name
             FROM device_registrations
             WHERE pairing_code = ?
               AND revoked_at IS NULL
               AND paired_at IS NULL
               AND expires_at > ?
+              AND failed_attempts < ?
             "#,
-            params![pairing_code, now],
-            |row| row.get::<_, String>(0),
+            params![pairing_code, now, DEVICE_PAIRING_MAX_FAILED_ATTEMPTS],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()
         .context("failed to check device registration eligibility")?
     {
-        Some(device_name) => device_name,
+        Some(row) => row,
         None => return Ok(None),
     };
-    connection
+    transaction
         .execute(
             r#"
             UPDATE device_registrations
@@ -494,7 +595,7 @@ pub fn complete_device_registration(
         .with_context(|| {
             format!("failed to revoke prior registrations for device name {device_name}")
         })?;
-    let changed = connection
+    let changed = transaction
         .execute(
             r#"
             UPDATE device_registrations
@@ -516,11 +617,24 @@ pub fn complete_device_registration(
         return Ok(None);
     }
 
-    let registration = connection
+    insert_device_registration_audit_event(
+        &transaction,
+        &now,
+        Some(&device_id),
+        Some(&device_name),
+        "pairing_completed",
+        remote_addr,
+        Some(&json!({
+            "public_key_fingerprint": fingerprint,
+        })),
+    )?;
+
+    let registration = transaction
         .query_row(
             r#"
             SELECT device_id, device_name, pairing_code, public_key_fingerprint,
-                   common_name, created_at, expires_at, paired_at, revoked_at
+                   common_name, created_at, expires_at, paired_at, revoked_at,
+                   failed_attempts, last_failed_attempt_at
             FROM device_registrations
             WHERE pairing_code = ?
             "#,
@@ -536,12 +650,206 @@ pub fn complete_device_registration(
                     expires_at: row.get(6)?,
                     paired_at: row.get(7)?,
                     revoked_at: row.get(8)?,
+                    failed_attempts: row.get(9)?,
+                    last_failed_attempt_at: row.get(10)?,
                 })
             },
         )
         .context("failed to reload completed device registration")?;
+    transaction
+        .commit()
+        .context("failed to commit device registration transaction")?;
 
     Ok(Some(registration))
+}
+
+pub fn record_device_pairing_failure(
+    database_path: &Path,
+    pairing_code: &str,
+    event: &str,
+    remote_addr: Option<&str>,
+    details: Option<&Value>,
+) -> Result<Option<DevicePairingFailure>> {
+    let mut connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let transaction = connection
+        .transaction()
+        .context("failed to start device pairing failure transaction")?;
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let candidate = transaction
+        .query_row(
+            r#"
+            SELECT device_id, device_name, failed_attempts
+            FROM device_registrations
+            WHERE pairing_code = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NULL
+              AND expires_at > ?
+            "#,
+            params![pairing_code, now],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .context("failed to look up pairing code for failure accounting")?;
+
+    let Some((device_id, device_name, failed_attempts)) = candidate else {
+        insert_device_registration_audit_event(
+            &transaction,
+            &now,
+            None,
+            None,
+            event,
+            remote_addr,
+            Some(&json!({
+                "pairing_code_hash": fingerprint_public_key(pairing_code),
+                "reason": "unknown_expired_or_inactive_code",
+            })),
+        )?;
+        transaction
+            .commit()
+            .context("failed to commit unknown pairing failure audit")?;
+        return Ok(None);
+    };
+
+    let next_failed_attempts = failed_attempts + 1;
+    let exhausted = next_failed_attempts >= DEVICE_PAIRING_MAX_FAILED_ATTEMPTS;
+    transaction
+        .execute(
+            r#"
+            UPDATE device_registrations
+            SET failed_attempts = ?,
+                last_failed_attempt_at = ?,
+                revoked_at = CASE WHEN ? THEN ? ELSE revoked_at END
+            WHERE device_id = ?
+              AND revoked_at IS NULL
+              AND paired_at IS NULL
+            "#,
+            params![next_failed_attempts, now, exhausted, now, device_id,],
+        )
+        .context("failed to record device pairing failure")?;
+
+    insert_device_registration_audit_event(
+        &transaction,
+        &now,
+        Some(&device_id),
+        Some(&device_name),
+        event,
+        remote_addr,
+        Some(&json!({
+            "failed_attempts": next_failed_attempts,
+            "max_failed_attempts": DEVICE_PAIRING_MAX_FAILED_ATTEMPTS,
+            "exhausted": exhausted,
+            "details": details,
+        })),
+    )?;
+    transaction
+        .commit()
+        .context("failed to commit device pairing failure audit")?;
+
+    Ok(Some(DevicePairingFailure {
+        device_id,
+        device_name,
+        failed_attempts: next_failed_attempts,
+        exhausted,
+    }))
+}
+
+pub fn log_unknown_device_pairing_attempt(
+    database_path: &Path,
+    pairing_code: &str,
+    remote_addr: Option<&str>,
+    reason: &str,
+) -> Result<()> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    insert_device_registration_audit_event(
+        &connection,
+        &now,
+        None,
+        None,
+        "pairing_code_rejected",
+        remote_addr,
+        Some(&json!({
+            "pairing_code_hash": fingerprint_public_key(pairing_code),
+            "reason": reason,
+        })),
+    )
+}
+
+pub fn list_device_registration_audit_events(
+    database_path: &Path,
+) -> Result<Vec<DeviceRegistrationAuditEvent>> {
+    let connection = Connection::open(database_path)
+        .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
+    let mut statement = connection
+        .prepare(
+            r#"
+            SELECT id, timestamp, device_id, device_name, event, remote_addr, details
+            FROM device_registration_audit
+            ORDER BY id ASC
+            "#,
+        )
+        .context("failed to prepare device registration audit query")?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(DeviceRegistrationAuditEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                device_id: row.get(2)?,
+                device_name: row.get(3)?,
+                event: row.get(4)?,
+                remote_addr: row.get(5)?,
+                details: row.get(6)?,
+            })
+        })
+        .context("failed to query device registration audit")?;
+
+    let mut events = Vec::new();
+    for row in rows {
+        events.push(row.context("failed to read device registration audit row")?);
+    }
+    Ok(events)
+}
+
+fn insert_device_registration_audit_event(
+    connection: &Connection,
+    timestamp: &str,
+    device_id: Option<&str>,
+    device_name: Option<&str>,
+    event: &str,
+    remote_addr: Option<&str>,
+    details: Option<&Value>,
+) -> Result<()> {
+    let details = details
+        .map(serde_json::to_string)
+        .transpose()
+        .context("failed to encode device registration audit details")?;
+    connection
+        .execute(
+            r#"
+            INSERT INTO device_registration_audit (
+                timestamp, device_id, device_name, event, remote_addr, details
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            "#,
+            params![
+                timestamp,
+                device_id,
+                device_name,
+                event,
+                remote_addr,
+                details
+            ],
+        )
+        .context("failed to insert device registration audit event")?;
+    Ok(())
 }
 
 fn random_device_id() -> String {
@@ -2288,6 +2596,7 @@ mod tests {
             &registration.pairing_code,
             "public-key",
             "device-1",
+            Some("192.168.5.50:51234"),
         )
         .expect("complete registration")
         .expect("registration completed");
@@ -2305,6 +2614,7 @@ mod tests {
             &replacement.pairing_code,
             "replacement-key",
             "device-2",
+            None,
         )
         .expect("complete replacement")
         .expect("replacement completed");
@@ -2339,6 +2649,98 @@ mod tests {
             find_active_device_registration_by_common_name(&db_path, "device-2")
                 .expect("find active device after revoke");
         assert!(active_after_revoke.is_none());
+
+        let audit_events =
+            list_device_registration_audit_events(&db_path).expect("list device audit events");
+        assert!(audit_events.iter().any(|event| {
+            event.event == "registration_created"
+                && event.device_id.as_deref() == Some(registration.device_id.as_str())
+        }));
+        assert!(audit_events.iter().any(|event| {
+            event.event == "pairing_completed"
+                && event.device_id.as_deref() == Some(replacement.device_id.as_str())
+        }));
+        assert!(audit_events.iter().any(|event| {
+            event.event == "device_revoked"
+                && event.device_id.as_deref() == Some(replacement.device_id.as_str())
+        }));
+    }
+
+    #[test]
+    fn pairing_failures_exhaust_pending_registration_and_audit_without_raw_code() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let registration =
+            create_device_registration(&db_path, "phone", 15).expect("create registration");
+        for attempt in 1..=DEVICE_PAIRING_MAX_FAILED_ATTEMPTS {
+            let failure = record_device_pairing_failure(
+                &db_path,
+                &registration.pairing_code,
+                "pairing_csr_rejected",
+                Some("192.168.5.50:51234"),
+                Some(&json!({"error": "invalid csr"})),
+            )
+            .expect("record pairing failure")
+            .expect("known registration");
+            assert_eq!(failure.failed_attempts, attempt);
+            assert_eq!(
+                failure.exhausted,
+                attempt == DEVICE_PAIRING_MAX_FAILED_ATTEMPTS
+            );
+        }
+
+        let pending =
+            pending_device_registration_by_pairing_code(&db_path, &registration.pairing_code)
+                .expect("query pending registration");
+        assert!(pending.is_none());
+
+        let completed = complete_device_registration(
+            &db_path,
+            &registration.pairing_code,
+            "public-key",
+            "device-1",
+            None,
+        )
+        .expect("complete exhausted registration");
+        assert!(completed.is_none());
+
+        log_unknown_device_pairing_attempt(
+            &db_path,
+            "BAD999",
+            Some("192.168.5.51:61234"),
+            "unknown_expired_or_already_paired",
+        )
+        .expect("log unknown attempt");
+
+        let devices = list_device_registrations(&db_path).expect("list devices");
+        let device = devices
+            .iter()
+            .find(|device| device.device_id == registration.device_id)
+            .expect("device row");
+        assert_eq!(device.failed_attempts, DEVICE_PAIRING_MAX_FAILED_ATTEMPTS);
+        assert!(device.last_failed_attempt_at.is_some());
+        assert!(device.revoked_at.is_some());
+
+        let audit_events =
+            list_device_registration_audit_events(&db_path).expect("list device audit events");
+        let failure_events = audit_events
+            .iter()
+            .filter(|event| event.event == "pairing_csr_rejected")
+            .count();
+        assert_eq!(failure_events, DEVICE_PAIRING_MAX_FAILED_ATTEMPTS as usize);
+        let unknown_event = audit_events
+            .iter()
+            .find(|event| event.event == "pairing_code_rejected")
+            .expect("unknown code audit event");
+        assert!(
+            !unknown_event
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("BAD999")
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -175,26 +175,7 @@ async fn complete_device_pairing(
     let csr_public_key_pem = match extract_public_key_from_csr_with_openssl(&payload.csr_pem) {
         Ok(public_key_pem) => public_key_pem,
         Err(error) => {
-            let exhausted = record_pairing_failure(
-                &state,
-                pairing_code,
-                Some(&remote_addr),
-                "pairing_csr_rejected",
-                &error.to_string(),
-            );
-            return (
-                if exhausted {
-                    StatusCode::TOO_MANY_REQUESTS
-                } else {
-                    StatusCode::BAD_REQUEST
-                },
-                Json(serde_json::json!({"error": if exhausted {
-                    "Too many invalid pairing attempts"
-                } else {
-                    "Invalid device CSR"
-                }})),
-            )
-                .into_response();
+            return invalid_csr_response(&state, pairing_code, Some(&remote_addr), &error);
         }
     };
     let certificate_pem = match sign_csr_with_openssl(
@@ -205,11 +186,7 @@ async fn complete_device_pairing(
     ) {
         Ok(pem) => pem,
         Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": error.to_string()})),
-            )
-                .into_response();
+            return invalid_csr_response(&state, pairing_code, Some(&remote_addr), &error);
         }
     };
 
@@ -268,6 +245,34 @@ fn record_pairing_failure(
     )
     .map(|failure| failure.map(|failure| failure.exhausted).unwrap_or(false))
     .unwrap_or(false)
+}
+
+fn invalid_csr_response(
+    state: &PairingState,
+    pairing_code: &str,
+    remote_addr: Option<&str>,
+    error: &anyhow::Error,
+) -> Response {
+    let exhausted = record_pairing_failure(
+        state,
+        pairing_code,
+        remote_addr,
+        "pairing_csr_rejected",
+        &error.to_string(),
+    );
+    (
+        if exhausted {
+            StatusCode::TOO_MANY_REQUESTS
+        } else {
+            StatusCode::BAD_REQUEST
+        },
+        Json(serde_json::json!({"error": if exhausted {
+            "Too many invalid pairing attempts"
+        } else {
+            "Invalid device CSR"
+        }})),
+    )
+        .into_response()
 }
 
 fn extract_public_key_from_csr_with_openssl(csr_pem: &str) -> Result<String> {

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -1,14 +1,15 @@
 use std::{
-    fs,
+    env, fs,
     net::SocketAddr,
     path::{Path, PathBuf},
     process::Command,
+    sync::{Arc, Mutex},
 };
 
 use anyhow::{Context, Result, bail};
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -18,14 +19,16 @@ use tokio::net::TcpListener;
 
 use crate::db::{self, DeviceRegistration};
 
-const DEFAULT_DEVICE_CA_CERT: &str = "/Users/rajesh/.office-automate/device-ca/device-ca.pem";
-const DEFAULT_DEVICE_CA_KEY: &str = "/Users/rajesh/.office-automate/device-ca/device-ca.key";
+const DEFAULT_DEVICE_CA_CERT: &str = "certs/device-ca.pem";
+const DEFAULT_DEVICE_CA_KEY: &str = "certs/device-ca.key";
+const MAX_UNKNOWN_PAIRING_ATTEMPTS: u32 = 25;
 
 #[derive(Debug, Clone)]
 struct PairingState {
     database_path: PathBuf,
     ca_cert_path: PathBuf,
     ca_key_path: PathBuf,
+    unknown_attempts: Arc<Mutex<u32>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -77,6 +80,7 @@ pub async fn serve_pairing_listener(
         database_path,
         ca_cert_path: ca_cert_path.unwrap_or_else(default_device_ca_cert_path),
         ca_key_path: ca_key_path.unwrap_or_else(default_device_ca_key_path),
+        unknown_attempts: Arc::new(Mutex::new(0)),
     };
 
     let app = Router::new()
@@ -87,17 +91,27 @@ pub async fn serve_pairing_listener(
     let listener = TcpListener::bind(bind_addr)
         .await
         .with_context(|| format!("failed to bind pairing listener at {bind_addr}"))?;
-    axum::serve(listener, app)
-        .await
-        .context("pairing listener exited with an error")
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .context("pairing listener exited with an error")
 }
 
 pub fn default_device_ca_cert_path() -> PathBuf {
-    PathBuf::from(DEFAULT_DEVICE_CA_CERT)
+    default_repo_local_path(DEFAULT_DEVICE_CA_CERT)
 }
 
 pub fn default_device_ca_key_path() -> PathBuf {
-    PathBuf::from(DEFAULT_DEVICE_CA_KEY)
+    default_repo_local_path(DEFAULT_DEVICE_CA_KEY)
+}
+
+fn default_repo_local_path(relative_path: &str) -> PathBuf {
+    env::var_os("OFFICE_AUTOMATE_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(relative_path)
 }
 
 async fn pairing_health() -> impl IntoResponse {
@@ -106,8 +120,10 @@ async fn pairing_health() -> impl IntoResponse {
 
 async fn complete_device_pairing(
     State(state): State<PairingState>,
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
     Json(payload): Json<CompleteDeviceRequest>,
 ) -> Response {
+    let remote_addr = remote_addr.to_string();
     let pairing_code = payload.pairing_code.trim();
     if pairing_code.is_empty() {
         return (
@@ -120,6 +136,24 @@ async fn complete_device_pairing(
         match db::pending_device_registration_by_pairing_code(&state.database_path, pairing_code) {
             Ok(Some(registration)) => registration,
             Ok(None) => {
+                let attempts = increment_unknown_attempts(&state);
+                let _ = db::log_unknown_device_pairing_attempt(
+                    &state.database_path,
+                    pairing_code,
+                    Some(&remote_addr),
+                    if attempts > MAX_UNKNOWN_PAIRING_ATTEMPTS {
+                        "too_many_unknown_attempts"
+                    } else {
+                        "unknown_expired_or_already_paired"
+                    },
+                );
+                if attempts > MAX_UNKNOWN_PAIRING_ATTEMPTS {
+                    return (
+                        StatusCode::TOO_MANY_REQUESTS,
+                        Json(serde_json::json!({"error": "Too many invalid pairing attempts"})),
+                    )
+                        .into_response();
+                }
                 return (
                     StatusCode::NOT_FOUND,
                     Json(serde_json::json!({"error": "Unknown, expired, or already paired code"})),
@@ -134,7 +168,46 @@ async fn complete_device_pairing(
                     .into_response();
             }
         };
+    if payload.public_key_pem.trim().is_empty() {
+        record_pairing_failure(
+            &state,
+            pairing_code,
+            Some(&remote_addr),
+            "pairing_public_key_rejected",
+            "missing public_key_pem",
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Missing public_key_pem"})),
+        )
+            .into_response();
+    }
     let certificate_common_name = pending_registration.device_id.clone();
+    let csr_public_key_pem = match extract_public_key_from_csr_with_openssl(&payload.csr_pem) {
+        Ok(public_key_pem) => public_key_pem,
+        Err(error) => {
+            let exhausted = record_pairing_failure(
+                &state,
+                pairing_code,
+                Some(&remote_addr),
+                "pairing_csr_rejected",
+                &error.to_string(),
+            );
+            return (
+                if exhausted {
+                    StatusCode::TOO_MANY_REQUESTS
+                } else {
+                    StatusCode::BAD_REQUEST
+                },
+                Json(serde_json::json!({"error": if exhausted {
+                    "Too many invalid pairing attempts"
+                } else {
+                    "Invalid device CSR"
+                }})),
+            )
+                .into_response();
+        }
+    };
     let certificate_pem = match sign_csr_with_openssl(
         &state.ca_cert_path,
         &state.ca_key_path,
@@ -154,8 +227,9 @@ async fn complete_device_pairing(
     match db::complete_device_registration(
         &state.database_path,
         pairing_code,
-        &payload.public_key_pem,
+        &csr_public_key_pem,
         &certificate_common_name,
+        Some(&remote_addr),
     ) {
         Ok(Some(registration)) => Json(CompleteDeviceResponse {
             device_id: registration.device_id,
@@ -178,6 +252,57 @@ async fn complete_device_pairing(
         )
             .into_response(),
     }
+}
+
+fn increment_unknown_attempts(state: &PairingState) -> u32 {
+    let mut attempts = state
+        .unknown_attempts
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *attempts += 1;
+    *attempts
+}
+
+fn record_pairing_failure(
+    state: &PairingState,
+    pairing_code: &str,
+    remote_addr: Option<&str>,
+    event: &str,
+    error: &str,
+) -> bool {
+    db::record_device_pairing_failure(
+        &state.database_path,
+        pairing_code,
+        event,
+        remote_addr,
+        Some(&serde_json::json!({"error": error})),
+    )
+    .map(|failure| failure.map(|failure| failure.exhausted).unwrap_or(false))
+    .unwrap_or(false)
+}
+
+fn extract_public_key_from_csr_with_openssl(csr_pem: &str) -> Result<String> {
+    let temp_dir =
+        tempfile::tempdir().context("failed to create temporary CSR validation directory")?;
+    let csr_path = temp_dir.path().join("device.csr.pem");
+    fs::write(&csr_path, csr_pem).context("failed to write CSR")?;
+
+    let output = Command::new("openssl")
+        .arg("req")
+        .arg("-in")
+        .arg(&csr_path)
+        .arg("-pubkey")
+        .arg("-noout")
+        .output()
+        .context("failed to invoke openssl for CSR public key extraction")?;
+
+    if !output.status.success() {
+        bail!("openssl failed to read CSR public key");
+    }
+
+    String::from_utf8(output.stdout)
+        .map(|value| value.trim().to_string())
+        .context("openssl returned non-UTF-8 CSR public key")
 }
 
 fn sign_csr_with_openssl(

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -33,8 +33,11 @@ struct PairingState {
 
 #[derive(Debug, Deserialize)]
 pub struct CompleteDeviceRequest {
+    #[serde(default)]
     pub pairing_code: String,
+    #[serde(default)]
     pub csr_pem: String,
+    #[serde(default)]
     pub public_key_pem: String,
     #[serde(default)]
     pub common_name: Option<String>,
@@ -362,4 +365,19 @@ authorityKeyIdentifier = keyid,issuer
     }
 
     fs::read_to_string(&cert_path).context("failed to read signed certificate")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complete_device_request_defaults_omitted_proof_fields() {
+        let payload: CompleteDeviceRequest =
+            serde_json::from_str(r#"{"pairing_code":"ABC123"}"#).expect("deserialize payload");
+
+        assert_eq!(payload.pairing_code, "ABC123");
+        assert_eq!(payload.csr_pem, "");
+        assert_eq!(payload.public_key_pem, "");
+    }
 }

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -171,20 +171,6 @@ async fn complete_device_pairing(
                     .into_response();
             }
         };
-    if payload.public_key_pem.trim().is_empty() {
-        record_pairing_failure(
-            &state,
-            pairing_code,
-            Some(&remote_addr),
-            "pairing_public_key_rejected",
-            "missing public_key_pem",
-        );
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "Missing public_key_pem"})),
-        )
-            .into_response();
-    }
     let certificate_common_name = pending_registration.device_id.clone();
     let csr_public_key_pem = match extract_public_key_from_csr_with_openssl(&payload.csr_pem) {
         Ok(public_key_pem) => public_key_pem,

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -186,7 +186,11 @@ async fn complete_device_pairing(
     ) {
         Ok(pem) => pem,
         Err(error) => {
-            return invalid_csr_response(&state, pairing_code, Some(&remote_addr), &error);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": error.to_string()})),
+            )
+                .into_response();
         }
     };
 
@@ -281,6 +285,8 @@ fn extract_public_key_from_csr_with_openssl(csr_pem: &str) -> Result<String> {
     let csr_path = temp_dir.path().join("device.csr.pem");
     fs::write(&csr_path, csr_pem).context("failed to write CSR")?;
 
+    verify_csr_self_signature_with_openssl(&csr_path)?;
+
     let output = Command::new("openssl")
         .arg("req")
         .arg("-in")
@@ -297,6 +303,27 @@ fn extract_public_key_from_csr_with_openssl(csr_pem: &str) -> Result<String> {
     String::from_utf8(output.stdout)
         .map(|value| value.trim().to_string())
         .context("openssl returned non-UTF-8 CSR public key")
+}
+
+fn verify_csr_self_signature_with_openssl(csr_path: &Path) -> Result<()> {
+    let output = Command::new("openssl")
+        .arg("req")
+        .arg("-in")
+        .arg(csr_path)
+        .arg("-verify")
+        .arg("-noout")
+        .output()
+        .context("failed to invoke openssl for CSR verification")?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "openssl failed to verify CSR self-signature: {}",
+        stderr.trim()
+    )
 }
 
 fn sign_csr_with_openssl(


### PR DESCRIPTION
## Summary
- add repo-root `oa` wrapper for the existing Rust binary, with default local `config.yaml` discovery
- harden local Android pairing with audit logging, five-attempt exhaustion, unknown-code audit hashing, and CSR-derived public-key fingerprints
- support `oa revoke-device <id>` while preserving `--device-id`, and document repo-local `certs/device-ca.pem/key` defaults

## Spec Reference
- `docs/working/100_security_threat_model.md`
- Refs #105

## Security Note
This PR completes the server/operator-side controls for the local-only Android bootstrap path. It does not change the currently working Android software-key fallback back to AndroidKeyStore; that non-exportable-key storage gap remains tracked under #107 because the previous AndroidKeyStore mTLS path failed on-device. Public registration-code redemption remains local-only and is not exposed through Cloudflare.

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml --lib` (217 passed)
- [x] `cargo build --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `git diff --check`
- [x] `OFFICE_AUTOMATE_SERVER_BIN=target/debug/office-automate-server ./oa migrate`
- [x] `OFFICE_AUTOMATE_SERVER_BIN=target/debug/office-automate-server ./oa list-devices`
- [x] absolute-path `oa --help` smoke from `/tmp`
