### PR TITLE
Store Android device keys in Android Keystore

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.OfficeClimate"
-        android:usesCleartextTraffic="true">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -6,15 +6,12 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.ByteArrayInputStream
 import java.net.Socket
-import java.security.KeyFactory
 import java.security.Principal
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
-import java.security.spec.PKCS8EncodedKeySpec
-import java.util.Base64
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedKeyManager
 import javax.net.ssl.TrustManagerFactory
@@ -51,9 +48,8 @@ class HttpClientFactory(
 
         val alias = settingsRepository.deviceCertificateAlias.first().trim()
         val certificateChainPem = settingsRepository.deviceCertificateChainPem.first().trim()
-        val privateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8.first().trim()
-        if (alias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
-            runCatching { loadClientCertificate(alias, certificateChainPem, privateKeyPkcs8) }
+        if (alias.isNotBlank() && certificateChainPem.isNotBlank()) {
+            runCatching { loadClientCertificate(alias, certificateChainPem) }
                 .onSuccess { sslConfig ->
                     sslConfig?.let { (sslSocketFactory, trustManager) ->
                         builder.sslSocketFactory(sslSocketFactory, trustManager)
@@ -70,13 +66,12 @@ class HttpClientFactory(
     private fun loadClientCertificate(
         alias: String,
         certificateChainPem: String,
-        privateKeyPkcs8: String,
     ): Pair<SSLSocketFactory, X509TrustManager>? {
         val certificateChain = decodeCertificates(certificateChainPem)
         if (certificateChain.isEmpty()) {
             return null
         }
-        val privateKey = decodePrivateKey(privateKeyPkcs8)
+        val privateKey = loadPrivateKey(alias) ?: return null
 
         val keyManager = SingleAliasKeyManager(
             alias = alias,
@@ -109,13 +104,14 @@ class HttpClientFactory(
             .filterIsInstance<X509Certificate>()
     }
 
-    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey {
-        val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8)
-        return KeyFactory.getInstance("EC").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
-    }
+    private fun loadPrivateKey(alias: String): PrivateKey? =
+        KeyStore.getInstance(ANDROID_KEYSTORE)
+            .apply { load(null) }
+            .getKey(alias, null) as? PrivateKey
 
     private companion object {
         const val TAG = "HttpClientFactory"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 
     private class SingleAliasKeyManager(

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -1,5 +1,7 @@
 package com.rajesh.officeclimate.data.repository
 
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -17,10 +19,11 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
 import java.io.StringWriter
+import java.net.URI
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.KeyStore
 import java.security.spec.ECGenParameterSpec
-import java.util.Base64
 import java.util.UUID
 
 @Serializable
@@ -59,8 +62,9 @@ class DeviceEnrollmentRepository(
         pairingCode: String,
         deviceName: String,
     ): DeviceEnrollmentResult = withContext(Dispatchers.IO) {
+        validatePairingUrl(pairingUrl)
         val alias = "office-device-${UUID.randomUUID()}"
-        val keyPair = generateKeyPair()
+        val keyPair = generateKeyPair(alias)
         try {
             val requestBody = DeviceEnrollmentRequest(
                 pairingCode = pairingCode.trim(),
@@ -89,9 +93,9 @@ class DeviceEnrollmentRepository(
                 }
 
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
-                settingsRepository.saveDeviceCertificateChainPem(payload.certificatePem)
-                settingsRepository.saveDevicePrivateKeyPkcs8(encodePrivateKeyPkcs8(keyPair))
+                settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
                 settingsRepository.saveDeviceCertificateAlias(alias)
+                settingsRepository.clearDevicePrivateKeyPkcs8()
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -101,14 +105,23 @@ class DeviceEnrollmentRepository(
                 )
             }
         } catch (e: Exception) {
-            clearDeviceCredential()
+            clearDeviceCredential(alias)
             throw e
         }
     }
 
-    private fun generateKeyPair(): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance("EC")
-        keyPairGenerator.initialize(ECGenParameterSpec("secp256r1"))
+    private fun generateKeyPair(alias: String): KeyPair {
+        val keyPairGenerator = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_EC,
+            ANDROID_KEYSTORE,
+        )
+        keyPairGenerator.initialize(
+            KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_SIGN)
+                .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .setUserAuthenticationRequired(false)
+                .build(),
+        )
         return keyPairGenerator.generateKeyPair()
     }
 
@@ -132,12 +145,36 @@ class DeviceEnrollmentRepository(
         return writer.toString()
     }
 
-    private fun encodePrivateKeyPkcs8(keyPair: KeyPair): String =
-        Base64.getEncoder().encodeToString(keyPair.private.encoded)
-
-    private suspend fun clearDeviceCredential() {
+    private suspend fun clearDeviceCredential(alias: String) {
+        deleteDeviceKey(alias)
         settingsRepository.clearDeviceCertificateAlias()
         settingsRepository.clearDeviceCertificateChainPem()
         settingsRepository.clearDevicePrivateKeyPkcs8()
+    }
+
+    private fun deleteDeviceKey(alias: String) {
+        runCatching {
+            KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
+        }
+    }
+
+    private fun validatePairingUrl(pairingUrl: String) {
+        val uri = runCatching { URI(pairingUrl.trim()) }.getOrNull()
+            ?: throw IllegalArgumentException("Pairing URL is not valid.")
+        val scheme = uri.scheme?.lowercase()
+        if (scheme == "https") {
+            return
+        }
+        if (scheme == "http" && uri.host == LOCAL_PAIRING_HOST) {
+            return
+        }
+        throw IllegalArgumentException(
+            "HTTP pairing is only allowed for $LOCAL_PAIRING_HOST. Use the default pairing URL or an HTTPS endpoint.",
+        )
+    }
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val LOCAL_PAIRING_HOST = "192.168.5.10"
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -10,6 +10,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.net.URI
+import java.security.KeyStore
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
@@ -21,7 +23,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("device_certificate_alias")
         val DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("device_certificate_chain_pem")
-        val DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
+        val LEGACY_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
         val DISMISSED_APP_NOTIFICATION_IDS = stringSetPreferencesKey("dismissed_app_notification_ids")
     }
@@ -46,21 +48,13 @@ class SettingsRepository(private val context: Context) {
         prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
     }
 
-    val devicePrivateKeyPkcs8: Flow<String> = context.dataStore.data.map { prefs ->
-        prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] ?: ""
-    }
-
     val isLoggedIn: Flow<Boolean> = context.dataStore.data.map { prefs ->
         !prefs[Keys.JWT_TOKEN].isNullOrBlank()
     }
 
     val isAuthenticated: Flow<Boolean> = context.dataStore.data.map { prefs ->
         !prefs[Keys.JWT_TOKEN].isNullOrBlank() ||
-            (
-                !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
-                    !prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM].isNullOrBlank() &&
-                    !prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8].isNullOrBlank()
-                )
+            hasValidDeviceCredential(prefs)
     }
 
     val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->
@@ -72,8 +66,12 @@ class SettingsRepository(private val context: Context) {
     }
 
     suspend fun saveServerUrl(serverUrl: String) {
+        val normalized = serverUrl.trimEnd('/')
+        require(isSecurePublicUrl(normalized)) {
+            "Public server URL must use HTTPS. Use the local pairing URL only for device enrollment."
+        }
         context.dataStore.edit { prefs ->
-            prefs[Keys.SERVER_URL] = serverUrl.trimEnd('/')
+            prefs[Keys.SERVER_URL] = normalized
         }
     }
 
@@ -96,12 +94,6 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun saveDevicePrivateKeyPkcs8(privateKeyPkcs8: String) {
-        context.dataStore.edit { prefs ->
-            prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
-        }
-    }
-
     suspend fun clearDeviceCertificateAlias() {
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
@@ -116,7 +108,20 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun clearDevicePrivateKeyPkcs8() {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.DEVICE_PRIVATE_KEY_PKCS8)
+            prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
+        }
+    }
+
+    suspend fun clearInvalidDeviceCredentialIfNeeded() {
+        context.dataStore.edit { prefs ->
+            if (
+                !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
+                    !hasValidDeviceCredential(prefs)
+            ) {
+                prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
+                prefs.remove(Keys.DEVICE_CERTIFICATE_CHAIN_PEM)
+                prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
+            }
         }
     }
 
@@ -139,5 +144,27 @@ class SettingsRepository(private val context: Context) {
             dismissed.add(id)
             prefs[Keys.DISMISSED_APP_NOTIFICATION_IDS] = dismissed
         }
+    }
+
+    private fun isSecurePublicUrl(url: String): Boolean {
+        val uri = runCatching { URI(url) }.getOrNull() ?: return false
+        return uri.scheme.equals("https", ignoreCase = true)
+    }
+
+    private fun hasValidDeviceCredential(prefs: Preferences): Boolean {
+        val alias = prefs[Keys.DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
+        val certificateChain = prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
+        return alias.isNotBlank() && certificateChain.isNotBlank() && hasDevicePrivateKey(alias)
+    }
+
+    private fun hasDevicePrivateKey(alias: String): Boolean =
+        runCatching {
+            KeyStore.getInstance(ANDROID_KEYSTORE)
+                .apply { load(null) }
+                .getKey(alias, null) != null
+        }.getOrDefault(false)
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
@@ -40,6 +40,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     init {
         viewModelScope.launch {
+            settingsRepo.clearInvalidDeviceCredentialIfNeeded()
             _uiState.value = _uiState.value.copy(
                 serverUrl = settingsRepo.serverUrl.first(),
                 userEmail = settingsRepo.userEmail.first(),
@@ -64,7 +65,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun saveServerUrl() {
         viewModelScope.launch {
-            settingsRepo.saveServerUrl(_uiState.value.serverUrl)
+            try {
+                settingsRepo.saveServerUrl(_uiState.value.serverUrl)
+                _uiState.value = _uiState.value.copy(error = null)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(error = e.message)
+            }
         }
     }
 
@@ -164,10 +170,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun logout() {
         viewModelScope.launch {
             settingsRepo.clearAuth()
-            val deviceCertificateAlias = settingsRepo.deviceCertificateAlias.first()
             _uiState.value = _uiState.value.copy(
                 userEmail = "",
-                isLoggedIn = deviceCertificateAlias.isNotBlank(),
+                isLoggedIn = settingsRepo.isAuthenticated.first(),
             )
         }
     }

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>192.168.5.10</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- generate Android device enrollment keys in AndroidKeyStore instead of storing PKCS8 private keys in DataStore
- load the enrolled private key by keystore alias for mTLS requests and clear legacy private-key preferences after enrollment
- require HTTPS for public server URLs and limit cleartext traffic to the local pairing host via network security config

## Spec Reference
- `docs/working/100_security_threat_model.md`
- Refs #107

## Security Note
This PR covers the Android secure-storage/no-cleartext-public-url slice of #107. Browser HttpOnly cookie, CSRF, CSP/security header, and CORS hardening remain for the next #107 slice.

Existing Android installs that paired before this change should re-enroll so the device private key is regenerated inside AndroidKeyStore.

## Test Plan
- [x] `./gradlew :app:assembleDebug`
- [x] `git diff --check main..HEAD`
