### PR TITLE
Add incident response and kill-switch runbook

### DIFF
--- a/docs/deployment/incident-response.md
+++ b/docs/deployment/incident-response.md
@@ -1,0 +1,184 @@
+# Incident Response And Kill Switch
+
+Ticket #114 covers the operational response for suspected Office Automate compromise. The first objective is to remove public reachability before rotating secrets. The second objective is to preserve useful evidence without leaking raw secrets into chat, tickets, or PRs.
+
+## Severity Triggers
+
+Treat any of these as an incident:
+
+- Cloudflare Access policy, tunnel route, DNS, or hostname drift.
+- Unexpected public success from an unauthenticated probe to `office.rajeshgo.li`.
+- Unknown Android mTLS device, repeated pairing failures, or unexpected device revocation.
+- Artifact upload or metadata change you did not initiate.
+- MQTT/Qingping wrong MAC, unexpected client, value-range rejection spike, or raw payload flood.
+- ERV/HVAC/YoLink/Kumo command failures after valid credentials recently worked.
+- Unknown listener, launchd restart loop, DB integrity failure, or unexplained binary hash change.
+
+## Handling Rules
+
+- Capture evidence before rotation when it is safe to do so.
+- Store raw evidence only in a local encrypted location. FileVault-on local storage is acceptable for the capture script; otherwise use an encrypted disk image or pass `--allow-unencrypted-local` only when you deliberately accept that risk.
+- Do not paste raw `ps eww`, logs, config files, Cloudflare exports, Access JWTs, cookies, Android cert material, or token-bearing output into tickets, chats, PRs, or issue comments.
+- Share redacted excerpts, hashes, timestamps, process IDs, file modes, and exact commands instead of raw secret-bearing files.
+
+## 1. Capture Evidence
+
+Run this from the repo root before changing secrets or restarting services:
+
+```bash
+scripts/security/capture-incident-evidence.sh \
+  --config "${OFFICE_AUTOMATE_CONFIG:-config.yaml}" \
+  --database "${OFFICE_AUTOMATE_DATABASE:-data/office_climate.db}" \
+  --server-bin "${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}" \
+  --cloudflared-config "${CLOUDFLARED_CONFIG:-/var/lib/office-automate/tunnel/config.yml}"
+```
+
+The script writes raw files under `tmp/incident-evidence/<timestamp>/` by default, creates redacted summaries under `redacted/`, and refuses to run when FileVault is not reported as enabled unless `--allow-unencrypted-local` is passed.
+
+Also preserve Cloudflare-side evidence before changing policies:
+
+```bash
+cloudflared tunnel list
+cloudflared tunnel info office
+cloudflared tunnel route ip show
+cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"
+```
+
+If the Cloudflare dashboard is the available source of truth, export or screenshot these exact fields before edits: Access application destinations, policy list and order, no Bypass policy, Service Auth valid-certificate policy, login allow policy, tunnel public hostname route, DNS records for `office.rajeshgo.li`, no wildcard DNS, no private network routes, and Access audit logs around the incident window.
+
+## 2. Kill Public Access
+
+Stop the tunnel first. In the hardened target deployment it is a system LaunchDaemon:
+
+```bash
+sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.tunnel.plist
+```
+
+If the host is still using the older user-session tunnel job, use:
+
+```bash
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist"
+```
+
+If the public edge is deployed separately, stop it after the tunnel:
+
+```bash
+sudo launchctl bootout system /Library/LaunchDaemons/com.office-automate.edge.plist
+```
+
+Confirm public access is gone:
+
+```bash
+curl -i https://office.rajeshgo.li/status
+curl -i https://office.rajeshgo.li/auth/login
+```
+
+Both requests must fail before reaching the origin. Acceptable results are Cloudflare Access denial, tunnel unavailable, DNS failure during emergency DNS removal, or connection failure. A JSON Office Automate origin response means the kill switch did not work.
+
+## 3. Keep Local Climate Safety Running
+
+The local controller should continue without public access. Check the controller job:
+
+```bash
+launchctl print "gui/$(id -u)/com.office-automate.server"
+```
+
+Run non-mutating smoke checks:
+
+```bash
+./oa smoke erv
+./oa smoke hvac
+./oa smoke presence
+```
+
+If the controller itself is suspected compromised, leave the tunnel down and stop the controller only after deciding whether additional local evidence is needed:
+
+```bash
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.office-automate.server.plist"
+```
+
+Manual fallback while the controller is down is the physical ERV/HVAC controls and vendor apps on the LAN.
+
+## 4. Rotate In Dependency Order
+
+Rotate from the public edge inward so a still-exposed public component cannot immediately consume fresh internal credentials.
+
+1. Keep the Cloudflare tunnel stopped.
+2. Rotate Cloudflare tunnel credentials and verify the tunnel still has no private network routes.
+3. Review Cloudflare Access app state: exact hostname, no Bypass policy, Service Auth valid certificate policy first, login allow policy second, no wildcard DNS, final deny/404 route.
+4. Revoke or rotate Android device registrations as needed:
+
+   ```bash
+   ./oa list-devices
+   ./oa revoke-device <device-id>
+   ```
+
+5. Rotate Office JWT secret and Google OAuth client secret if browser sessions or origin config may be exposed.
+6. Revoke bad Android artifacts, remove bad metadata, and publish a known-good signed APK if update metadata may be exposed.
+7. Rotate ERV local key if local device credentials or config may be exposed.
+8. Rotate Kumo credentials.
+9. Rotate YoLink credentials.
+10. Rotate any remaining operator tokens used for Cloudflare API evidence, GitHub release work, or local automation.
+
+Record each rotation timestamp in the incident notes. Do not store new secret values in those notes.
+
+## 5. Recovery Validation
+
+Before restoring public access:
+
+```bash
+./oa migrate
+./oa smoke erv
+./oa smoke hvac
+./oa smoke presence
+sqlite3 data/office_climate.db "PRAGMA quick_check;"
+scripts/security/validate-edge-quarantine.sh \
+  --tunnel-user _office_tunnel \
+  --edge-user _office_edge \
+  --tunnel-readable /var/lib/office-automate/tunnel/config.yml \
+  --tunnel-readable /var/lib/office-automate/tunnel/credentials.json \
+  --edge-readable /var/lib/office-automate/edge/config.yaml \
+  --protected-path "${OFFICE_AUTOMATE_CONFIG:-config.yaml}" \
+  --protected-path "${OFFICE_AUTOMATE_DATABASE:-data/office_climate.db}" \
+  --protected-path "$PWD" \
+  --origin-probe 127.0.0.1:8080 \
+  --lan-control-user "$(id -un)" \
+  --lan-probe 192.168.5.1:80
+```
+
+Then reload the public edge and tunnel:
+
+```bash
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.office-automate.edge.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.office-automate.tunnel.plist
+```
+
+Run cutover validation with Cloudflare evidence and Access service credentials:
+
+```bash
+./oa validate cutover \
+  --cloudflared-config "$CLOUDFLARED_CONFIG" \
+  --cloudflare-evidence "$OFFICE_AUTOMATE_CLOUDFLARE_EVIDENCE" \
+  --cloudflare-access-client-id "$OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_CLIENT_ID" \
+  --cloudflare-access-client-secret "$OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_CLIENT_SECRET"
+```
+
+Final public checks:
+
+- Unauthenticated public requests to `/status`, `/auth/login`, `/auth/callback`, `/auth/device/start`, `/auth/device/poll`, `/apps/office-climate/meta.json`, `/apk`, `/ws`, static `.json` and `.png` paths, and `/deploy/` must be blocked by Cloudflare before origin.
+- Authenticated browser access for the operator must reach the dashboard.
+- Enrolled Android mTLS access must reach the API without browser OAuth.
+- Unknown Android mTLS certificates must be blocked by Cloudflare or rejected by Office Automate enrollment checks.
+- Local controller smoke checks must still pass.
+
+## 6. Closeout
+
+Keep the evidence directory until the incident is closed. The closeout note should include:
+
+- Incident window in local time and UTC.
+- Initial trigger and first containment time.
+- Public kill-switch command used and validation result.
+- Hash of the evidence directory manifest, not raw secret-bearing files.
+- Secrets rotated, by name and timestamp only.
+- Recovery validation commands and results.
+- Follow-up tickets for any failed validation, missing alert, missing Cloudflare evidence, or manual-only step.

