### PR TITLE
Harden browser session cookies and CSRF

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -12,7 +12,7 @@ import {
 import { STATUS_CONFIG } from './constants';
 import VitalTile from './components/VitalTile';
 import CO2Chart from './components/CO2Chart';
-import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, setPresence, setHVACTemperatureBands, ERVSpeed as ApiERVSpeed, HVACMode, HVACTemperatureBands, isAuthenticated, logout, getUserEmail, checkTrustedNetwork } from './api';
+import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, setPresence, setHVACTemperatureBands, ERVSpeed as ApiERVSpeed, HVACMode, HVACTemperatureBands, logout, checkTrustedNetwork } from './api';
 import Login from './Login';
 import HistoricalCharts from './HistoricalCharts';
 import OfficeReplay from './OfficeReplay';
@@ -156,23 +156,16 @@ const App: React.FC = () => {
     setUserEmail(null);
   };
 
-  // Check authentication on load - try trusted network first, then token
+  // Check authentication on load through the server-side session.
   useEffect(() => {
     if (!authChecking) return;
 
     checkTrustedNetwork().then((isTrusted) => {
       if (isTrusted) {
-        // Trusted network - no token needed
         setAuthenticated(true);
-        setUserEmail('Local Network');
-        setAuthChecking(false);
-      } else if (isAuthenticated()) {
-        // Not trusted network, but have a token - use it
-        setAuthenticated(true);
-        setUserEmail(getUserEmail());
+        setUserEmail('Authenticated');
         setAuthChecking(false);
       } else {
-        // No trusted network, no token - need login
         setAuthChecking(false);
       }
     });

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -19,14 +19,15 @@ const WS_URL = `${wsProtocol}//${API_HOST}${portSuffix}/ws`;
 
 const TOKEN_KEY = 'auth_token';
 const EMAIL_KEY = 'user_email';
+const CSRF_COOKIE = 'office_csrf';
+const CSRF_HEADER = 'X-CSRF-Token';
 
 export function getAuthToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+  return null;
 }
 
-export function setAuthToken(token: string, email: string) {
-  localStorage.setItem(TOKEN_KEY, token);
-  localStorage.setItem(EMAIL_KEY, email);
+export function setAuthToken(_token: string, _email: string) {
+  clearAuthToken();
 }
 
 export function clearAuthToken() {
@@ -35,11 +36,38 @@ export function clearAuthToken() {
 }
 
 export function getUserEmail(): string | null {
-  return localStorage.getItem(EMAIL_KEY);
+  return null;
 }
 
 export function isAuthenticated(): boolean {
-  return getAuthToken() !== null;
+  return false;
+}
+
+function getCsrfToken(): string | null {
+  const prefix = `${CSRF_COOKIE}=`;
+  const cookie = document.cookie
+    .split(';')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(prefix));
+  return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : null;
+}
+
+function addCsrfHeader(headers: HeadersInit = {}): HeadersInit {
+  const csrfToken = getCsrfToken();
+  if (!csrfToken) return headers;
+  return { ...headers, [CSRF_HEADER]: csrfToken };
+}
+
+function authFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const method = (init.method || 'GET').toUpperCase();
+  const headers = method === 'GET' || method === 'HEAD'
+    ? init.headers
+    : addCsrfHeader(init.headers);
+  return fetch(input, {
+    ...init,
+    headers,
+    credentials: 'include',
+  });
 }
 
 /**
@@ -48,8 +76,7 @@ export function isAuthenticated(): boolean {
  */
 export async function checkTrustedNetwork(): Promise<boolean> {
   try {
-    const response = await fetch(`${API_BASE}/status`);
-    // If we get 200 without a token, we're on a trusted network
+    const response = await authFetch(`${API_BASE}/status`);
     return response.ok;
   } catch {
     return false;
@@ -57,7 +84,8 @@ export async function checkTrustedNetwork(): Promise<boolean> {
 }
 
 export async function startLogin(): Promise<{ authorization_url: string }> {
-  const response = await fetch(`${API_BASE}/auth/login`);
+  clearAuthToken();
+  const response = await authFetch(`${API_BASE}/auth/login`);
   if (!response.ok) {
     throw new Error('Failed to initiate login');
   }
@@ -65,13 +93,7 @@ export async function startLogin(): Promise<{ authorization_url: string }> {
 }
 
 export async function logout(): Promise<void> {
-  const token = getAuthToken();
-  if (token) {
-    await fetch(`${API_BASE}/auth/logout`, {
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-  }
+  await authFetch(`${API_BASE}/auth/logout`, { method: 'POST' });
   clearAuthToken();
 }
 
@@ -138,14 +160,7 @@ export interface ApiEvent {
  * Fetch current status from orchestrator
  */
 export async function fetchStatus(): Promise<ApiStatus> {
-  const token = getAuthToken();
-  const headers: HeadersInit = {};
-
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/status`, { headers });
+  const response = await authFetch(`${API_BASE}/status`);
 
   if (response.status === 401) {
     clearAuthToken();
@@ -163,7 +178,7 @@ export async function fetchStatus(): Promise<ApiStatus> {
  * Fetch recent events from orchestrator
  */
 export async function fetchEvents(limit: number = 50): Promise<ApiEvent[]> {
-  const response = await fetch(`${API_BASE}/events?limit=${limit}`);
+  const response = await authFetch(`${API_BASE}/events?limit=${limit}`);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
   }
@@ -174,14 +189,7 @@ export async function fetchEvents(limit: number = 50): Promise<ApiEvent[]> {
  * Fetch historical data from orchestrator
  */
 export async function fetchHistory(hours: number = 24): Promise<any> {
-  const token = getAuthToken();
-  const headers: HeadersInit = {};
-
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/history?hours=${hours}`, { headers });
+  const response = await authFetch(`${API_BASE}/history?hours=${hours}`);
 
   if (response.status === 401) {
     clearAuthToken();
@@ -208,14 +216,9 @@ export type ERVSpeed = 'off' | 'quiet' | 'medium' | 'turbo';
  * Set ERV speed manually
  */
 export async function setERVSpeed(speed: ERVSpeed): Promise<{ ok: boolean; error?: string }> {
-  const token = getAuthToken();
   const headers: HeadersInit = { 'Content-Type': 'application/json' };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/erv`, {
+  const response = await authFetch(`${API_BASE}/erv`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ speed }),
@@ -236,14 +239,9 @@ export type PresenceState = 'present' | 'away';
  * Set HVAC mode manually
  */
 export async function setHVACMode(mode: HVACMode, setpoint_f: number = 70): Promise<{ ok: boolean; error?: string }> {
-  const token = getAuthToken();
   const headers: HeadersInit = { 'Content-Type': 'application/json' };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/hvac`, {
+  const response = await authFetch(`${API_BASE}/hvac`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ mode, setpoint_f }),
@@ -261,14 +259,9 @@ export async function setHVACMode(mode: HVACMode, setpoint_f: number = 70): Prom
  * Manually correct detected presence.
  */
 export async function setPresence(state: PresenceState): Promise<{ ok: boolean; error?: string; state?: string; is_present?: boolean }> {
-  const token = getAuthToken();
   const headers: HeadersInit = { 'Content-Type': 'application/json' };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/presence`, {
+  const response = await authFetch(`${API_BASE}/presence`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ state }),
@@ -293,14 +286,9 @@ export async function setHVACTemperatureBands(
   temperature_bands?: HVACTemperatureBands;
   temperature_band_defaults?: HVACTemperatureBands;
 }> {
-  const token = getAuthToken();
   const headers: HeadersInit = { 'Content-Type': 'application/json' };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(`${API_BASE}/hvac/temperature-bands`, {
+  const response = await authFetch(`${API_BASE}/hvac/temperature-bands`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ temperature_bands }),
@@ -333,11 +321,6 @@ export class StatusWebSocket {
 
       this.ws.onopen = () => {
         console.log('WebSocket connected');
-        // Send auth message first
-        const token = getAuthToken();
-        if (token) {
-          this.ws!.send(JSON.stringify({ type: 'auth', token }));
-        }
         this.onConnectionCallback?.(true);
         if (this.reconnectTimer) {
           clearTimeout(this.reconnectTimer);

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #09090b;
+  color: #fafafa;
+  margin: 0;
+  overflow-x: hidden;
+}
+
+.font-mono {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,31 +17,6 @@
 
     <!-- Theme color -->
     <meta name="theme-color" content="#09090b" />
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-      body {
-        font-family: 'Inter', sans-serif;
-        background-color: #09090b;
-        color: #fafafa;
-        margin: 0;
-        overflow-x: hidden;
-      }
-      .font-mono {
-        font-family: 'JetBrains+Mono', monospace;
-      }
-    </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react/": "https://esm.sh/react@^19.2.3/",
-    "react": "https://esm.sh/react@^19.2.3",
-    "react-dom/": "https://esm.sh/react-dom@^19.2.3/",
-    "recharts": "https://esm.sh/recharts@^3.6.0"
-  }
-}
-</script>
-<link rel="stylesheet" href="/index.css">
 </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,8 +16,24 @@
       "devDependencies": {
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -794,6 +810,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1390,6 +1444,85 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -1398,6 +1531,32 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -1434,6 +1593,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001762",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
@@ -1455,6 +1624,44 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1464,12 +1671,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -1626,12 +1856,36 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.43.0",
@@ -1701,6 +1955,46 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1719,6 +2013,33 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1734,6 +2055,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1742,6 +2073,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/immer": {
@@ -1761,6 +2118,78 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-tokens": {
@@ -1796,6 +2225,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1806,12 +2255,61 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -1839,6 +2337,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1857,6 +2402,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/postcss": {
@@ -1887,6 +2452,154 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.3",
@@ -1949,6 +2662,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
@@ -2000,6 +2749,39 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
@@ -2045,6 +2827,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2071,6 +2877,103 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -2093,6 +2996,26 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -2154,6 +3077,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -2258,6 +3188,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,9 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+export default {
+  content: [
+    './index.html',
+    './*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -29,6 +29,9 @@ const GOOGLE_TOKENINFO_URL: &str = "https://oauth2.googleapis.com/tokeninfo";
 const OAUTH_SCOPE: &str = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
 const BASIC_WS_COOKIE: &str = "office_basic_ws";
 const BASIC_WS_COOKIE_MAX_AGE_SECONDS: i64 = 600;
+pub const OAUTH_SESSION_COOKIE: &str = "office_auth";
+pub const OAUTH_CSRF_COOKIE: &str = "office_csrf";
+pub const OAUTH_CSRF_HEADER: &str = "x-csrf-token";
 
 #[derive(Clone)]
 pub struct AuthManager {
@@ -96,6 +99,18 @@ pub enum WebSocketAuth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthenticatedUser {
     pub email: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthCredentialSource {
+    Bearer,
+    SessionCookie,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedOAuthRequest {
+    pub user: AuthenticatedUser,
+    pub source: OAuthCredentialSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,6 +241,35 @@ impl AuthManager {
             .map(|email| AuthenticatedUser { email })
     }
 
+    pub fn verify_oauth_request(&self, headers: &HeaderMap) -> Option<VerifiedOAuthRequest> {
+        if let Some(user) = self.verify_bearer_header(headers) {
+            return Some(VerifiedOAuthRequest {
+                user,
+                source: OAuthCredentialSource::Bearer,
+            });
+        }
+
+        let token = oauth_session_cookie(headers)?;
+        self.verify_jwt(token).map(|email| VerifiedOAuthRequest {
+            user: AuthenticatedUser { email },
+            source: OAuthCredentialSource::SessionCookie,
+        })
+    }
+
+    pub fn bearer_or_session_token<'a>(&self, headers: &'a HeaderMap) -> Option<&'a str> {
+        bearer_token(headers).or_else(|| oauth_session_cookie(headers))
+    }
+
+    pub fn verify_oauth_csrf(&self, headers: &HeaderMap) -> bool {
+        let Some(header_token) = headers.get(OAUTH_CSRF_HEADER).and_then(header_to_str) else {
+            return false;
+        };
+        let Some(cookie_token) = cookie_value(headers, OAUTH_CSRF_COOKIE) else {
+            return false;
+        };
+        !header_token.is_empty() && header_token == cookie_token
+    }
+
     pub async fn verify_cloudflare_access_assertion(
         &self,
         token: &str,
@@ -317,6 +361,27 @@ impl AuthManager {
         ))
     }
 
+    pub fn issue_oauth_session_cookies(&self, token: &str) -> Option<Vec<String>> {
+        let oauth = self.inner.oauth.as_ref()?;
+        let max_age = oauth.token_expiry_days.max(1) * 24 * 60 * 60;
+        let csrf_token = random_url_token(32);
+        Some(vec![
+            format!(
+                "{OAUTH_SESSION_COOKIE}={token}; Max-Age={max_age}; Path=/; HttpOnly; Secure; SameSite=Lax"
+            ),
+            format!(
+                "{OAUTH_CSRF_COOKIE}={csrf_token}; Max-Age={max_age}; Path=/; Secure; SameSite=Lax"
+            ),
+        ])
+    }
+
+    pub fn clear_oauth_session_cookies() -> [&'static str; 2] {
+        [
+            "office_auth=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax",
+            "office_csrf=; Max-Age=0; Path=/; Secure; SameSite=Lax",
+        ]
+    }
+
     pub fn verify_basic_websocket_auth(&self, headers: &HeaderMap) -> bool {
         self.verify_basic_header(headers) || self.verify_basic_websocket_cookie(headers)
     }
@@ -391,7 +456,7 @@ impl AuthManager {
             if self.is_trusted_request(headers) {
                 return WebSocketAuth::TrustedNetwork;
             }
-            if self.verify_bearer_header(headers).is_some() {
+            if self.verify_oauth_request(headers).is_some() {
                 return WebSocketAuth::UpgradeBearer;
             }
             WebSocketAuth::FirstMessage
@@ -713,6 +778,10 @@ pub fn bearer_token(headers: &HeaderMap) -> Option<&str> {
         .get(header::AUTHORIZATION)
         .and_then(header_to_str)?
         .strip_prefix("Bearer ")
+}
+
+fn oauth_session_cookie(headers: &HeaderMap) -> Option<&str> {
+    cookie_value(headers, OAUTH_SESSION_COOKIE)
 }
 
 fn forwarded_client_ip(headers: &HeaderMap) -> Option<&str> {

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -361,24 +361,26 @@ impl AuthManager {
         ))
     }
 
-    pub fn issue_oauth_session_cookies(&self, token: &str) -> Option<Vec<String>> {
+    pub fn issue_oauth_session_cookies(&self, token: &str, secure: bool) -> Option<Vec<String>> {
         let oauth = self.inner.oauth.as_ref()?;
         let max_age = oauth.token_expiry_days.max(1) * 24 * 60 * 60;
         let csrf_token = random_url_token(32);
+        let secure_attribute = secure.then_some("; Secure").unwrap_or("");
         Some(vec![
             format!(
-                "{OAUTH_SESSION_COOKIE}={token}; Max-Age={max_age}; Path=/; HttpOnly; Secure; SameSite=Lax"
+                "{OAUTH_SESSION_COOKIE}={token}; Max-Age={max_age}; Path=/; HttpOnly{secure_attribute}; SameSite=Lax"
             ),
             format!(
-                "{OAUTH_CSRF_COOKIE}={csrf_token}; Max-Age={max_age}; Path=/; Secure; SameSite=Lax"
+                "{OAUTH_CSRF_COOKIE}={csrf_token}; Max-Age={max_age}; Path=/{secure_attribute}; SameSite=Lax"
             ),
         ])
     }
 
-    pub fn clear_oauth_session_cookies() -> [&'static str; 2] {
+    pub fn clear_oauth_session_cookies(secure: bool) -> [String; 2] {
+        let secure_attribute = secure.then_some("; Secure").unwrap_or("");
         [
-            "office_auth=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax",
-            "office_csrf=; Max-Age=0; Path=/; Secure; SameSite=Lax",
+            format!("office_auth=; Max-Age=0; Path=/; HttpOnly{secure_attribute}; SameSite=Lax"),
+            format!("office_csrf=; Max-Age=0; Path=/{secure_attribute}; SameSite=Lax"),
         ]
     }
 
@@ -577,6 +579,7 @@ impl AuthManager {
             email,
             jwt,
             platform: pending.platform,
+            secure_cookie: pending.redirect_uri.starts_with("https://"),
             refresh_token: token_response.refresh_token,
             access_token: token_response.access_token,
         }))
@@ -736,6 +739,7 @@ pub struct FinishedOAuthLogin {
     pub email: String,
     pub jwt: String,
     pub platform: Option<String>,
+    pub secure_cookie: bool,
     pub access_token: Option<String>,
     pub refresh_token: Option<String>,
 }

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -914,7 +914,7 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt),
+        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt, login.secure_cookie),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -941,7 +941,7 @@ async fn auth_logout(State(state): State<EdgeState>, headers: HeaderMap) -> Resp
 
     state.auth.invalidate_token(token);
     let mut response = Json(json!({"ok": true, "message": "Logged out"})).into_response();
-    append_clear_oauth_cookies(&mut response);
+    append_clear_oauth_cookies(&mut response, oauth_cookie_secure_from_headers(&headers));
     response
 }
 
@@ -1044,13 +1044,13 @@ fn escape_html_text(value: &str) -> String {
         .collect()
 }
 
-fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
+fn browser_login_response(auth: &AuthManager, token: &str, secure_cookie: bool) -> Response {
     let mut response = Response::builder()
         .status(StatusCode::FOUND)
         .header(header::LOCATION, "/")
         .body(Body::empty())
         .expect("valid browser login response");
-    if let Some(cookies) = auth.issue_oauth_session_cookies(token) {
+    if let Some(cookies) = auth.issue_oauth_session_cookies(token, secure_cookie) {
         for cookie in cookies {
             response.headers_mut().append(
                 header::SET_COOKIE,
@@ -1061,13 +1061,24 @@ fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
     response
 }
 
-fn append_clear_oauth_cookies(response: &mut Response) {
-    for cookie in AuthManager::clear_oauth_session_cookies() {
+fn append_clear_oauth_cookies(response: &mut Response, secure_cookie: bool) {
+    for cookie in AuthManager::clear_oauth_session_cookies(secure_cookie) {
         response.headers_mut().append(
             header::SET_COOKIE,
             cookie.parse().expect("valid clear cookie"),
         );
     }
+}
+
+fn oauth_cookie_secure_from_headers(headers: &HeaderMap) -> bool {
+    let host = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok());
+    crate::auth::resolve_redirect_scheme(host, forwarded_proto) == "https"
 }
 
 fn is_loopback_bind_host(host: &str) -> bool {
@@ -1114,7 +1125,7 @@ mod tests {
 
     fn oauth_cookie_header(auth: &AuthManager, token: &str) -> (String, String) {
         let cookies = auth
-            .issue_oauth_session_cookies(token)
+            .issue_oauth_session_cookies(token, true)
             .expect("oauth cookies");
         let cookie_header = cookies
             .iter()

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -15,7 +15,7 @@ use axum::{
         ConnectInfo, OriginalUri, Path, Query, Request, State, WebSocketUpgrade,
         ws::{CloseFrame, Message, WebSocket},
     },
-    http::{HeaderMap, HeaderValue, Method, StatusCode, Uri, header},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header},
     middleware::{self, Next},
     response::{Html, IntoResponse, Response},
     routing::{get, get_service, post},
@@ -29,14 +29,10 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{Message as TungsteniteMessage, client::IntoClientRequest},
 };
-use tower_http::{
-    cors::{Any, CorsLayer},
-    services::ServeDir,
-    trace::TraceLayer,
-};
+use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
 
 use crate::{
-    auth::{AuthManager, HttpAuthMode, WebSocketAuth, bearer_token},
+    auth::{AuthManager, HttpAuthMode, OAUTH_CSRF_HEADER, OAuthCredentialSource, WebSocketAuth},
     config::OrchestratorConfig,
     http::CONTROLLER_IPC_TOKEN_HEADER,
 };
@@ -95,6 +91,7 @@ struct EdgeState {
     auth: AuthManager,
     controller: ControllerClient,
     frontend_dist: PathBuf,
+    public_url: Option<String>,
     rate_limiter: Arc<Mutex<HashMap<String, VecDeque<Instant>>>>,
 }
 
@@ -181,6 +178,7 @@ pub fn app(config: PublicEdgeConfig) -> Result<Router> {
         auth: AuthManager::new(&config.orchestrator)?,
         controller: ControllerClient::new(&config.controller)?,
         frontend_dist: config.runtime.frontend_dist.clone(),
+        public_url: config.runtime.public_url.clone(),
         rate_limiter: Arc::new(Mutex::new(HashMap::new())),
     };
     Ok(router_from_state(state))
@@ -231,10 +229,7 @@ fn validate_public_edge_config(config: &PublicEdgeConfig) -> Result<()> {
 }
 
 fn router_from_state(state: EdgeState) -> Router {
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+    let cors = cors_layer(state.public_url.as_deref());
     let assets_dir = state.frontend_dist.join("assets");
 
     Router::new()
@@ -277,8 +272,58 @@ fn router_from_state(state: EdgeState) -> Router {
             edge_auth_middleware,
         ))
         .with_state(state)
+        .layer(middleware::from_fn(security_headers_middleware))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
+}
+
+fn cors_layer(public_url: Option<&str>) -> CorsLayer {
+    let mut layer = CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            HeaderName::from_static(OAUTH_CSRF_HEADER),
+        ]);
+    if let Some(origin) = public_origin_header(public_url) {
+        layer = layer.allow_origin(origin).allow_credentials(true);
+    }
+    layer
+}
+
+fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
+    let url = Url::parse(public_url?).ok()?;
+    let host = url.host_str()?;
+    let origin = match url.port() {
+        Some(port) => format!("{}://{host}:{port}", url.scheme()),
+        None => format!("{}://{host}", url.scheme()),
+    };
+    HeaderValue::from_str(&origin).ok()
+}
+
+async fn security_headers_middleware(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        header::STRICT_TRANSPORT_SECURITY,
+        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+        ),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    response
 }
 
 async fn edge_auth_middleware(
@@ -301,8 +346,8 @@ async fn edge_auth_middleware(
         return next.run(request).await;
     }
 
-    let Some(user) = state.auth.verify_bearer_header(&headers) else {
-        let missing = bearer_token(&headers).is_none();
+    let Some(verified) = state.auth.verify_oauth_request(&headers) else {
+        let missing = state.auth.bearer_or_session_token(&headers).is_none();
         let message = if missing {
             "Authentication required"
         } else {
@@ -315,6 +360,18 @@ async fn edge_auth_middleware(
             .into_response();
     };
 
+    if verified.source == OAuthCredentialSource::SessionCookie
+        && requires_csrf(request.method())
+        && !state.auth.verify_oauth_csrf(&headers)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "CSRF token required"})),
+        )
+            .into_response();
+    }
+
+    let user = verified.user;
     if is_control_route(request.method(), request.uri().path()) {
         let actor = rate_limit_actor(remote_addr, &user.email, request.uri().path());
         if !allow_control_request(&state, actor) {
@@ -727,6 +784,13 @@ fn should_skip_auth(method: &Method, path: &str, auth_mode: HttpAuthMode) -> boo
             || path.ends_with(".json"))
 }
 
+fn requires_csrf(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    )
+}
+
 fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
     headers
         .get(header::UPGRADE)
@@ -833,14 +897,7 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => {
-            let token = script_json_string(&login.jwt);
-            let email = script_json_string(&login.email);
-            Html(format!(
-                "<html><head><script>localStorage.setItem('auth_token', {token});localStorage.setItem('user_email', {email});window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
-            ))
-            .into_response()
-        }
+        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -857,7 +914,7 @@ async fn auth_callback(
 }
 
 async fn auth_logout(State(state): State<EdgeState>, headers: HeaderMap) -> Response {
-    let Some(token) = bearer_token(&headers) else {
+    let Some(token) = state.auth.bearer_or_session_token(&headers) else {
         return (
             StatusCode::UNAUTHORIZED,
             Json(json!({"error": "No token provided"})),
@@ -866,7 +923,9 @@ async fn auth_logout(State(state): State<EdgeState>, headers: HeaderMap) -> Resp
     };
 
     state.auth.invalidate_token(token);
-    Json(json!({"ok": true, "message": "Logged out"})).into_response()
+    let mut response = Json(json!({"ok": true, "message": "Logged out"})).into_response();
+    append_clear_oauth_cookies(&mut response);
+    response
 }
 
 async fn auth_device_start(State(state): State<EdgeState>) -> Response {
@@ -968,12 +1027,30 @@ fn escape_html_text(value: &str) -> String {
         .collect()
 }
 
-fn script_json_string(value: &str) -> String {
-    serde_json::to_string(value)
-        .expect("string serializes")
-        .replace('<', "\\u003c")
-        .replace('>', "\\u003e")
-        .replace('&', "\\u0026")
+fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
+    let mut response = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, "/")
+        .body(Body::empty())
+        .expect("valid browser login response");
+    if let Some(cookies) = auth.issue_oauth_session_cookies(token) {
+        for cookie in cookies {
+            response.headers_mut().append(
+                header::SET_COOKIE,
+                cookie.parse().expect("valid OAuth session cookie"),
+            );
+        }
+    }
+    response
+}
+
+fn append_clear_oauth_cookies(response: &mut Response) {
+    for cookie in AuthManager::clear_oauth_session_cookies() {
+        response.headers_mut().append(
+            header::SET_COOKIE,
+            cookie.parse().expect("valid clear cookie"),
+        );
+    }
 }
 
 fn is_loopback_bind_host(host: &str) -> bool {
@@ -1016,6 +1093,23 @@ mod tests {
                 public_url: Some("https://office.example.test".to_string()),
             },
         }
+    }
+
+    fn oauth_cookie_header(auth: &AuthManager, token: &str) -> (String, String) {
+        let cookies = auth
+            .issue_oauth_session_cookies(token)
+            .expect("oauth cookies");
+        let cookie_header = cookies
+            .iter()
+            .map(|cookie| cookie.split(';').next().expect("cookie pair"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        let csrf_token = cookie_header
+            .split("; ")
+            .find_map(|cookie| cookie.strip_prefix("office_csrf="))
+            .expect("csrf cookie")
+            .to_string();
+        (cookie_header, csrf_token)
     }
 
     #[test]
@@ -1165,6 +1259,110 @@ qingping:
             .expect("body");
         let payload: Value = serde_json::from_slice(&body).expect("json");
         assert_eq!(payload["source"], "controller");
+    }
+
+    #[tokio::test]
+    async fn edge_sets_security_headers_and_exact_cors_origin() {
+        let app = app(edge_config("http://127.0.0.1:9".to_string())).expect("edge app");
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/auth/login")
+                    .header(header::HOST, "office.example.test")
+                    .header(header::ORIGIN, "https://office.example.test")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .expect("cors origin"),
+            "https://office.example.test"
+        );
+        assert!(
+            response
+                .headers()
+                .contains_key(header::CONTENT_SECURITY_POLICY)
+        );
+        assert!(
+            response
+                .headers()
+                .contains_key(header::STRICT_TRANSPORT_SECURITY)
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::X_CONTENT_TYPE_OPTIONS)
+                .expect("nosniff"),
+            "nosniff"
+        );
+    }
+
+    #[tokio::test]
+    async fn edge_session_cookie_requires_csrf_before_forwarding_post() {
+        let controller = Router::new().route(
+            "/presence",
+            axum::routing::post(|headers: HeaderMap| async move {
+                let token = headers
+                    .get(CONTROLLER_IPC_TOKEN_HEADER)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("");
+                if token == "controller-token" {
+                    Json(json!({"ok": true})).into_response()
+                } else {
+                    StatusCode::UNAUTHORIZED.into_response()
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind controller");
+        let address = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, controller).await.expect("controller");
+        });
+
+        let config = edge_config(format!("http://{address}"));
+        let auth = AuthManager::new(&config.orchestrator).expect("auth");
+        let token = auth.generate_jwt("engineer@example.test").expect("token");
+        let (cookie_header, csrf_token) = oauth_cookie_header(&auth, &token);
+        let app = app(config).expect("edge app");
+        let payload = json!({"state": "away"}).to_string();
+
+        let response = app
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::COOKIE, cookie_header.as_str())
+                    .body(Body::from(payload.clone()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::COOKIE, cookie_header)
+                    .header(OAUTH_CSRF_HEADER, csrf_token)
+                    .body(Body::from(payload))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -29,7 +29,11 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{Message as TungsteniteMessage, client::IntoClientRequest},
 };
-use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
+use tower_http::{
+    cors::{AllowOrigin, CorsLayer},
+    services::ServeDir,
+    trace::TraceLayer,
+};
 
 use crate::{
     auth::{AuthManager, HttpAuthMode, OAUTH_CSRF_HEADER, OAuthCredentialSource, WebSocketAuth},
@@ -278,17 +282,22 @@ fn router_from_state(state: EdgeState) -> Router {
 }
 
 fn cors_layer(public_url: Option<&str>) -> CorsLayer {
-    let mut layer = CorsLayer::new()
+    CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([
             header::CONTENT_TYPE,
             header::AUTHORIZATION,
             HeaderName::from_static(OAUTH_CSRF_HEADER),
-        ]);
-    if let Some(origin) = public_origin_header(public_url) {
-        layer = layer.allow_origin(origin).allow_credentials(true);
+        ])
+        .allow_origin(allowed_cors_origins(public_url))
+        .allow_credentials(true)
+}
+
+fn allowed_cors_origins(public_url: Option<&str>) -> AllowOrigin {
+    match public_origin_header(public_url) {
+        Some(origin) => AllowOrigin::exact(origin),
+        None => AllowOrigin::list(local_dev_origins()),
     }
-    layer
 }
 
 fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
@@ -299,6 +308,14 @@ fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
         None => format!("{}://{host}", url.scheme()),
     };
     HeaderValue::from_str(&origin).ok()
+}
+
+fn local_dev_origins() -> [HeaderValue; 3] {
+    [
+        HeaderValue::from_static("http://localhost:9002"),
+        HeaderValue::from_static("http://127.0.0.1:9002"),
+        HeaderValue::from_static("http://[::1]:9002"),
+    ]
 }
 
 async fn security_headers_middleware(request: Request, next: Next) -> Response {
@@ -1300,6 +1317,31 @@ qingping:
                 .get(header::X_CONTENT_TYPE_OPTIONS)
                 .expect("nosniff"),
             "nosniff"
+        );
+    }
+
+    #[tokio::test]
+    async fn edge_allows_local_dev_cors_origin_when_public_url_unset() {
+        let mut config = edge_config("http://127.0.0.1:9".to_string());
+        config.runtime.public_url = None;
+        let app = app(config).expect("edge app");
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/auth/login")
+                    .header(header::ORIGIN, "http://localhost:9002")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .expect("cors origin"),
+            "http://localhost:9002"
         );
     }
 

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -30,7 +30,11 @@ use tokio::{
     task::JoinHandle,
     time::{self, timeout},
 };
-use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
+use tower_http::{
+    cors::{AllowOrigin, CorsLayer},
+    services::ServeDir,
+    trace::TraceLayer,
+};
 
 use crate::{
     artifacts::ARTIFACT_MAX_SIZE_BYTES,
@@ -451,17 +455,22 @@ fn router_from_state(state: AppState) -> Router {
 }
 
 fn cors_layer(public_url: Option<&str>) -> CorsLayer {
-    let mut layer = CorsLayer::new()
+    CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([
             header::CONTENT_TYPE,
             header::AUTHORIZATION,
             HeaderName::from_static(OAUTH_CSRF_HEADER),
-        ]);
-    if let Some(origin) = public_origin_header(public_url) {
-        layer = layer.allow_origin(origin).allow_credentials(true);
+        ])
+        .allow_origin(allowed_cors_origins(public_url))
+        .allow_credentials(true)
+}
+
+fn allowed_cors_origins(public_url: Option<&str>) -> AllowOrigin {
+    match public_origin_header(public_url) {
+        Some(origin) => AllowOrigin::exact(origin),
+        None => AllowOrigin::list(local_dev_origins()),
     }
-    layer
 }
 
 fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
@@ -472,6 +481,14 @@ fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
         None => format!("{}://{host}", url.scheme()),
     };
     HeaderValue::from_str(&origin).ok()
+}
+
+fn local_dev_origins() -> [HeaderValue; 3] {
+    [
+        HeaderValue::from_static("http://localhost:9002"),
+        HeaderValue::from_static("http://127.0.0.1:9002"),
+        HeaderValue::from_static("http://[::1]:9002"),
+    ]
 }
 
 async fn security_headers_middleware(request: Request, next: Next) -> Response {
@@ -3356,6 +3373,48 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn local_dev_cors_origin_allowed_when_public_url_unset() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/auth/login")
+                    .header(header::ORIGIN, "http://localhost:9002")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .expect("cors origin"),
+            "http://localhost:9002"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_local_dev_cors_origin_blocked_when_public_url_unset() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/auth/login")
+                    .header(header::ORIGIN, "https://evil.example.test")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert!(
+            !response
+                .headers()
+                .contains_key(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -15,12 +15,13 @@ use axum::{
         WebSocketUpgrade,
         ws::{CloseFrame, Message, WebSocket},
     },
-    http::{HeaderMap, Method, StatusCode, header},
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, header},
     middleware::{self, Next},
     response::{Html, IntoResponse, Response},
     routing::{get, get_service, post},
 };
 use chrono::{NaiveTime, Timelike};
+use reqwest::Url;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::{
@@ -29,16 +30,15 @@ use tokio::{
     task::JoinHandle,
     time::{self, timeout},
 };
-use tower_http::{
-    cors::{Any, CorsLayer},
-    services::ServeDir,
-    trace::TraceLayer,
-};
+use tower_http::{cors::CorsLayer, services::ServeDir, trace::TraceLayer};
 
 use crate::{
     artifacts::ARTIFACT_MAX_SIZE_BYTES,
     artifacts::{ArtifactStore, is_valid_artifact_hash},
-    auth::{AuthManager, AuthenticatedUser, HttpAuthMode, WebSocketAuth, bearer_token},
+    auth::{
+        AuthManager, AuthenticatedUser, HttpAuthMode, OAUTH_CSRF_HEADER, OAuthCredentialSource,
+        WebSocketAuth,
+    },
     automation::ErvPolicyCoordinator,
     config::{AppConfig, ThresholdsConfig},
     db,
@@ -396,10 +396,7 @@ fn build_app_state(
 }
 
 fn router_from_state(state: AppState) -> Router {
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+    let cors = cors_layer(state.config.runtime.public_url.as_deref());
 
     let frontend_dist = state.config.runtime.frontend_dist.clone();
     let assets_dir = frontend_dist.join("assets");
@@ -448,8 +445,58 @@ fn router_from_state(state: AppState) -> Router {
             auth_middleware,
         ))
         .with_state(state.clone())
+        .layer(middleware::from_fn(security_headers_middleware))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
+}
+
+fn cors_layer(public_url: Option<&str>) -> CorsLayer {
+    let mut layer = CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            HeaderName::from_static(OAUTH_CSRF_HEADER),
+        ]);
+    if let Some(origin) = public_origin_header(public_url) {
+        layer = layer.allow_origin(origin).allow_credentials(true);
+    }
+    layer
+}
+
+fn public_origin_header(public_url: Option<&str>) -> Option<HeaderValue> {
+    let url = Url::parse(public_url?).ok()?;
+    let host = url.host_str()?;
+    let origin = match url.port() {
+        Some(port) => format!("{}://{host}:{port}", url.scheme()),
+        None => format!("{}://{host}", url.scheme()),
+    };
+    HeaderValue::from_str(&origin).ok()
+}
+
+async fn security_headers_middleware(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        header::STRICT_TRANSPORT_SECURITY,
+        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+        ),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    response
 }
 
 pub async fn serve(config: AppConfig) -> Result<()> {
@@ -606,8 +653,8 @@ async fn auth_middleware(
                 return next.run(request).await;
             }
 
-            let Some(user) = state.auth.verify_bearer_header(&headers) else {
-                let missing = bearer_token(&headers).is_none();
+            let Some(verified) = state.auth.verify_oauth_request(&headers) else {
+                let missing = state.auth.bearer_or_session_token(&headers).is_none();
                 let message = if missing {
                     "Authentication required"
                 } else {
@@ -620,7 +667,18 @@ async fn auth_middleware(
                     .into_response();
             };
 
-            request.extensions_mut().insert(user);
+            if verified.source == OAuthCredentialSource::SessionCookie
+                && requires_csrf(request.method())
+                && !state.auth.verify_oauth_csrf(&headers)
+            {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({"error": "CSRF token required"})),
+                )
+                    .into_response();
+            }
+
+            request.extensions_mut().insert(verified.user);
             next.run(request).await
         }
         HttpAuthMode::Basic => {
@@ -703,6 +761,13 @@ fn should_skip_auth(route_class: RouteAuthorizationClass, auth_mode: HttpAuthMod
             route_class,
             RouteAuthorizationClass::MobileBootstrap | RouteAuthorizationClass::PublicStatic
         ))
+}
+
+fn requires_csrf(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    )
 }
 
 fn has_cloudflare_proxy_context(headers: &HeaderMap) -> bool {
@@ -2241,14 +2306,7 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => {
-            let token = script_json_string(&login.jwt);
-            let email = script_json_string(&login.email);
-            Html(format!(
-                "<html><head><script>localStorage.setItem('auth_token', {token});localStorage.setItem('user_email', {email});window.location.href = '/';</script></head><body><p>Login successful! Redirecting...</p></body></html>",
-            ))
-            .into_response()
-        }
+        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -2286,6 +2344,32 @@ fn script_json_string(value: &str) -> String {
         .replace('&', "\\u0026")
 }
 
+fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
+    let mut response = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, "/")
+        .body(Body::empty())
+        .expect("valid browser login response");
+    if let Some(cookies) = auth.issue_oauth_session_cookies(token) {
+        for cookie in cookies {
+            response.headers_mut().append(
+                header::SET_COOKIE,
+                cookie.parse().expect("valid OAuth session cookie"),
+            );
+        }
+    }
+    response
+}
+
+fn append_clear_oauth_cookies(response: &mut Response) {
+    for cookie in AuthManager::clear_oauth_session_cookies() {
+        response.headers_mut().append(
+            header::SET_COOKIE,
+            cookie.parse().expect("valid clear cookie"),
+        );
+    }
+}
+
 async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
     if !state.auth.oauth_enabled() {
         return (
@@ -2295,7 +2379,7 @@ async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Respo
             .into_response();
     }
 
-    let Some(token) = bearer_token(&headers) else {
+    let Some(token) = state.auth.bearer_or_session_token(&headers) else {
         return (
             StatusCode::UNAUTHORIZED,
             Json(json!({"error": "No token provided"})),
@@ -2304,7 +2388,9 @@ async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Respo
     };
 
     state.auth.invalidate_token(token);
-    Json(json!({"ok": true, "message": "Logged out"})).into_response()
+    let mut response = Json(json!({"ok": true, "message": "Logged out"})).into_response();
+    append_clear_oauth_cookies(&mut response);
+    response
 }
 
 async fn auth_device_start(State(state): State<AppState>) -> Response {
@@ -2651,6 +2737,23 @@ mod tests {
             },
             ..test_config()
         }
+    }
+
+    fn oauth_cookie_header(auth: &AuthManager, token: &str) -> (String, String) {
+        let cookies = auth
+            .issue_oauth_session_cookies(token)
+            .expect("oauth cookies");
+        let cookie_header = cookies
+            .iter()
+            .map(|cookie| cookie.split(';').next().expect("cookie pair"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        let csrf_token = cookie_header
+            .split("; ")
+            .find_map(|cookie| cookie.strip_prefix("office_csrf="))
+            .expect("csrf cookie")
+            .to_string();
+        (cookie_header, csrf_token)
     }
 
     #[test]
@@ -3177,6 +3280,82 @@ mod tests {
             .expect("read body");
         let value: Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(value["login_url"], "/auth/login");
+    }
+
+    #[test]
+    fn browser_login_response_sets_httponly_session_and_csrf_cookies() {
+        let config = oauth_config();
+        let auth = AuthManager::new(&config.orchestrator).expect("auth");
+        let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
+        let response = browser_login_response(&auth, &token);
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response.headers().get(header::LOCATION).expect("location"),
+            "/"
+        );
+        let cookies = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .map(|value| value.to_str().expect("cookie").to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            cookies
+                .iter()
+                .any(|cookie| cookie.starts_with("office_auth=")
+                    && cookie.contains("HttpOnly")
+                    && cookie.contains("Secure")
+                    && cookie.contains("SameSite=Lax"))
+        );
+        assert!(
+            cookies
+                .iter()
+                .any(|cookie| cookie.starts_with("office_csrf=")
+                    && !cookie.contains("HttpOnly")
+                    && cookie.contains("Secure")
+                    && cookie.contains("SameSite=Lax"))
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_session_cookie_requires_csrf_for_state_changing_routes() {
+        let config = oauth_config();
+        let auth = AuthManager::new(&config.orchestrator).expect("auth");
+        let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
+        let (cookie_header, csrf_token) = oauth_cookie_header(&auth, &token);
+        let service = app(config);
+        let payload = json!({"state": "away"}).to_string();
+
+        let response = service
+            .clone()
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::COOKIE, cookie_header.as_str())
+                    .body(Body::from(payload.clone()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::COOKIE, cookie_header)
+                    .header(OAUTH_CSRF_HEADER, csrf_token)
+                    .body(Body::from(payload))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2323,7 +2323,7 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt),
+        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt, login.secure_cookie),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -2361,13 +2361,13 @@ fn script_json_string(value: &str) -> String {
         .replace('&', "\\u0026")
 }
 
-fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
+fn browser_login_response(auth: &AuthManager, token: &str, secure_cookie: bool) -> Response {
     let mut response = Response::builder()
         .status(StatusCode::FOUND)
         .header(header::LOCATION, "/")
         .body(Body::empty())
         .expect("valid browser login response");
-    if let Some(cookies) = auth.issue_oauth_session_cookies(token) {
+    if let Some(cookies) = auth.issue_oauth_session_cookies(token, secure_cookie) {
         for cookie in cookies {
             response.headers_mut().append(
                 header::SET_COOKIE,
@@ -2378,8 +2378,8 @@ fn browser_login_response(auth: &AuthManager, token: &str) -> Response {
     response
 }
 
-fn append_clear_oauth_cookies(response: &mut Response) {
-    for cookie in AuthManager::clear_oauth_session_cookies() {
+fn append_clear_oauth_cookies(response: &mut Response, secure_cookie: bool) {
+    for cookie in AuthManager::clear_oauth_session_cookies(secure_cookie) {
         response.headers_mut().append(
             header::SET_COOKIE,
             cookie.parse().expect("valid clear cookie"),
@@ -2406,8 +2406,19 @@ async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Respo
 
     state.auth.invalidate_token(token);
     let mut response = Json(json!({"ok": true, "message": "Logged out"})).into_response();
-    append_clear_oauth_cookies(&mut response);
+    append_clear_oauth_cookies(&mut response, oauth_cookie_secure_from_headers(&headers));
     response
+}
+
+fn oauth_cookie_secure_from_headers(headers: &HeaderMap) -> bool {
+    let host = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok());
+    crate::auth::resolve_redirect_scheme(host, forwarded_proto) == "https"
 }
 
 async fn auth_device_start(State(state): State<AppState>) -> Response {
@@ -2758,7 +2769,7 @@ mod tests {
 
     fn oauth_cookie_header(auth: &AuthManager, token: &str) -> (String, String) {
         let cookies = auth
-            .issue_oauth_session_cookies(token)
+            .issue_oauth_session_cookies(token, true)
             .expect("oauth cookies");
         let cookie_header = cookies
             .iter()
@@ -3304,7 +3315,7 @@ mod tests {
         let config = oauth_config();
         let auth = AuthManager::new(&config.orchestrator).expect("auth");
         let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
-        let response = browser_login_response(&auth, &token);
+        let response = browser_login_response(&auth, &token, true);
 
         assert_eq!(response.status(), StatusCode::FOUND);
         assert_eq!(
@@ -3333,6 +3344,33 @@ mod tests {
                     && cookie.contains("Secure")
                     && cookie.contains("SameSite=Lax"))
         );
+    }
+
+    #[test]
+    fn browser_login_response_allows_nonsecure_cookies_for_local_http_oauth() {
+        let config = oauth_config();
+        let auth = AuthManager::new(&config.orchestrator).expect("auth");
+        let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
+        let response = browser_login_response(&auth, &token, false);
+
+        let cookies = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .map(|value| value.to_str().expect("cookie").to_string())
+            .collect::<Vec<_>>();
+        assert!(cookies.iter().any(|cookie| {
+            cookie.starts_with("office_auth=")
+                && cookie.contains("HttpOnly")
+                && !cookie.contains("Secure")
+                && cookie.contains("SameSite=Lax")
+        }));
+        assert!(cookies.iter().any(|cookie| {
+            cookie.starts_with("office_csrf=")
+                && !cookie.contains("HttpOnly")
+                && !cookie.contains("Secure")
+                && cookie.contains("SameSite=Lax")
+        }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- move browser OAuth login from localStorage bearer tokens to `HttpOnly; Secure; SameSite=Lax` session cookies plus a readable CSRF cookie
- require `X-CSRF-Token` for cookie-backed state-changing requests while preserving bearer/device paths
- add exact-origin CORS, security headers, and frontend cookie/CSRF request handling for the controller and public edge

## Spec Reference
- `docs/working/100_security_threat_model.md`
- Refs #107

## Security Note
This PR covers the browser cookie, CSRF, CSP/security-header, and narrow-CORS slice of #107. The remaining #107 follow-up is to remove or replace the Android OAuth custom-scheme fallback now that Android uses explicit device enrollment and mTLS.

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml --lib` (227 passed)
- [x] `npm run build`
- [x] `git diff --check`
