### PR TITLE
Harden route authorization and deploy admin checks

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -55,7 +55,8 @@ thresholds:
 orchestrator:
   host: "127.0.0.1"
   port: 8080
-  # Admins can upload Android artifacts through /deploy. Leave empty to disable uploads.
+  # Admins can upload Android artifacts through /deploy. OAuth uses email addresses;
+  # Basic auth uses the configured auth_username. Leave empty to disable uploads.
   admin_emails:
     - "your_email@example.com"
   # Optional: Enable HTTP Basic Auth for remote access (recommended with Cloudflare Tunnel)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -55,6 +55,9 @@ thresholds:
 orchestrator:
   host: "127.0.0.1"
   port: 8080
+  # Admins can upload Android artifacts through /deploy. Leave empty to disable uploads.
+  admin_emails:
+    - "your_email@example.com"
   # Optional: Enable HTTP Basic Auth for remote access (recommended with Cloudflare Tunnel)
   # auth_username: "admin"
   # auth_password: "your_secure_password"

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -38,6 +38,7 @@ pub struct AuthManager {
 struct AuthInner {
     oauth: Option<OAuthRuntime>,
     basic: Option<BasicCredentials>,
+    admin_emails: HashSet<String>,
     pending_oauth: RwLock<HashMap<String, PendingOAuthState>>,
     device_flows: RwLock<HashMap<String, DeviceFlowState>>,
     invalidated_tokens: RwLock<HashSet<String>>,
@@ -159,6 +160,11 @@ impl AuthManager {
             inner: Arc::new(AuthInner {
                 oauth,
                 basic,
+                admin_emails: config
+                    .admin_emails
+                    .iter()
+                    .map(|email| email.to_ascii_lowercase())
+                    .collect(),
                 pending_oauth: RwLock::new(HashMap::new()),
                 device_flows: RwLock::new(HashMap::new()),
                 invalidated_tokens: RwLock::new(HashSet::new()),
@@ -187,6 +193,12 @@ impl AuthManager {
 
     pub fn basic_enabled(&self) -> bool {
         self.inner.basic.is_some()
+    }
+
+    pub fn is_admin_user(&self, email: &str) -> bool {
+        self.inner
+            .admin_emails
+            .contains(&email.to_ascii_lowercase())
     }
 
     pub fn is_trusted_request(&self, headers: &HeaderMap) -> bool {

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -269,26 +269,36 @@ impl AuthManager {
     }
 
     pub fn verify_basic_header(&self, headers: &HeaderMap) -> bool {
+        self.verify_basic_header_user(headers).is_some()
+    }
+
+    pub fn verify_basic_header_user(&self, headers: &HeaderMap) -> Option<AuthenticatedUser> {
         let Some(credentials) = &self.inner.basic else {
-            return false;
+            return None;
         };
         let Some(header_value) = headers.get(header::AUTHORIZATION).and_then(header_to_str) else {
-            return false;
+            return None;
         };
         let Some(encoded) = header_value.strip_prefix("Basic ") else {
-            return false;
+            return None;
         };
         let Ok(decoded) = general_purpose::STANDARD.decode(encoded) else {
-            return false;
+            return None;
         };
         let Ok(decoded) = String::from_utf8(decoded) else {
-            return false;
+            return None;
         };
         let Some((username, password)) = decoded.split_once(':') else {
-            return false;
+            return None;
         };
 
-        username == credentials.username && password == credentials.password
+        if username == credentials.username && password == credentials.password {
+            Some(AuthenticatedUser {
+                email: credentials.username.clone(),
+            })
+        } else {
+            None
+        }
     }
 
     pub fn issue_basic_websocket_cookie(&self) -> Option<String> {

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -56,6 +56,7 @@ pub struct TelemetryConfig {
 pub struct OrchestratorConfig {
     pub host: String,
     pub port: u16,
+    pub admin_emails: Vec<String>,
     pub auth_username: Option<String>,
     pub auth_password: Option<String>,
     pub google_oauth: Option<GoogleOAuthConfig>,
@@ -67,6 +68,7 @@ impl Default for OrchestratorConfig {
         Self {
             host: "127.0.0.1".to_string(),
             port: 8080,
+            admin_emails: Vec::new(),
             auth_username: None,
             auth_password: None,
             google_oauth: None,
@@ -480,6 +482,15 @@ impl AppConfig {
             file_config.orchestrator.controller_ipc_token = Some(token);
         }
 
+        if let Some(admin_emails) = env_lookup("OFFICE_AUTOMATE_ADMIN_EMAILS") {
+            file_config.orchestrator.admin_emails = admin_emails
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+        }
+
         if let Some(repos) = env_lookup("OFFICE_AUTOMATE_TELEMETRY_REPOS") {
             file_config.telemetry.repos = repos
                 .split(',')
@@ -645,6 +656,7 @@ mod tests {
 
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 8080);
+        assert!(config.admin_emails.is_empty());
     }
 
     #[test]
@@ -750,6 +762,9 @@ thresholds:
             "OFFICE_AUTOMATE_TELEMETRY_DAYS" => Some("14".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             "OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN" => Some("edge-ipc-token".to_string()),
+            "OFFICE_AUTOMATE_ADMIN_EMAILS" => {
+                Some("rajesh@example.com,ops@example.com".to_string())
+            }
             _ => None,
         })
         .expect("load config");
@@ -846,6 +861,10 @@ thresholds:
         assert_eq!(
             config.orchestrator.controller_ipc_token.as_deref(),
             Some("edge-ipc-token")
+        );
+        assert_eq!(
+            config.orchestrator.admin_emails,
+            vec!["rajesh@example.com", "ops@example.com"]
         );
         assert_eq!(config.thresholds.hvac_heat_on_temp_f, 70);
         assert_eq!(config.thresholds.hvac_cool_setpoint_f, 77);

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -818,9 +818,18 @@ async fn websocket(
     let mode = if has_valid_controller_ipc_token(&state.config, &auth_headers, Some(remote_addr)) {
         WebSocketAuth::Open
     } else {
-        state.auth.websocket_auth(&auth_headers)
+        websocket_auth_mode(&state, &auth_headers)
     };
     ws.on_upgrade(move |socket| websocket_session(socket, state, mode))
+}
+
+fn websocket_auth_mode(state: &AppState, headers: &HeaderMap) -> WebSocketAuth {
+    let mode = state.auth.websocket_auth(headers);
+    if mode == WebSocketAuth::TrustedNetwork && has_cloudflare_proxy_context(headers) {
+        WebSocketAuth::FirstMessage
+    } else {
+        mode
+    }
 }
 
 fn has_valid_controller_ipc_token(
@@ -3563,6 +3572,40 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn websocket_cloudflare_context_cannot_use_trusted_network_bypass() {
+        let config = oauth_config();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            unix_timestamp_now(),
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let (state, _) = build_app_state(
+            config.clone(),
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            ErvState::new(config.runtime.database_path.clone()),
+            HvacState::new(config.runtime.database_path.clone()),
+            Arc::new(FakeErvWriter::default()),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app state");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "127.0.0.1".parse().expect("header"));
+
+        assert_eq!(
+            websocket_auth_mode(&state, &headers),
+            WebSocketAuth::TrustedNetwork
+        );
+
+        headers.insert("cf-connecting-ip", "127.0.0.1".parse().expect("header"));
+        assert_eq!(
+            websocket_auth_mode(&state, &headers),
+            WebSocketAuth::FirstMessage
+        );
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -583,7 +583,9 @@ async fn auth_middleware(
         CloudflareAccessServiceAuth::AbsentOrUserAccess => {}
     }
 
-    if should_skip_auth(request.method(), request.uri().path(), auth_mode) {
+    let route_class = route_authorization_class(request.method(), request.uri().path());
+
+    if should_skip_auth(route_class, auth_mode) {
         return next.run(request).await;
     }
 
@@ -597,7 +599,7 @@ async fn auth_middleware(
     match auth_mode {
         HttpAuthMode::Open => next.run(request).await,
         HttpAuthMode::OAuth => {
-            if state.auth.is_trusted_request(&headers) {
+            if state.auth.is_trusted_request(&headers) && !has_cloudflare_proxy_context(&headers) {
                 request.extensions_mut().insert(AuthenticatedUser {
                     email: "trusted_network".to_string(),
                 });
@@ -643,25 +645,70 @@ async fn auth_middleware(
     }
 }
 
-fn should_skip_auth(method: &Method, path: &str, auth_mode: HttpAuthMode) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteAuthorizationClass {
+    Preflight,
+    PublicArtifact,
+    PublicStatic,
+    MobileBootstrap,
+    WebSocket,
+    AdminUpload,
+    Authenticated,
+}
+
+fn route_authorization_class(method: &Method, path: &str) -> RouteAuthorizationClass {
     if *method == Method::OPTIONS {
-        return true;
+        return RouteAuthorizationClass::Preflight;
     }
 
     if path == "/apk" || path.starts_with("/apps/") {
-        return true;
+        return RouteAuthorizationClass::PublicArtifact;
     }
 
-    matches!(auth_mode, HttpAuthMode::OAuth)
-        && (path == "/auth/login"
-            || path == "/auth/callback"
-            || path == "/auth/device/start"
-            || path == "/auth/device/poll"
-            || path == "/"
-            || path == "/index.html"
-            || path.starts_with("/assets/")
-            || path.ends_with(".png")
-            || path.ends_with(".json"))
+    if *method == Method::POST && path.starts_with("/deploy/") {
+        return RouteAuthorizationClass::AdminUpload;
+    }
+
+    if path == "/ws" {
+        return RouteAuthorizationClass::WebSocket;
+    }
+
+    if path == "/auth/login"
+        || path == "/auth/callback"
+        || path == "/auth/device/start"
+        || path == "/auth/device/poll"
+    {
+        return RouteAuthorizationClass::MobileBootstrap;
+    }
+
+    if path == "/"
+        || path == "/index.html"
+        || path.starts_with("/assets/")
+        || path.ends_with(".png")
+        || path.ends_with(".json")
+    {
+        return RouteAuthorizationClass::PublicStatic;
+    }
+
+    RouteAuthorizationClass::Authenticated
+}
+
+fn should_skip_auth(route_class: RouteAuthorizationClass, auth_mode: HttpAuthMode) -> bool {
+    matches!(
+        route_class,
+        RouteAuthorizationClass::Preflight | RouteAuthorizationClass::PublicArtifact
+    ) || (matches!(auth_mode, HttpAuthMode::OAuth)
+        && matches!(
+            route_class,
+            RouteAuthorizationClass::MobileBootstrap | RouteAuthorizationClass::PublicStatic
+        ))
+}
+
+fn has_cloudflare_proxy_context(headers: &HeaderMap) -> bool {
+    headers.contains_key("cf-access-jwt-assertion")
+        || headers.contains_key("cf-connecting-ip")
+        || headers.contains_key("cf-ray")
+        || headers.contains_key("cf-visitor")
 }
 
 fn artifact_upload_body_limit() -> usize {
@@ -2002,9 +2049,21 @@ async fn deploy_app(
     Path(app): Path<String>,
     multipart: Multipart,
 ) -> Response {
-    let user_email = user
-        .map(|Extension(user)| user.email)
-        .unwrap_or_else(|| "unknown".to_string());
+    let Some(Extension(user)) = user else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Admin authentication required"})),
+        )
+            .into_response();
+    };
+    if !state.auth.is_admin_user(&user.email) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "Admin access required"})),
+        )
+            .into_response();
+    }
+    let user_email = user.email;
     match state
         .artifacts
         .store_upload(&app, multipart, &user_email)
@@ -2558,6 +2617,7 @@ mod tests {
     fn oauth_config() -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig {
+                admin_emails: vec!["engineer@rajeshgo.li".to_string()],
                 google_oauth: Some(GoogleOAuthConfig {
                     client_id: "client".to_string(),
                     client_secret: "secret".to_string(),
@@ -3109,6 +3169,54 @@ mod tests {
         assert_eq!(value["login_url"], "/auth/login");
     }
 
+    #[test]
+    fn route_authorization_matrix_classifies_current_route_groups() {
+        assert_eq!(
+            route_authorization_class(&Method::OPTIONS, "/status"),
+            RouteAuthorizationClass::Preflight
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/apps/office-climate/latest.apk"),
+            RouteAuthorizationClass::PublicArtifact
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/apk"),
+            RouteAuthorizationClass::PublicArtifact
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/"),
+            RouteAuthorizationClass::PublicStatic
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/assets/app.js"),
+            RouteAuthorizationClass::PublicStatic
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/auth/login"),
+            RouteAuthorizationClass::MobileBootstrap
+        );
+        assert_eq!(
+            route_authorization_class(&Method::POST, "/auth/device/start"),
+            RouteAuthorizationClass::MobileBootstrap
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/ws"),
+            RouteAuthorizationClass::WebSocket
+        );
+        assert_eq!(
+            route_authorization_class(&Method::POST, "/deploy/office-climate"),
+            RouteAuthorizationClass::AdminUpload
+        );
+        assert_eq!(
+            route_authorization_class(&Method::GET, "/status"),
+            RouteAuthorizationClass::Authenticated
+        );
+        assert_eq!(
+            route_authorization_class(&Method::POST, "/erv"),
+            RouteAuthorizationClass::Authenticated
+        );
+    }
+
     #[tokio::test]
     async fn controller_ipc_token_allows_local_edge_calls() {
         let mut config = oauth_config();
@@ -3142,6 +3250,97 @@ mod tests {
         let response = app(config).oneshot(request).await.expect("response");
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn deploy_requires_explicit_admin_identity() {
+        let boundary = "deploy-boundary";
+        let response = app(test_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let mut config = oauth_config();
+        config.orchestrator.admin_emails = vec!["admin@rajeshgo.li".to_string()];
+        config
+            .orchestrator
+            .google_oauth
+            .as_mut()
+            .expect("oauth")
+            .allowed_emails = vec![
+            "engineer@rajeshgo.li".to_string(),
+            "admin@rajeshgo.li".to_string(),
+        ];
+        let user_token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {user_token}"))
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header("x-forwarded-for", "127.0.0.1")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let admin_token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("admin@rajeshgo.li")
+            .expect("token");
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {admin_token}"))
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -3304,6 +3503,25 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn oauth_cloudflare_loopback_request_cannot_use_trusted_network_bypass() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .header("x-forwarded-for", "127.0.0.1")
+                    .header("cf-connecting-ip", "127.0.0.1")
+                    .header("cf-ray", "test-ray")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -624,7 +624,8 @@ async fn auth_middleware(
             next.run(request).await
         }
         HttpAuthMode::Basic => {
-            if state.auth.verify_basic_header(&headers) {
+            if let Some(user) = state.auth.verify_basic_header_user(&headers) {
+                request.extensions_mut().insert(user);
                 let mut response = next.run(request).await;
                 if let Some(cookie) = state.auth.issue_basic_websocket_cookie() {
                     if let Ok(cookie) = cookie.parse() {
@@ -3335,6 +3336,46 @@ mod tests {
                         format!("multipart/form-data; boundary={boundary}"),
                     )
                     .header(header::AUTHORIZATION, format!("Bearer {admin_token}"))
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn basic_deploy_requires_configured_admin_principal() {
+        let boundary = "deploy-boundary";
+        let mut config = basic_config();
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+                    .body(Body::from(multipart_body(boundary, b"apk-bytes")))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        config.orchestrator.admin_emails = vec!["user".to_string()];
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
                     .body(Body::from(multipart_body(boundary, b"apk-bytes")))
                     .expect("request"),
             )


### PR DESCRIPTION
## Summary
- add explicit route authorization classification tests for public artifacts/static/bootstrap, authenticated routes, websocket, and admin uploads
- add `orchestrator.admin_emails` / `OFFICE_AUTOMATE_ADMIN_EMAILS` and require explicit admin identity for `/deploy`
- reject Cloudflare-shaped loopback requests from using trusted-network bypass unless Cloudflare Access service auth already succeeded

## Spec Reference
- `docs/working/100_security_threat_model.md`

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml --lib` (217 passed)
- [x] `git diff --check`

Fixes #106
