### PR TITLE
Harden Android artifact update integrity

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AppArtifactMetadata(
     @SerialName("artifact_hash") val artifactHash: String? = null,
+    @SerialName("sha256") val sha256: String? = null,
     @SerialName("uploaded_at") val uploadedAt: String? = null,
     @SerialName("size_bytes") val sizeBytes: Long? = null,
     @SerialName("uploaded_by") val uploadedBy: String? = null,

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
@@ -2,6 +2,9 @@ package com.rajesh.officeclimate.data.repository
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.content.FileProvider
 import com.rajesh.officeclimate.BuildConfig
 import com.rajesh.officeclimate.data.model.AppArtifactMetadata
@@ -22,8 +25,11 @@ import java.security.MessageDigest
 
 data class AvailableAppUpdate(
     val artifactHash: String,
+    val sha256: String,
     val versionName: String,
     val uploadedAt: String?,
+    val versionCode: Long?,
+    val sizeBytes: Long?,
 )
 
 class AppUpdateRepository(
@@ -32,16 +38,22 @@ class AppUpdateRepository(
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
     private val httpClientFactory = HttpClientFactory(settingsRepository)
-    @Volatile private var cachedCurrentArtifactHash: String? = null
+    @Volatile private var cachedCurrentBuildSha256: String? = null
 
     suspend fun getAvailableUpdate(): AvailableAppUpdate? {
         val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
         val metadata = fetchMetadata(serverUrl) ?: return null
         val serverArtifactHash = metadata.artifactHash?.trim()?.lowercase() ?: return null
-        val currentArtifactHash = currentBuildArtifactHash()
-        if (serverArtifactHash == currentArtifactHash) {
+        if (!isValidArtifactHash(serverArtifactHash)) {
             return null
         }
+        val serverSha256 = metadata.sha256?.trim()?.lowercase() ?: return null
+        if (!isValidSha256(serverSha256) || !serverSha256.startsWith(serverArtifactHash)) {
+            return null
+        }
+
+        val currentBuildSha256 = currentBuildSha256()
+        if (serverSha256 == currentBuildSha256) return null
 
         if (settingsRepository.dismissedUpdateArtifactHash.first() == serverArtifactHash) {
             return null
@@ -49,8 +61,11 @@ class AppUpdateRepository(
 
         return AvailableAppUpdate(
             artifactHash = serverArtifactHash,
+            sha256 = serverSha256,
             versionName = metadata.versionName ?: serverArtifactHash,
             uploadedAt = metadata.uploadedAt,
+            versionCode = metadata.versionCode,
+            sizeBytes = metadata.sizeBytes,
         )
     }
 
@@ -83,6 +98,7 @@ class AppUpdateRepository(
                 }
             }
 
+        verifyDownloadedUpdate(update, apkFile)
         apkFile
     }
 
@@ -112,23 +128,116 @@ class AppUpdateRepository(
         }
     }
 
-    private suspend fun currentBuildArtifactHash(): String {
-        cachedCurrentArtifactHash?.let { return it }
+    private suspend fun currentBuildSha256(): String {
+        cachedCurrentBuildSha256?.let { return it }
 
         val configuredHash = BuildConfig.APK_HASH.trim().lowercase()
-        if (configuredHash.isNotEmpty()) {
-            cachedCurrentArtifactHash = configuredHash
+        if (isValidSha256(configuredHash)) {
+            cachedCurrentBuildSha256 = configuredHash
             return configuredHash
         }
 
         return withContext(Dispatchers.IO) {
-            val computedHash = sha256Prefix(File(context.packageCodePath))
-            cachedCurrentArtifactHash = computedHash
+            val computedHash = sha256(File(context.packageCodePath))
+            cachedCurrentBuildSha256 = computedHash
             computedHash
         }
     }
 
-    private fun sha256Prefix(file: File): String {
+    private fun verifyDownloadedUpdate(update: AvailableAppUpdate, apkFile: File) {
+        if (update.sizeBytes != null && apkFile.length() != update.sizeBytes) {
+            throw IOException("Update APK size did not match metadata")
+        }
+
+        val actualSha256 = sha256(apkFile)
+        if (actualSha256 != update.sha256) {
+            apkFile.delete()
+            throw IOException("Update APK digest did not match metadata")
+        }
+
+        val archiveInfo = packageInfoForArchive(apkFile)
+            ?: throw IOException("Downloaded update is not a valid APK")
+        if (archiveInfo.packageName != context.packageName) {
+            throw IOException("Downloaded update package did not match installed app")
+        }
+
+        if (update.versionCode != null && packageVersionCode(archiveInfo) != update.versionCode) {
+            throw IOException("Downloaded update version did not match metadata")
+        }
+        if (packageVersionCode(archiveInfo) < installedVersionCode()) {
+            throw IOException("Downloaded update is older than the installed app")
+        }
+
+        val installedCertDigests = signingCertificateDigests(installedPackageInfo())
+        val updateCertDigests = signingCertificateDigests(archiveInfo)
+        if (installedCertDigests.isEmpty() || updateCertDigests.isEmpty()) {
+            throw IOException("Unable to verify update signing certificate")
+        }
+        if (installedCertDigests != updateCertDigests) {
+            throw IOException("Downloaded update signing certificate did not match installed app")
+        }
+    }
+
+    private fun packageInfoForArchive(apkFile: File): PackageInfo? {
+        val flags = signingPackageManagerFlags()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageArchiveInfo(
+                apkFile.absolutePath,
+                PackageManager.PackageInfoFlags.of(flags.toLong()),
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageArchiveInfo(apkFile.absolutePath, flags)
+        }
+    }
+
+    private fun installedPackageInfo(): PackageInfo {
+        val flags = signingPackageManagerFlags()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.PackageInfoFlags.of(flags.toLong()),
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(context.packageName, flags)
+        }
+    }
+
+    private fun signingPackageManagerFlags(): Int =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            @Suppress("DEPRECATION")
+            PackageManager.GET_SIGNATURES
+        }
+
+    private fun signingCertificateDigests(packageInfo: PackageInfo): Set<String> {
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.signingInfo?.apkContentsSigners ?: return emptySet()
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.signatures
+        } ?: return emptySet()
+
+        return signatures.map { signature ->
+            MessageDigest.getInstance("SHA-256")
+                .digest(signature.toByteArray())
+                .joinToString(separator = "") { byte -> "%02x".format(byte) }
+        }.toSet()
+    }
+
+    private fun installedVersionCode(): Long = packageVersionCode(installedPackageInfo())
+
+    private fun packageVersionCode(packageInfo: PackageInfo): Long =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.versionCode.toLong()
+        }
+
+    private fun sha256(file: File): String {
         val digest = MessageDigest.getInstance("SHA-256")
         file.inputStream().use { input ->
             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
@@ -140,8 +249,13 @@ class AppUpdateRepository(
         }
         return digest.digest()
             .joinToString(separator = "") { byte -> "%02x".format(byte) }
-            .take(8)
     }
+
+    private fun isValidArtifactHash(value: String): Boolean =
+        value.length == 8 && value.all { it in '0'..'9' || it in 'a'..'f' }
+
+    private fun isValidSha256(value: String): Boolean =
+        value.length == 64 && value.all { it in '0'..'9' || it in 'a'..'f' }
 
     private suspend fun apiService(serverUrl: String): ApiService {
         val retrofit = Retrofit.Builder()

--- a/rust/office-automate-server/src/artifacts.rs
+++ b/rust/office-automate-server/src/artifacts.rs
@@ -35,6 +35,8 @@ struct ArtifactStoreInner {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactMetadata {
     pub artifact_hash: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub sha256: String,
     pub uploaded_at: String,
     pub size_bytes: u64,
     pub uploaded_by: String,
@@ -92,9 +94,26 @@ impl ArtifactStore {
         let contents = fs::read_to_string(&meta_path)
             .await
             .with_context(|| format!("failed to read {}", meta_path.display()))?;
-        serde_json::from_str(&contents)
-            .with_context(|| format!("failed to parse {}", meta_path.display()))
-            .map(Some)
+        let mut metadata: ArtifactMetadata = serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", meta_path.display()))?;
+
+        if metadata.sha256.is_empty() && is_valid_artifact_hash(&metadata.artifact_hash) {
+            let artifact_path = self.hashed_path(app, &metadata.artifact_hash);
+            let bytes = fs::read(&artifact_path)
+                .await
+                .with_context(|| format!("failed to read {}", artifact_path.display()))?;
+            let sha256 = format!("{:x}", Sha256::digest(&bytes));
+            if !sha256.starts_with(&metadata.artifact_hash) {
+                anyhow::bail!(
+                    "artifact hash prefix does not match computed sha256 for {}",
+                    artifact_path.display()
+                );
+            }
+            metadata.sha256 = sha256;
+            self.write_metadata(app, &metadata).await?;
+        }
+
+        Ok(Some(metadata))
     }
 
     async fn write_metadata(&self, app: &str, metadata: &ArtifactMetadata) -> Result<()> {
@@ -264,7 +283,8 @@ impl ArtifactStore {
             ));
         }
 
-        let artifact_hash = format!("{:x}", sha256.finalize())[..8].to_string();
+        let sha256 = format!("{:x}", sha256.finalize());
+        let artifact_hash = sha256[..8].to_string();
         let hashed_path = self.hashed_path(app, &artifact_hash);
         if !hashed_path.exists() {
             copy_file_atomically(&temp_path, &hashed_path).await?;
@@ -279,6 +299,7 @@ impl ArtifactStore {
 
         let metadata = ArtifactMetadata {
             artifact_hash,
+            sha256,
             uploaded_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
             size_bytes,
             uploaded_by: user_email.to_string(),
@@ -354,6 +375,13 @@ pub fn is_valid_artifact_hash(artifact_hash: &str) -> bool {
             .all(|character| character.is_ascii_hexdigit() && !character.is_ascii_uppercase())
 }
 
+pub fn is_valid_sha256_digest(sha256: &str) -> bool {
+    sha256.len() == 64
+        && sha256
+            .chars()
+            .all(|character| character.is_ascii_hexdigit() && !character.is_ascii_uppercase())
+}
+
 async fn copy_file_atomically(
     source_path: &PathBuf,
     destination_path: &PathBuf,
@@ -409,6 +437,70 @@ async fn remove_file_if_exists(path: &PathBuf) {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn read_metadata_hydrates_legacy_short_hash_metadata() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ArtifactStore::new(
+            temp_dir.path().join("apps"),
+            temp_dir.path().join("legacy.apk"),
+        );
+        let app_dir = store.app_dir("office-climate");
+        fs::create_dir_all(&app_dir).await.expect("app dir");
+        fs::write(app_dir.join("dd37c2d7.apk"), b"apk")
+            .await
+            .expect("hashed artifact");
+        fs::write(
+            app_dir.join("meta.json"),
+            r#"{"artifact_hash":"dd37c2d7","uploaded_at":"2026-06-05T00:00:00","size_bytes":3,"uploaded_by":"test@example.com"}"#,
+        )
+        .await
+        .expect("legacy metadata");
+
+        let metadata = store
+            .read_metadata("office-climate")
+            .await
+            .expect("metadata read")
+            .expect("metadata");
+
+        assert_eq!(
+            metadata.sha256,
+            "dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04"
+        );
+        let persisted = fs::read_to_string(app_dir.join("meta.json"))
+            .await
+            .expect("persisted metadata");
+        assert!(persisted.contains(
+            r#""sha256":"dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04""#
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_metadata_rejects_legacy_hash_prefix_mismatch() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ArtifactStore::new(
+            temp_dir.path().join("apps"),
+            temp_dir.path().join("legacy.apk"),
+        );
+        let app_dir = store.app_dir("office-climate");
+        fs::create_dir_all(&app_dir).await.expect("app dir");
+        fs::write(app_dir.join("1a2b3c4d.apk"), b"apk")
+            .await
+            .expect("hashed artifact");
+        fs::write(
+            app_dir.join("meta.json"),
+            r#"{"artifact_hash":"1a2b3c4d","uploaded_at":"2026-06-05T00:00:00","size_bytes":3,"uploaded_by":"test@example.com"}"#,
+        )
+        .await
+        .expect("legacy metadata");
+
+        let error = store
+            .read_metadata("office-climate")
+            .await
+            .expect_err("metadata should reject mismatched digest");
+
+        assert!(error.to_string().contains("artifact hash prefix"));
+    }
+
     #[test]
     fn validates_app_names_and_hashes() {
         assert!(is_valid_app_name("office-climate"));
@@ -418,5 +510,12 @@ mod tests {
         assert!(is_valid_artifact_hash("1a2b3c4d"));
         assert!(!is_valid_artifact_hash("1A2B3C4D"));
         assert!(!is_valid_artifact_hash("abcd"));
+        assert!(is_valid_sha256_digest(
+            "dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04"
+        ));
+        assert!(!is_valid_sha256_digest("1a2b3c4d"));
+        assert!(!is_valid_sha256_digest(
+            "DD37C2D7274F7EA982CB83390C36918FEE9CE8889073C44B68CDC00BDB8C3E04"
+        ));
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2549,6 +2549,7 @@ mod tests {
         http::Request as HttpRequest,
     };
     use futures_util::{SinkExt, StreamExt};
+    use sha2::{Digest, Sha256};
     use tokio_tungstenite::{
         connect_async,
         tungstenite::{Message as TungsteniteMessage, client::IntoClientRequest},
@@ -6080,6 +6081,9 @@ mod tests {
             .expect("read body");
         let metadata: Value = serde_json::from_slice(&body).expect("json body");
         let artifact_hash = metadata["artifact_hash"].as_str().expect("hash");
+        let sha256 = format!("{:x}", Sha256::digest(b"apk-bytes"));
+        assert_eq!(artifact_hash, &sha256[..8]);
+        assert_eq!(metadata["sha256"], sha256);
         assert_eq!(metadata["uploaded_by"], "engineer@rajeshgo.li");
         assert_eq!(metadata["version_code"], 7);
         assert_eq!(metadata["version_name"], "1.2.0");

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -12,9 +12,10 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Local};
 use rusqlite::{Connection, DatabaseName, OpenFlags};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::{
-    artifacts::{ArtifactMetadata, is_valid_artifact_hash},
+    artifacts::{ArtifactMetadata, is_valid_artifact_hash, is_valid_sha256_digest},
     config::AppConfig,
     db,
 };
@@ -759,7 +760,7 @@ fn validate_artifact_metadata(artifacts_dir: &Path, validations: &mut Vec<String
         }
         let contents = fs::read_to_string(&meta_path)
             .with_context(|| format!("failed to read {}", meta_path.display()))?;
-        let metadata: ArtifactMetadata = serde_json::from_str(&contents)
+        let mut metadata: ArtifactMetadata = serde_json::from_str(&contents)
             .with_context(|| format!("failed to parse {}", meta_path.display()))?;
         if !is_valid_artifact_hash(&metadata.artifact_hash) {
             bail!(
@@ -772,6 +773,41 @@ fn validate_artifact_metadata(artifacts_dir: &Path, validations: &mut Vec<String
         if !hashed_path.is_file() {
             bail!(
                 "artifact metadata references missing APK: {}",
+                hashed_path.display()
+            );
+        }
+        let hashed_bytes = fs::read(&hashed_path)
+            .with_context(|| format!("failed to read {}", hashed_path.display()))?;
+        let actual_sha256 = format!("{:x}", Sha256::digest(&hashed_bytes));
+        if metadata.sha256.is_empty() {
+            if !actual_sha256.starts_with(&metadata.artifact_hash) {
+                bail!(
+                    "artifact hash prefix does not match computed sha256 in {}",
+                    meta_path.display()
+                );
+            }
+            metadata.sha256 = actual_sha256.clone();
+            let updated_metadata =
+                serde_json::to_vec(&metadata).context("failed to serialize hydrated metadata")?;
+            fs::write(&meta_path, updated_metadata)
+                .with_context(|| format!("failed to hydrate {}", meta_path.display()))?;
+        }
+        if !is_valid_sha256_digest(&metadata.sha256) {
+            bail!(
+                "invalid artifact sha256 in {}: {}",
+                meta_path.display(),
+                metadata.sha256
+            );
+        }
+        if !metadata.sha256.starts_with(&metadata.artifact_hash) {
+            bail!(
+                "artifact hash prefix does not match sha256 in {}",
+                meta_path.display()
+            );
+        }
+        if actual_sha256 != metadata.sha256 {
+            bail!(
+                "artifact metadata sha256 does not match APK {}",
                 hashed_path.display()
             );
         }
@@ -927,10 +963,10 @@ mod tests {
         let app_dir = root.join("data/apps/office-climate");
         fs::create_dir_all(&app_dir).expect("app dir");
         fs::write(app_dir.join("latest.apk"), b"apk").expect("latest");
-        fs::write(app_dir.join("1a2b3c4d.apk"), b"apk").expect("hashed");
+        fs::write(app_dir.join("dd37c2d7.apk"), b"apk").expect("hashed");
         fs::write(
             app_dir.join("meta.json"),
-            r#"{"artifact_hash":"1a2b3c4d","uploaded_at":"2026-06-05T00:00:00Z","size_bytes":3,"uploaded_by":"test@example.com"}"#,
+            r#"{"artifact_hash":"dd37c2d7","sha256":"dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04","uploaded_at":"2026-06-05T00:00:00Z","size_bytes":3,"uploaded_by":"test@example.com"}"#,
         )
         .expect("metadata");
         fs::write(
@@ -1184,6 +1220,36 @@ mod tests {
                 .expect_err("invalid metadata should fail");
 
         assert!(error.to_string().contains("invalid artifact hash"));
+    }
+
+    #[test]
+    fn snapshot_hydrates_legacy_artifact_metadata_sha256() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let root = temp_dir.path();
+        let config_path = root.join("config.yaml");
+        fs::write(&config_path, "orchestrator:\n  port: 9001\n").expect("config");
+        let database_path = root.join("data/office_climate.db");
+        fs::create_dir_all(database_path.parent().expect("db parent")).expect("data dir");
+        db::migrate_database(&database_path).expect("office db");
+
+        let app_dir = root.join("data/apps/office-climate");
+        fs::create_dir_all(&app_dir).expect("app dir");
+        fs::write(app_dir.join("latest.apk"), b"apk").expect("latest");
+        fs::write(app_dir.join("dd37c2d7.apk"), b"apk").expect("hashed");
+        fs::write(
+            app_dir.join("meta.json"),
+            r#"{"artifact_hash":"dd37c2d7","uploaded_at":"2026-06-05T00:00:00Z","size_bytes":3,"uploaded_by":"test@example.com"}"#,
+        )
+        .expect("legacy metadata");
+
+        let config = test_config(root, config_path.clone(), database_path);
+        create_pre_cutover_snapshot(&config, &config_path, &root.join("snapshots"), None)
+            .expect("snapshot succeeds with legacy metadata");
+
+        let hydrated = fs::read_to_string(app_dir.join("meta.json")).expect("hydrated metadata");
+        assert!(hydrated.contains(
+            r#""sha256":"dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04""#
+        ));
     }
 
     #[test]

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -27,7 +27,7 @@ use tokio_tungstenite::{
 };
 
 use crate::{
-    artifacts::is_valid_artifact_hash,
+    artifacts::{is_valid_artifact_hash, is_valid_sha256_digest},
     auth::AuthManager,
     config::AppConfig,
     db, erv, http, hvac,
@@ -1611,9 +1611,19 @@ async fn validate_artifact_interface(
             if !is_valid_artifact_hash(hash) {
                 bail!("artifact metadata contains invalid artifact_hash {hash:?}");
             }
+            let sha256 = metadata
+                .get("sha256")
+                .and_then(Value::as_str)
+                .context("artifact metadata missing sha256")?;
+            if !is_valid_sha256_digest(sha256) {
+                bail!("artifact metadata contains invalid sha256 {sha256:?}");
+            }
+            if !sha256.starts_with(hash) {
+                bail!("artifact metadata hash prefix does not match sha256");
+            }
             report.push_pass(
                 "artifact-interface",
-                format!("office-climate metadata exists with artifact_hash={hash}"),
+                format!("office-climate metadata exists with artifact_hash={hash} and full sha256"),
             );
         }
         StatusCode::NOT_FOUND => report.push_skip(


### PR DESCRIPTION
## Summary
- store full SHA-256 artifact metadata while preserving the existing 8-character artifact URL key
- hydrate legacy short-hash metadata only when the existing APK bytes match the short hash prefix
- require full digest metadata in shadow validation and pre-cutover artifact metadata checks
- make Android update installs fail closed on full digest, package name, version metadata, downgrade, and signing certificate mismatch checks

Refs #110

## Verification
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml artifacts --lib`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml migration::tests::snapshot_copies_config_database_artifacts_and_manifest --lib`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml migration::tests::snapshot_rejects_invalid_artifact_metadata --lib`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml validation::tests::shadow_validation_can_run_offline_database_checks --lib`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml --lib`
- `./gradlew :app:assembleDebug`
- `git diff --check`