--- a/docs/deployment/incident-response.md
+++ b/docs/deployment/incident-response.md
@@ -157,6 +157,10 @@ Run cutover validation with Cloudflare evidence and Access service credentials:
 
 ```bash
 ./oa validate cutover \
+  --legacy-controller-stopped-at "$OFFICE_AUTOMATE_LEGACY_STOPPED_AT" \
+  --mqtt-strategy "$OFFICE_AUTOMATE_MQTT_CUTOVER_STRATEGY" \
+  --snapshot-dir "$OFFICE_AUTOMATE_CUTOVER_SNAPSHOT_DIR" \
+  --cutover-log "$OFFICE_AUTOMATE_CUTOVER_LOG" \
   --cloudflared-config "$CLOUDFLARED_CONFIG" \
   --cloudflare-evidence "$OFFICE_AUTOMATE_CLOUDFLARE_EVIDENCE" \
   --cloudflare-access-client-id "$OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_CLIENT_ID" \

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_root="${OFFICE_AUTOMATE_INCIDENT_EVIDENCE_DIR:-tmp/incident-evidence}"
+config_path="${OFFICE_AUTOMATE_CONFIG:-config.yaml}"
+database_path="${OFFICE_AUTOMATE_DATABASE:-data/office_climate.db}"
+server_bin="${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}"
+cloudflared_config="${CLOUDFLARED_CONFIG:-}"
+log_lines="${OFFICE_AUTOMATE_INCIDENT_LOG_LINES:-2000}"
+allow_unencrypted_local=false
+
+usage() {
+  cat <<'USAGE'
+Usage: capture-incident-evidence.sh [options]
+
+Captures local Office Automate incident evidence into a mode-0700 directory.
+Raw output may contain secrets. Keep it local, encrypted, and sanitized before
+sharing.
+
+Options:
+  --output-dir DIR             Evidence root. Defaults to tmp/incident-evidence
+                               or OFFICE_AUTOMATE_INCIDENT_EVIDENCE_DIR.
+  --config PATH                Controller config. Defaults to config.yaml or
+                               OFFICE_AUTOMATE_CONFIG.
+  --database PATH              Climate SQLite DB. Defaults to data/office_climate.db
+                               or OFFICE_AUTOMATE_DATABASE.
+  --server-bin PATH            Rust server binary to hash. Defaults to
+                               target/release/office-automate-server.
+  --cloudflared-config PATH    Cloudflared config to preserve and hash.
+  --log-lines N                Tail line count per log. Defaults to 2000.
+  --allow-unencrypted-local    Allow capture when FileVault state is unknown/off.
+  -h, --help                   Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      output_root="${2:-}"
+      shift 2
+      ;;
+    --config)
+      config_path="${2:-}"
+      shift 2
+      ;;
+    --database)
+      database_path="${2:-}"
+      shift 2
+      ;;
+    --server-bin)
+      server_bin="${2:-}"
+      shift 2
+      ;;
+    --cloudflared-config)
+      cloudflared_config="${2:-}"
+      shift 2
+      ;;
+    --log-lines)
+      log_lines="${2:-}"
+      shift 2
+      ;;
+    --allow-unencrypted-local)
+      allow_unencrypted_local=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$output_root" ]]; then
+  echo "output directory must not be empty" >&2
+  exit 2
+fi
+if [[ ! "$log_lines" =~ ^[0-9]+$ ]] || [[ "$log_lines" -lt 1 ]]; then
+  echo "--log-lines must be a positive integer" >&2
+  exit 2
+fi
+
+if [[ "$allow_unencrypted_local" != true ]] && command -v fdesetup >/dev/null 2>&1; then
+  if ! fdesetup status 2>/dev/null | grep -q "FileVault is On"; then
+    cat >&2 <<'MSG'
+FileVault is not reported as enabled.
+Raw incident evidence may contain secrets. Use an encrypted evidence directory
+or re-run with --allow-unencrypted-local only for a local, access-controlled
+machine you accept as evidence storage.
+MSG
+    exit 1
+  fi
+fi
+
+timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+evidence_dir="$output_root/$timestamp"
+mkdir -p "$evidence_dir"/{commands,hashes,logs,plists,redacted,sqlite}
+chmod 700 "$output_root" "$evidence_dir"
+
+capture() {
+  local output="$1"
+  shift
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n\n'
+    "$@"
+  } >"$evidence_dir/$output" 2>&1 || true
+  chmod 600 "$evidence_dir/$output"
+}
+
+capture_shell() {
+  local output="$1"
+  local command_text="$2"
+  {
+    printf '$ %s\n\n' "$command_text"
+    bash -c "$command_text"
+  } >"$evidence_dir/$output" 2>&1 || true
+  chmod 600 "$evidence_dir/$output"
+}
+
+redact_file() {
+  local source="$1"
+  local dest="$2"
+  if [[ ! -f "$source" ]]; then
+    return
+  fi
+  sed -E \
+    -e 's/((secret|token|password|key|credential|authorization|cookie|client_secret|jwt)[A-Za-z0-9_.:-]*[=:])[[:graph:]]+/\1<redacted>/Ig' \
+    -e 's/(Bearer )[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig' \
+    -e 's/(cf-access-[A-Za-z0-9_-]+: )[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig' \
+    "$source" >"$dest" || true
+  chmod 600 "$dest"
+}
+
+copy_if_file() {
+  local source="$1"
+  local dest_dir="$2"
+  if [[ -f "$source" ]]; then
+    cp "$source" "$dest_dir/"
+    chmod 600 "$dest_dir/$(basename "$source")"
+  fi
+}
+
+echo "Office Automate incident evidence"
+echo "evidence_dir=$evidence_dir"
+echo "raw evidence may contain secrets; do not paste it into tickets, chats, PRs, or issue comments"
+
+capture commands/date.txt date
+capture commands/host.txt hostname
+capture commands/uname.txt uname -a
+capture commands/git-head.txt git rev-parse HEAD
+capture commands/git-status.txt git status --short --branch
+capture commands/git-log.txt git log --oneline -20
+
+capture commands/listeners.txt lsof -nP -iTCP -sTCP:LISTEN
+capture commands/cloudflared-version.txt cloudflared --version
+capture_shell hashes/cloudflared.sha256 'command -v cloudflared >/dev/null 2>&1 && shasum -a 256 "$(command -v cloudflared)"'
+
+capture commands/launchctl-server.txt launchctl print "gui/$(id -u)/com.office-automate.server"
+capture commands/launchctl-telemetry.txt launchctl print "gui/$(id -u)/com.office-automate.telemetry"
+capture commands/launchctl-project-leverage.txt launchctl print "gui/$(id -u)/com.office-automate.project-leverage"
+capture commands/launchctl-edge.txt sudo -n launchctl print system/com.office-automate.edge
+capture commands/launchctl-tunnel.txt sudo -n launchctl print system/com.office-automate.tunnel
+capture commands/launchctl-gui-tunnel.txt launchctl print "gui/$(id -u)/com.office-automate.tunnel"
+
+capture_shell commands/ps-eww.raw.secret.txt 'pids="$(pgrep -f "office-automate-server|cloudflared" | tr "\n" " ")"; if [[ -n "$pids" ]]; then for pid in $pids; do ps eww -p "$pid"; done; fi'
+redact_file "$evidence_dir/commands/ps-eww.raw.secret.txt" "$evidence_dir/redacted/ps-eww.redacted.txt"
+
+capture_shell commands/file-permissions.txt 'stat -f "%Sp %Su %Sg %N" config.yaml data data/*.db data/apps logs logs/* certs certs/* /var/lib/office-automate /var/lib/office-automate/* /var/log/office-automate /var/log/office-automate/* 2>/dev/null'
+capture hashes/server-binary.sha256 shasum -a 256 "$server_bin"
+capture_shell hashes/artifacts.sha256 'if [[ -d data/apps ]]; then find data/apps -maxdepth 3 -type f -print0 | xargs -0 shasum -a 256; fi'
+
+if [[ -f "$database_path" ]]; then
+  capture sqlite/office-climate-quick-check.txt sqlite3 "$database_path" "PRAGMA quick_check;"
+  capture sqlite/recent-device-events.txt sqlite3 "$database_path" "SELECT timestamp, device_type, event, device_name FROM device_events ORDER BY timestamp DESC LIMIT 100;"
+  capture sqlite/recent-climate-actions.txt sqlite3 "$database_path" "SELECT timestamp, action, reason FROM climate_actions ORDER BY timestamp DESC LIMIT 100;"
+  capture sqlite/recent-device-registration-audit.txt sqlite3 "$database_path" "SELECT created_at, event, device_id, details FROM device_registration_audit ORDER BY created_at DESC LIMIT 100;"
+fi
+
+copy_if_file "$config_path" "$evidence_dir/plists"
+copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.server.plist" "$evidence_dir/plists"
+copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist" "$evidence_dir/plists"
+copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist" "$evidence_dir/plists"
+copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist" "$evidence_dir/plists"
+copy_if_file "/Library/LaunchDaemons/com.office-automate.edge.plist" "$evidence_dir/plists"
+copy_if_file "/Library/LaunchDaemons/com.office-automate.tunnel.plist" "$evidence_dir/plists"
+if [[ -n "$cloudflared_config" ]]; then
+  copy_if_file "$cloudflared_config" "$evidence_dir/plists"
+  capture hashes/cloudflared-config.sha256 shasum -a 256 "$cloudflared_config"
+fi
+
+capture_shell logs/recent-office-logs.raw.secret.txt "for log in logs/*.log /var/log/office-automate/*/*.log; do [[ -f \"\$log\" ]] && { echo \"===== \$log\"; tail -n '$log_lines' \"\$log\"; }; done"
+redact_file "$evidence_dir/logs/recent-office-logs.raw.secret.txt" "$evidence_dir/redacted/recent-office-logs.redacted.txt"
+
+capture_shell logs/security-signals.raw.secret.txt "for log in logs/*.log /var/log/office-automate/*/*.log; do [[ -f \"\$log\" ]] && grep -iE 'auth|access|cloudflare|deploy|artifact|mqtt|qingping|yolink|token|secret|error|fail|restart' \"\$log\" | tail -n '$log_lines'; done"
+redact_file "$evidence_dir/logs/security-signals.raw.secret.txt" "$evidence_dir/redacted/security-signals.redacted.txt"
+
+cat >"$evidence_dir/README.txt" <<'README'
+Office Automate incident evidence bundle.
+
+Handling rules:
+- Raw files may contain secrets, bearer tokens, cookies, device keys, or private
+  configuration. Keep this directory local and encrypted.
+- Do not paste raw output into tickets, chats, PRs, issue comments, or email.
+- Share only files from redacted/ unless an explicit incident commander approves
+  a narrower raw excerpt.
+- Preserve this directory mode as 0700 and individual files as 0600.
+README
+chmod 600 "$evidence_dir/README.txt"
+
+echo "captured=$evidence_dir"
+echo "redacted_summaries=$evidence_dir/redacted"

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -130,9 +130,10 @@ redact_file() {
     return
   fi
   sed -E \
-    -e 's/((secret|token|password|key|credential|authorization|cookie|client_secret|jwt)[A-Za-z0-9_.:-]*[=:])[[:graph:]]+/\1<redacted>/Ig' \
+    -e 's/([Aa]uthorization[[:space:]]*[:=][[:space:]]*)[^[:space:]]+([[:space:]][^[:space:]]+)?/\1<redacted>/g' \
     -e 's/(Bearer )[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig' \
-    -e 's/(cf-access-[A-Za-z0-9_-]+: )[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig' \
+    -e "s/((secret|token|password|key|credential|cookie|client_secret|jwt)[A-Za-z0-9_.-]*[[:space:]]*[:=][[:space:]]*)(\"[^\"]*\"|[^[:space:]]+)/\1<redacted>/Ig" \
+    -e 's/(cf-access-[A-Za-z0-9_-]+:[[:space:]]*)[A-Za-z0-9._~+\/=-]+/\1<redacted>/Ig' \
     "$source" >"$dest" || true
   chmod 600 "$dest"
 }

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -84,7 +84,25 @@ if [[ ! "$log_lines" =~ ^[0-9]+$ ]] || [[ "$log_lines" -lt 1 ]]; then
   exit 2
 fi
 
-if [[ "$allow_unencrypted_local" != true ]]; then
+existing_path_for_volume_check() {
+  local path="$1"
+  while [[ ! -e "$path" ]]; do
+    local parent
+    parent="$(dirname "$path")"
+    if [[ "$parent" == "$path" ]]; then
+      return 1
+    fi
+    path="$parent"
+  done
+  printf '%s\n' "$path"
+}
+
+mount_point_for_path() {
+  local path="$1"
+  df -P "$path" 2>/dev/null | awk 'NR == 2 { for (i = 6; i <= NF; i++) printf "%s%s", (i == 6 ? "" : " "), $i; print "" }'
+}
+
+require_encrypted_evidence_volume() {
   if ! command -v fdesetup >/dev/null 2>&1 || ! fdesetup status 2>/dev/null | grep -q "FileVault is On"; then
     cat >&2 <<'MSG'
 FileVault is not reported as enabled.
@@ -94,6 +112,41 @@ machine you accept as evidence storage.
 MSG
     exit 1
   fi
+  if ! command -v diskutil >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+diskutil is not available to verify the evidence destination volume.
+Raw incident evidence may contain secrets. Use an encrypted evidence directory
+or re-run with --allow-unencrypted-local only for a local, access-controlled
+machine you accept as evidence storage.
+MSG
+    exit 1
+  fi
+  local probe_path
+  probe_path="$(existing_path_for_volume_check "$output_root")" || {
+    echo "failed to resolve an existing parent for output directory: $output_root" >&2
+    exit 1
+  }
+  local mount_point
+  mount_point="$(mount_point_for_path "$probe_path")"
+  if [[ -z "$mount_point" ]]; then
+    echo "failed to resolve evidence destination mount point for: $output_root" >&2
+    exit 1
+  fi
+  local volume_info
+  volume_info="$(diskutil info "$mount_point" 2>/dev/null || true)"
+  if ! grep -Eq '^[[:space:]]*(FileVault|Encrypted):[[:space:]]*Yes' <<<"$volume_info"; then
+    cat >&2 <<MSG
+Evidence destination volume is not reported as encrypted: $mount_point
+Raw incident evidence may contain secrets. Choose a FileVault/encrypted local
+volume or re-run with --allow-unencrypted-local only for a local,
+access-controlled machine you accept as evidence storage.
+MSG
+    exit 1
+  fi
+}
+
+if [[ "$allow_unencrypted_local" != true ]]; then
+  require_encrypted_evidence_volume
 fi
 
 timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -152,6 +152,33 @@ copy_if_file() {
   fi
 }
 
+capture_file_permissions() {
+  local output="$evidence_dir/commands/file-permissions.txt"
+  local db_dir
+  db_dir="$(dirname "$database_path")"
+  local paths=(
+    "$config_path"
+    "$database_path"
+    "$db_dir"
+    data
+    data/apps
+    logs
+    certs
+    /var/lib/office-automate
+    /var/log/office-automate
+  )
+  shopt -s nullglob
+  paths+=(data/*.db logs/* certs/* /var/lib/office-automate/* /var/log/office-automate/*)
+  shopt -u nullglob
+  {
+    printf '$ stat -f "%%Sp %%Su %%Sg %%N"'
+    printf ' %q' "${paths[@]}"
+    printf '\n\n'
+    stat -f "%Sp %Su %Sg %N" "${paths[@]}" 2>/dev/null || true
+  } >"$output" 2>&1 || true
+  chmod 600 "$output"
+}
+
 echo "Office Automate incident evidence"
 echo "evidence_dir=$evidence_dir"
 echo "raw evidence may contain secrets; do not paste it into tickets, chats, PRs, or issue comments"
@@ -177,7 +204,7 @@ capture commands/launchctl-gui-tunnel.txt launchctl print "gui/$(id -u)/com.offi
 capture_shell commands/ps-eww.raw.secret.txt 'pids="$(pgrep -f "office-automate-server|cloudflared" | tr "\n" " ")"; if [[ -n "$pids" ]]; then for pid in $pids; do ps eww -p "$pid"; done; fi'
 redact_file "$evidence_dir/commands/ps-eww.raw.secret.txt" "$evidence_dir/redacted/ps-eww.redacted.txt"
 
-capture_shell commands/file-permissions.txt 'stat -f "%Sp %Su %Sg %N" config.yaml data data/*.db data/apps logs logs/* certs certs/* /var/lib/office-automate /var/lib/office-automate/* /var/log/office-automate /var/log/office-automate/* 2>/dev/null'
+capture_file_permissions
 capture hashes/server-binary.sha256 shasum -a 256 "$server_bin"
 capture_shell hashes/artifacts.sha256 'if [[ -d data/apps ]]; then find data/apps -maxdepth 3 -type f -print0 | xargs -0 shasum -a 256; fi'
 

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -98,8 +98,12 @@ fi
 
 timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
 evidence_dir="$output_root/$timestamp"
+if [[ ! -d "$output_root" ]]; then
+  mkdir -p "$output_root"
+  chmod 700 "$output_root"
+fi
 mkdir -p "$evidence_dir"/{commands,hashes,logs,plists,redacted,sqlite}
-chmod 700 "$output_root" "$evidence_dir"
+chmod 700 "$evidence_dir"
 
 capture() {
   local output="$1"
@@ -141,9 +145,10 @@ redact_file() {
 copy_if_file() {
   local source="$1"
   local dest_dir="$2"
+  local dest_name="${3:-$(basename "$source")}"
   if [[ -f "$source" ]]; then
-    cp "$source" "$dest_dir/"
-    chmod 600 "$dest_dir/$(basename "$source")"
+    cp "$source" "$dest_dir/$dest_name"
+    chmod 600 "$dest_dir/$dest_name"
   fi
 }
 
@@ -187,9 +192,9 @@ copy_if_file "$config_path" "$evidence_dir/plists"
 copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.server.plist" "$evidence_dir/plists"
 copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.telemetry.plist" "$evidence_dir/plists"
 copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.project-leverage.plist" "$evidence_dir/plists"
-copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist" "$evidence_dir/plists"
-copy_if_file "/Library/LaunchDaemons/com.office-automate.edge.plist" "$evidence_dir/plists"
-copy_if_file "/Library/LaunchDaemons/com.office-automate.tunnel.plist" "$evidence_dir/plists"
+copy_if_file "$HOME/Library/LaunchAgents/com.office-automate.tunnel.plist" "$evidence_dir/plists" "user-com.office-automate.tunnel.plist"
+copy_if_file "/Library/LaunchDaemons/com.office-automate.edge.plist" "$evidence_dir/plists" "system-com.office-automate.edge.plist"
+copy_if_file "/Library/LaunchDaemons/com.office-automate.tunnel.plist" "$evidence_dir/plists" "system-com.office-automate.tunnel.plist"
 if [[ -n "$cloudflared_config" ]]; then
   copy_if_file "$cloudflared_config" "$evidence_dir/plists"
   capture hashes/cloudflared-config.sha256 shasum -a 256 "$cloudflared_config"

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -179,7 +179,7 @@ if [[ -f "$database_path" ]]; then
   capture sqlite/office-climate-quick-check.txt sqlite3 "$database_path" "PRAGMA quick_check;"
   capture sqlite/recent-device-events.txt sqlite3 "$database_path" "SELECT timestamp, device_type, event, device_name FROM device_events ORDER BY timestamp DESC LIMIT 100;"
   capture sqlite/recent-climate-actions.txt sqlite3 "$database_path" "SELECT timestamp, action, reason FROM climate_actions ORDER BY timestamp DESC LIMIT 100;"
-  capture sqlite/recent-device-registration-audit.txt sqlite3 "$database_path" "SELECT created_at, event, device_id, details FROM device_registration_audit ORDER BY created_at DESC LIMIT 100;"
+  capture sqlite/recent-device-registration-audit.txt sqlite3 "$database_path" "SELECT timestamp, event, device_id, details FROM device_registration_audit ORDER BY timestamp DESC LIMIT 100;"
 fi
 
 copy_if_file "$config_path" "$evidence_dir/plists"

--- a/scripts/security/capture-incident-evidence.sh
+++ b/scripts/security/capture-incident-evidence.sh
@@ -84,8 +84,8 @@ if [[ ! "$log_lines" =~ ^[0-9]+$ ]] || [[ "$log_lines" -lt 1 ]]; then
   exit 2
 fi
 
-if [[ "$allow_unencrypted_local" != true ]] && command -v fdesetup >/dev/null 2>&1; then
-  if ! fdesetup status 2>/dev/null | grep -q "FileVault is On"; then
+if [[ "$allow_unencrypted_local" != true ]]; then
+  if ! command -v fdesetup >/dev/null 2>&1 || ! fdesetup status 2>/dev/null | grep -q "FileVault is On"; then
     cat >&2 <<'MSG'
 FileVault is not reported as enabled.
 Raw incident evidence may contain secrets. Use an encrypted evidence directory


### PR DESCRIPTION
## Summary

- Add an Office Automate incident response and kill-switch runbook for ticket #114.
- Add a local evidence capture script that records launchd/process/listener/hash/log/SQLite evidence into a mode-0700 directory with redacted summaries.
- Document public tunnel shutdown, local controller safety checks, dependency-ordered secret rotation, and recovery validation.

## Tests

- `bash -n scripts/security/capture-incident-evidence.sh`
- `scripts/security/capture-incident-evidence.sh --help`
- `scripts/security/capture-incident-evidence.sh --log-lines nope --output-dir /tmp/oa-invalid-evidence --allow-unencrypted-local` exits 2 with validation error
- Dummy capture with fake config/database/binary/cloudflared paths and `--log-lines 1`; verified expected bundle files and `0700`/`0600` modes, then removed the temporary bundle

## Security Checklist

- [x] I reviewed whether this touches auth, deploy, artifact update, WebSocket, tunnel, Android storage/deep links, MQTT, device-control, or secret-handling code.
- [x] If it touches one of those areas, the PR explains the threat model impact and the validation added.
- [x] Dependency changes keep lockfiles updated and pass the supply-chain gates.

Fixes #114
