### PR TITLE
Complete remaining security hardening

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AppArtifactMetadata.kt
@@ -12,4 +12,8 @@ data class AppArtifactMetadata(
     @SerialName("uploaded_by") val uploadedBy: String? = null,
     @SerialName("version_code") val versionCode: Long? = null,
     @SerialName("version_name") val versionName: String? = null,
+    @SerialName("signing_cert_sha256") val signingCertSha256: String? = null,
+    @SerialName("revoked_at") val revokedAt: String? = null,
+    @SerialName("revocation_reason") val revocationReason: String? = null,
+    @SerialName("replacement_artifact_hash") val replacementArtifactHash: String? = null,
 )

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/AppUpdateRepository.kt
@@ -47,6 +47,9 @@ class AppUpdateRepository(
         if (!isValidArtifactHash(serverArtifactHash)) {
             return null
         }
+        if (!metadata.revokedAt.isNullOrBlank()) {
+            return null
+        }
         val serverSha256 = metadata.sha256?.trim()?.lowercase() ?: return null
         if (!isValidSha256(serverSha256) || !serverSha256.startsWith(serverArtifactHash)) {
             return null

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,7 +10,26 @@ yolink:
 qingping:
   mqtt_broker: "localhost"  # or IP of your MQTT broker
   mqtt_port: 1883
+  mqtt_username: "qingping"
+  mqtt_password: "replace-with-random-device-password"
   device_mac: "AA:BB:CC:DD:EE:FF"
+
+# Android artifact upload hardening. Set this to the SHA-256 digest of the
+# office-climate release signing certificate. The deploy endpoint rejects APKs
+# signed by any other cert when this is configured.
+artifacts:
+  office_climate_signing_cert_sha256: "replace-with-release-signing-cert-sha256"
+  # Optional if apksigner is not on PATH.
+  # apksigner_path: "/absolute/path/to/apksigner"
+
+# Cloudflare Access device policy sync. The Android Service Auth policy should
+# use Common Name selectors, not a broad Valid Certificate selector. The same
+# Rust binary updates that allowlist during oa register-device/revoke-device.
+cloudflare_access:
+  account_id: "cloudflare-account-id"
+  app_id: "optional-access-application-id"
+  device_policy_id: "cloudflare-device-mtls-policy-id"
+  api_token: "cloudflare-api-token-with-access-apps-policies-write"
 
 # Airlink ERV (Tuya-based)
 # Option 1: LocalTuya

--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -58,6 +58,7 @@ The Cloudflare evidence file must use the schema from `docs/deployment/shadow-mo
 - the exact hostname is protected by an Access application,
 - no policy action is Bypass,
 - no policy includes public users,
+- the Android Service Auth policy uses per-device Common Name selectors and does not include a broad Valid Certificate selector,
 - no wildcard DNS record points at Office Automate,
 - the tunnel routes only to the loopback or Unix-socket origin,
 - no Cloudflare private-network routes exist for this tunnel,
@@ -73,6 +74,7 @@ export OFFICE_AUTOMATE_LEGACY_STOPPED_AT="$(date -Iseconds)"
 Apply the selected MQTT feed strategy:
 
 - `atomic-switch`: move Qingping to the Rust embedded broker in the same window that Python active control stops and Rust active control starts.
+- Configure Qingping Private MQTT with the `qingping.mqtt_username` and `qingping.mqtt_password` values from `config.yaml`; production security validation fails if the broker is anonymous.
 
 Start the Rust backend and Cloudflare Tunnel services with launchd or the equivalent foreground commands:
 

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -253,6 +253,17 @@ Use the repo-root `oa` wrapper for local device administration. It executes the 
 
 `register-device` starts a short-lived LAN pairing listener, prints a six-character one-time code, and records audit events for registration creation, successful pairing, rejected codes, rejected CSR/proof attempts, and revocation. A pending code is invalidated after five failed CSR/proof attempts. Unknown-code audit entries store a hash of the submitted code, not the raw code.
 
+For remote Android access, configure the Cloudflare Access Service Auth policy as a per-device Common Name allowlist, not as broad `Valid Certificate`. Set these on the trusted host before running `oa register-device` or `oa revoke-device`:
+
+```bash
+export OFFICE_AUTOMATE_CLOUDFLARE_ACCOUNT_ID="..."
+export OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_APP_ID="..."        # optional for reusable policies
+export OFFICE_AUTOMATE_CLOUDFLARE_DEVICE_POLICY_ID="..."
+export OFFICE_AUTOMATE_CLOUDFLARE_API_TOKEN="..."
+```
+
+When those values are configured, pairing adds the new device certificate CN to the Cloudflare policy before completing local enrollment. Revocation removes the CN from Cloudflare before marking the local registration revoked. If the Cloudflare update fails, the command fails instead of silently leaving stale edge access.
+
 The default device mTLS CA files are repo-local and gitignored:
 
 | Path | Purpose |
@@ -261,6 +272,19 @@ The default device mTLS CA files are repo-local and gitignored:
 | `certs/device-ca.key` | Local signing key used only by `oa register-device`; do not upload it to Cloudflare. |
 
 Override these paths with `--device-ca-cert`, `--device-ca-key`, `OFFICE_AUTOMATE_DEVICE_CA_CERT`, or `OFFICE_AUTOMATE_DEVICE_CA_KEY` if a deployment keeps private key material elsewhere.
+
+## Android Artifact Recovery
+
+Configure `OFFICE_AUTOMATE_ANDROID_SIGNING_CERT_SHA256` to the release signing certificate SHA-256 digest. When present, `/deploy/office-climate` verifies uploaded APKs with `apksigner verify --print-certs` before accepting them. Use `OFFICE_AUTOMATE_APKSIGNER` if `apksigner` is not on `PATH`.
+
+Local recovery commands:
+
+```bash
+./oa revoke-artifact --app office-climate --reason "bad release"
+./oa rollback-artifact --app office-climate --artifact-hash <known-good-8-char-hash> --reason "rollback"
+```
+
+Revoked metadata is served to clients, current APK redirects fail closed with HTTP 410, and revoked content-addressed hashes remain blocked through the artifact revocation index so rollback cannot re-expose a known-bad APK.
 
 ## Cloudflare Tunnel Notes
 

--- a/docs/deployment/shadow-mode-validation.md
+++ b/docs/deployment/shadow-mode-validation.md
@@ -80,7 +80,9 @@ Local `cloudflared` YAML validation is necessary but not enough. Capture a sanit
       {
         "name": "allow-device-mtls",
         "action": "Service Auth",
-        "includes_public": false
+        "includes_public": false,
+        "includes_common_name": true,
+        "includes_valid_certificate": false
       },
       {
         "name": "allow-rajesh",
@@ -151,7 +153,7 @@ The command validates:
 - `/history`, `/history/project-leverage`, `/apps/office-climate/meta.json`, and `/auth/login` retain their expected interface behavior.
 - `/ws` accepts the configured auth mode and delivers the initial status frame.
 - The Cloudflare tunnel config publishes only the exact public hostname, routes it to a loopback/Unix origin, has no wildcard hostname/private-network route, and ends in `http_status:404` when supplied.
-- The sanitized Cloudflare evidence proves the Access app, no Bypass/public policies, exact hostname, no wildcard DNS, no private routes, final deny rule, and Access audit allow/deny observations when supplied.
+- The sanitized Cloudflare evidence proves the Access app, no Bypass/public policies, device mTLS through per-device Common Name selectors rather than broad Valid Certificate, exact hostname, no wildcard DNS, no private routes, final deny rule, and Access audit allow/deny observations when supplied.
 - Unauthenticated public HTTP routes and `/ws` are blocked by Cloudflare Access before origin when a public URL is supplied.
 - Public `/status` reaches Rust through Cloudflare Access and Office auth when a service token or manual verification timestamp is supplied.
 

--- a/rust/office-automate-server/src/artifacts.rs
+++ b/rust/office-automate-server/src/artifacts.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, anyhow};
 use axum::{
@@ -16,6 +19,7 @@ use sha2::{Digest, Sha256};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt},
+    process::Command,
 };
 
 pub const ARTIFACT_MAX_SIZE_BYTES: u64 = 100 * 1024 * 1024;
@@ -30,6 +34,7 @@ struct ArtifactStoreInner {
     artifacts_root: PathBuf,
     legacy_apk_path: PathBuf,
     max_size_bytes: u64,
+    upload_policy: ArtifactUploadPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -40,10 +45,43 @@ pub struct ArtifactMetadata {
     pub uploaded_at: String,
     pub size_bytes: u64,
     pub uploaded_by: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub signing_cert_sha256: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_code: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocation_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_artifact_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rolled_back_from_artifact_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+struct ArtifactRevocationIndex {
+    #[serde(default)]
+    artifacts: Vec<ArtifactRevocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ArtifactRevocation {
+    artifact_hash: String,
+    revoked_at: String,
+    reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replacement_artifact_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArtifactUploadPolicy {
+    pub expected_office_climate_signing_cert_sha256: Option<String>,
+    pub apksigner_path: Option<PathBuf>,
 }
 
 impl ArtifactStore {
@@ -56,11 +94,26 @@ impl ArtifactStore {
         legacy_apk_path: PathBuf,
         max_size_bytes: u64,
     ) -> Self {
+        Self::with_upload_policy(
+            artifacts_root,
+            legacy_apk_path,
+            max_size_bytes,
+            ArtifactUploadPolicy::default(),
+        )
+    }
+
+    pub fn with_upload_policy(
+        artifacts_root: PathBuf,
+        legacy_apk_path: PathBuf,
+        max_size_bytes: u64,
+        upload_policy: ArtifactUploadPolicy,
+    ) -> Self {
         Self {
             inner: Arc::new(ArtifactStoreInner {
                 artifacts_root,
                 legacy_apk_path,
                 max_size_bytes,
+                upload_policy,
             }),
         }
     }
@@ -79,6 +132,10 @@ impl ArtifactStore {
 
     fn meta_path(&self, app: &str) -> PathBuf {
         self.app_dir(app).join("meta.json")
+    }
+
+    fn revocations_path(&self, app: &str) -> PathBuf {
+        self.app_dir(app).join("revocations.json")
     }
 
     pub async fn read_metadata(&self, app: &str) -> Result<Option<ArtifactMetadata>> {
@@ -118,7 +175,7 @@ impl ArtifactStore {
 
     async fn write_metadata(&self, app: &str, metadata: &ArtifactMetadata) -> Result<()> {
         let meta_path = self.meta_path(app);
-        let temp_path = unique_temp_path(&self.app_dir(app), ".tmp-meta-", ".json");
+        let temp_path = unique_temp_path(self.app_dir(app), ".tmp-meta-", ".json");
         let contents = serde_json::to_vec(metadata).context("failed to serialize metadata")?;
         fs::write(&temp_path, contents)
             .await
@@ -163,6 +220,10 @@ impl ArtifactStore {
         artifact_hash: &str,
     ) -> Result<Option<Response>> {
         if !is_valid_app_name(app) || !is_valid_artifact_hash(artifact_hash) {
+            return Ok(None);
+        }
+
+        if self.is_artifact_revoked(app, artifact_hash).await? {
             return Ok(None);
         }
 
@@ -283,8 +344,26 @@ impl ArtifactStore {
             ));
         }
 
+        let signing_cert_sha256 = self
+            .verify_upload(app, &temp_path)
+            .await
+            .map_err(|error| ArtifactError::BadRequest(error.to_string()))?
+            .unwrap_or_default();
         let sha256 = format!("{:x}", sha256.finalize());
         let artifact_hash = sha256[..8].to_string();
+        let artifact_revoked = match self.is_artifact_revoked(app, &artifact_hash).await {
+            Ok(revoked) => revoked,
+            Err(error) => {
+                remove_file_if_exists(&temp_path).await;
+                return Err(ArtifactError::Internal(error));
+            }
+        };
+        if artifact_revoked {
+            remove_file_if_exists(&temp_path).await;
+            return Err(ArtifactError::BadRequest(format!(
+                "artifact hash {artifact_hash} is revoked"
+            )));
+        }
         let hashed_path = self.hashed_path(app, &artifact_hash);
         if !hashed_path.exists() {
             copy_file_atomically(&temp_path, &hashed_path).await?;
@@ -303,8 +382,14 @@ impl ArtifactStore {
             uploaded_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
             size_bytes,
             uploaded_by: user_email.to_string(),
+            signing_cert_sha256,
             version_code,
             version_name,
+            revoked_at: None,
+            revocation_reason: None,
+            replacement_artifact_hash: None,
+            rolled_back_from_artifact_hash: None,
+            rollback_reason: None,
         };
         self.write_metadata(app, &metadata)
             .await
@@ -315,6 +400,211 @@ impl ArtifactStore {
             size_bytes,
             download_url: format!("/apps/{app}/latest.apk"),
         })
+    }
+
+    async fn verify_upload(&self, app: &str, apk_path: &Path) -> Result<Option<String>> {
+        let expected = match app {
+            "office-climate" => self
+                .inner
+                .upload_policy
+                .expected_office_climate_signing_cert_sha256
+                .as_deref()
+                .map(normalize_cert_digest)
+                .transpose()
+                .context("invalid expected office-climate signing certificate SHA-256")?,
+            _ => None,
+        };
+        let Some(expected) = expected else {
+            return Ok(None);
+        };
+        let actual = verify_apk_signing_cert_sha256(
+            self.inner.upload_policy.apksigner_path.as_deref(),
+            apk_path,
+        )
+        .await?;
+        if actual != expected {
+            anyhow::bail!(
+                "APK signing certificate SHA-256 {actual} does not match expected {expected}"
+            );
+        }
+        Ok(Some(actual))
+    }
+
+    pub async fn revoke_current(
+        &self,
+        app: &str,
+        reason: &str,
+        replacement_artifact_hash: Option<&str>,
+    ) -> Result<Option<ArtifactMetadata>> {
+        if !is_valid_app_name(app) {
+            anyhow::bail!("invalid app name {app:?}");
+        }
+        let reason = reason.trim();
+        if reason.is_empty() {
+            anyhow::bail!("artifact revocation reason must not be empty");
+        }
+        let Some(mut metadata) = self.read_metadata(app).await? else {
+            return Ok(None);
+        };
+        if let Some(hash) = replacement_artifact_hash {
+            if !is_valid_artifact_hash(hash) {
+                anyhow::bail!("invalid replacement artifact hash {hash:?}");
+            }
+            if !self.hashed_path(app, hash).is_file() {
+                anyhow::bail!("replacement artifact does not exist: {hash}");
+            }
+            metadata.replacement_artifact_hash = Some(hash.to_string());
+        }
+        let revoked_at = Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        metadata.revoked_at = Some(revoked_at.clone());
+        metadata.revocation_reason = Some(reason.to_string());
+        self.record_artifact_revocation(
+            app,
+            &metadata.artifact_hash,
+            &revoked_at,
+            reason,
+            metadata.replacement_artifact_hash.as_deref(),
+        )
+        .await?;
+        self.write_metadata(app, &metadata).await?;
+        Ok(Some(metadata))
+    }
+
+    pub async fn rollback_to(
+        &self,
+        app: &str,
+        artifact_hash: &str,
+        reason: &str,
+        user_email: &str,
+    ) -> Result<Option<ArtifactMetadata>> {
+        if !is_valid_app_name(app) || !is_valid_artifact_hash(artifact_hash) {
+            anyhow::bail!("invalid app name or artifact hash");
+        }
+        let reason = reason.trim();
+        if reason.is_empty() {
+            anyhow::bail!("artifact rollback reason must not be empty");
+        }
+        if self.is_artifact_revoked(app, artifact_hash).await? {
+            anyhow::bail!("rollback target artifact {artifact_hash} is revoked");
+        }
+        let artifact_path = self.hashed_path(app, artifact_hash);
+        if !artifact_path.is_file() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&artifact_path)
+            .await
+            .with_context(|| format!("failed to read {}", artifact_path.display()))?;
+        let sha256 = format!("{:x}", Sha256::digest(&bytes));
+        if !sha256.starts_with(artifact_hash) {
+            anyhow::bail!("rollback artifact hash prefix does not match SHA-256");
+        }
+        let signing_cert_sha256 = self
+            .verify_upload(app, &artifact_path)
+            .await?
+            .unwrap_or_default();
+        let previous = self.read_metadata(app).await?;
+        let previous_hash = previous
+            .as_ref()
+            .map(|metadata| metadata.artifact_hash.clone())
+            .filter(|hash| hash != artifact_hash);
+        if let Some(previous_hash) = previous_hash.as_deref() {
+            let revoked_at = Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+            self.record_artifact_revocation(
+                app,
+                previous_hash,
+                &revoked_at,
+                reason,
+                Some(artifact_hash),
+            )
+            .await?;
+        }
+        let latest_path = self.latest_path(app);
+        copy_file_atomically_anyhow(&artifact_path, &latest_path).await?;
+        let metadata = ArtifactMetadata {
+            artifact_hash: artifact_hash.to_string(),
+            sha256,
+            uploaded_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+            size_bytes: bytes.len() as u64,
+            uploaded_by: user_email.to_string(),
+            signing_cert_sha256,
+            version_code: None,
+            version_name: None,
+            revoked_at: None,
+            revocation_reason: None,
+            replacement_artifact_hash: None,
+            rolled_back_from_artifact_hash: previous.map(|metadata| metadata.artifact_hash),
+            rollback_reason: Some(reason.to_string()),
+        };
+        self.write_metadata(app, &metadata).await?;
+        Ok(Some(metadata))
+    }
+
+    async fn is_artifact_revoked(&self, app: &str, artifact_hash: &str) -> Result<bool> {
+        let metadata_revoked = self.read_metadata(app).await?.is_some_and(|metadata| {
+            metadata.revoked_at.is_some() && metadata.artifact_hash == artifact_hash
+        });
+        if metadata_revoked {
+            return Ok(true);
+        }
+        let revocations = self.read_revocations(app).await?;
+        Ok(revocations
+            .artifacts
+            .iter()
+            .any(|revocation| revocation.artifact_hash == artifact_hash))
+    }
+
+    async fn record_artifact_revocation(
+        &self,
+        app: &str,
+        artifact_hash: &str,
+        revoked_at: &str,
+        reason: &str,
+        replacement_artifact_hash: Option<&str>,
+    ) -> Result<()> {
+        if !is_valid_artifact_hash(artifact_hash) {
+            anyhow::bail!("invalid revoked artifact hash {artifact_hash:?}");
+        }
+        let mut revocations = self.read_revocations(app).await?;
+        revocations
+            .artifacts
+            .retain(|revocation| revocation.artifact_hash != artifact_hash);
+        revocations.artifacts.push(ArtifactRevocation {
+            artifact_hash: artifact_hash.to_string(),
+            revoked_at: revoked_at.to_string(),
+            reason: reason.to_string(),
+            replacement_artifact_hash: replacement_artifact_hash.map(str::to_string),
+        });
+        self.write_revocations(app, &revocations).await
+    }
+
+    async fn read_revocations(&self, app: &str) -> Result<ArtifactRevocationIndex> {
+        let path = self.revocations_path(app);
+        if !path.exists() {
+            return Ok(ArtifactRevocationIndex::default());
+        }
+        let contents = fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", path.display()))
+    }
+
+    async fn write_revocations(
+        &self,
+        app: &str,
+        revocations: &ArtifactRevocationIndex,
+    ) -> Result<()> {
+        let path = self.revocations_path(app);
+        let temp_path = unique_temp_path(self.app_dir(app), ".tmp-revocations-", ".json");
+        let contents =
+            serde_json::to_vec(revocations).context("failed to serialize revocations")?;
+        fs::write(&temp_path, contents)
+            .await
+            .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        fs::rename(&temp_path, &path)
+            .await
+            .with_context(|| format!("failed to replace {}", path.display()))?;
+        Ok(())
     }
 }
 
@@ -380,6 +670,69 @@ pub fn is_valid_sha256_digest(sha256: &str) -> bool {
         && sha256
             .chars()
             .all(|character| character.is_ascii_hexdigit() && !character.is_ascii_uppercase())
+}
+
+pub fn normalize_cert_digest(value: &str) -> Result<String> {
+    let normalized = value
+        .trim()
+        .chars()
+        .filter(|character| character.is_ascii_hexdigit())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if !is_valid_sha256_digest(&normalized) {
+        anyhow::bail!("invalid SHA-256 certificate digest {value:?}");
+    }
+    Ok(normalized)
+}
+
+pub async fn verify_apk_signing_cert_sha256(
+    apksigner_path: Option<&Path>,
+    apk_path: &Path,
+) -> Result<String> {
+    let executable = apksigner_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("apksigner"));
+    let output = Command::new(&executable)
+        .arg("verify")
+        .arg("--print-certs")
+        .arg(apk_path)
+        .output()
+        .await
+        .with_context(|| format!("failed to run {}", executable.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("apksigner rejected APK: {}", stderr.trim());
+    }
+    parse_apksigner_sha256_digest(&String::from_utf8_lossy(&output.stdout))
+        .context("apksigner output did not include a signer certificate SHA-256 digest")
+}
+
+fn parse_apksigner_sha256_digest(output: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let lower = line.to_ascii_lowercase();
+        if !lower.contains("sha-256") || !lower.contains("digest") {
+            return None;
+        }
+        let (_, value) = line.split_once(':')?;
+        normalize_cert_digest(value).ok()
+    })
+}
+
+async fn copy_file_atomically_anyhow(source_path: &Path, destination_path: &Path) -> Result<()> {
+    let temp_path = unique_temp_path(
+        destination_path
+            .parent()
+            .context("destination has no parent")?,
+        ".tmp-artifact-copy-",
+        ".apk",
+    );
+    fs::copy(source_path, &temp_path)
+        .await
+        .with_context(|| format!("failed to copy {}", source_path.display()))?;
+    fs::rename(&temp_path, destination_path)
+        .await
+        .with_context(|| format!("failed to replace {}", destination_path.display()))?;
+    Ok(())
 }
 
 async fn copy_file_atomically(
@@ -517,5 +870,132 @@ mod tests {
         assert!(!is_valid_sha256_digest(
             "DD37C2D7274F7EA982CB83390C36918FEE9CE8889073C44B68CDC00BDB8C3E04"
         ));
+    }
+
+    #[test]
+    fn parses_apksigner_sha256_digest() {
+        let output = "Signer #1 certificate SHA-256 digest: AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+        assert_eq!(
+            parse_apksigner_sha256_digest(output).expect("digest"),
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_current_marks_metadata_revoked() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ArtifactStore::new(
+            temp_dir.path().join("apps"),
+            temp_dir.path().join("legacy.apk"),
+        );
+        let app_dir = store.app_dir("office-climate");
+        fs::create_dir_all(&app_dir).await.expect("app dir");
+        fs::write(app_dir.join("dd37c2d7.apk"), b"apk")
+            .await
+            .expect("hashed artifact");
+        fs::write(
+            app_dir.join("meta.json"),
+            r#"{"artifact_hash":"dd37c2d7","sha256":"dd37c2d7274f7ea982cb83390c36918fee9ce8889073c44b68cdc00bdb8c3e04","uploaded_at":"2026-06-05T00:00:00","size_bytes":3,"uploaded_by":"test@example.com"}"#,
+        )
+        .await
+        .expect("metadata");
+
+        let metadata = store
+            .revoke_current("office-climate", "bad release", None)
+            .await
+            .expect("revoke")
+            .expect("metadata");
+
+        assert!(metadata.revoked_at.is_some());
+        assert_eq!(metadata.revocation_reason.as_deref(), Some("bad release"));
+        assert!(
+            store
+                .serve_hashed_artifact("office-climate", "dd37c2d7")
+                .await
+                .expect("serve artifact")
+                .is_none()
+        );
+        let revocations = store
+            .read_revocations("office-climate")
+            .await
+            .expect("revocations");
+        assert_eq!(revocations.artifacts[0].artifact_hash, "dd37c2d7");
+    }
+
+    #[tokio::test]
+    async fn rollback_records_previous_artifact_revocation() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ArtifactStore::new(
+            temp_dir.path().join("apps"),
+            temp_dir.path().join("legacy.apk"),
+        );
+        let app_dir = store.app_dir("office-climate");
+        fs::create_dir_all(&app_dir).await.expect("app dir");
+
+        let previous_bytes = b"bad apk";
+        let previous_sha256 = format!("{:x}", Sha256::digest(previous_bytes));
+        let previous_hash = &previous_sha256[..8];
+        fs::write(app_dir.join(format!("{previous_hash}.apk")), previous_bytes)
+            .await
+            .expect("previous artifact");
+
+        let rollback_bytes = b"known good apk";
+        let rollback_sha256 = format!("{:x}", Sha256::digest(rollback_bytes));
+        let rollback_hash = &rollback_sha256[..8];
+        fs::write(app_dir.join(format!("{rollback_hash}.apk")), rollback_bytes)
+            .await
+            .expect("rollback artifact");
+
+        fs::write(
+            app_dir.join("meta.json"),
+            format!(
+                r#"{{"artifact_hash":"{previous_hash}","sha256":"{previous_sha256}","uploaded_at":"2026-06-05T00:00:00","size_bytes":{},"uploaded_by":"test@example.com"}}"#,
+                previous_bytes.len()
+            ),
+        )
+        .await
+        .expect("metadata");
+
+        let metadata = store
+            .rollback_to(
+                "office-climate",
+                rollback_hash,
+                "bad release",
+                "local_operator",
+            )
+            .await
+            .expect("rollback")
+            .expect("metadata");
+
+        assert_eq!(metadata.artifact_hash, rollback_hash);
+        assert_eq!(
+            metadata.rolled_back_from_artifact_hash.as_deref(),
+            Some(previous_hash)
+        );
+        assert!(
+            store
+                .serve_hashed_artifact("office-climate", previous_hash)
+                .await
+                .expect("serve previous")
+                .is_none()
+        );
+        assert!(
+            store
+                .serve_hashed_artifact("office-climate", rollback_hash)
+                .await
+                .expect("serve rollback")
+                .is_some()
+        );
+
+        let error = store
+            .rollback_to(
+                "office-climate",
+                previous_hash,
+                "try bad rollback",
+                "local_operator",
+            )
+            .await
+            .expect_err("revoked rollback target should fail");
+        assert!(error.to_string().contains("is revoked"));
     }
 }

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -432,6 +432,8 @@ mod tests {
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig {
                 device_type: "tuya".to_string(),
                 ip: "192.0.2.10".to_string(),

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
+    artifacts::{ARTIFACT_MAX_SIZE_BYTES, ArtifactStore, ArtifactUploadPolicy},
     config::AppConfig,
     db, device, edge, erv, http, hvac, migration, presence, telemetry,
     validation::{
@@ -35,6 +36,10 @@ pub enum Command {
     ListDevices(ConfigArgs),
     /// Revoke an enrolled device registration.
     RevokeDevice(RevokeDeviceArgs),
+    /// Mark the current app artifact revoked so clients refuse it.
+    RevokeArtifact(RevokeArtifactArgs),
+    /// Roll latest app artifact back to a known content-addressed APK.
+    RollbackArtifact(RollbackArtifactArgs),
     /// Run local dependency checks without changing device state.
     Smoke(SmokeArgs),
     /// Run local telemetry collectors.
@@ -97,6 +102,30 @@ pub struct RevokeDeviceArgs {
     pub device_id: Option<String>,
     #[arg(long = "device-id")]
     pub device_id_flag: Option<String>,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct RevokeArtifactArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[arg(long, default_value = "office-climate")]
+    pub app: String,
+    #[arg(long)]
+    pub reason: String,
+    #[arg(long)]
+    pub replacement_artifact_hash: Option<String>,
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct RollbackArtifactArgs {
+    #[arg(long, env = "OFFICE_AUTOMATE_CONFIG")]
+    pub config: PathBuf,
+    #[arg(long, default_value = "office-climate")]
+    pub app: String,
+    #[arg(long)]
+    pub artifact_hash: String,
+    #[arg(long)]
+    pub reason: String,
 }
 
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
@@ -299,6 +328,9 @@ pub struct SecurityValidationArgs {
     /// Dedicated public edge user for sudo-based boundary probes.
     #[arg(long, env = "OFFICE_AUTOMATE_EDGE_USER")]
     pub edge_user: Option<String>,
+    /// Dedicated controller/device-ingress user for launchd and containment validation.
+    #[arg(long, env = "OFFICE_AUTOMATE_CONTROLLER_USER")]
+    pub controller_user: Option<String>,
     /// Additional secret/config file that must be owner-only. Repeatable.
     #[arg(long = "secret-file")]
     pub secret_files: Vec<PathBuf>,
@@ -426,6 +458,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 args.listen,
                 args.device_ca_cert,
                 args.device_ca_key,
+                config.cloudflare_access,
             )
             .await
         }
@@ -459,11 +492,68 @@ pub async fn run(cli: Cli) -> Result<()> {
                 .device_id
                 .or(args.device_id_flag)
                 .context("revoke-device requires DEVICE_ID or --device-id")?;
-            let revoked = device::revoke_device(&config.runtime.database_path, &device_id)?;
+            let revoked = device::revoke_device(
+                &config.runtime.database_path,
+                &config.cloudflare_access,
+                &device_id,
+            )
+            .await?;
             if revoked {
                 println!("device revoked: {device_id}");
             } else {
                 println!("device not found or already revoked: {device_id}");
+            }
+            Ok(())
+        }
+        Command::RevokeArtifact(args) => {
+            let config = AppConfig::load(&args.config)?;
+            let store = artifact_store(&config);
+            match store
+                .revoke_current(
+                    &args.app,
+                    &args.reason,
+                    args.replacement_artifact_hash.as_deref(),
+                )
+                .await?
+            {
+                Some(metadata) => {
+                    println!(
+                        "artifact revoked: app={} artifact_hash={} revoked_at={} replacement={}",
+                        args.app,
+                        metadata.artifact_hash,
+                        metadata.revoked_at.as_deref().unwrap_or("-"),
+                        metadata.replacement_artifact_hash.as_deref().unwrap_or("-")
+                    );
+                }
+                None => println!("artifact metadata not found: app={}", args.app),
+            }
+            Ok(())
+        }
+        Command::RollbackArtifact(args) => {
+            let config = AppConfig::load(&args.config)?;
+            let store = artifact_store(&config);
+            match store
+                .rollback_to(
+                    &args.app,
+                    &args.artifact_hash,
+                    &args.reason,
+                    "local_operator",
+                )
+                .await?
+            {
+                Some(metadata) => println!(
+                    "artifact rolled back: app={} artifact_hash={} previous={}",
+                    args.app,
+                    metadata.artifact_hash,
+                    metadata
+                        .rolled_back_from_artifact_hash
+                        .as_deref()
+                        .unwrap_or("-")
+                ),
+                None => println!(
+                    "rollback artifact not found: app={} artifact_hash={}",
+                    args.app, args.artifact_hash
+                ),
             }
             Ok(())
         }
@@ -499,6 +589,21 @@ pub async fn run(cli: Cli) -> Result<()> {
             run_validate(&config, args.target).await
         }
     }
+}
+
+fn artifact_store(config: &AppConfig) -> ArtifactStore {
+    ArtifactStore::with_upload_policy(
+        config.runtime.artifacts_dir.clone(),
+        config.runtime.legacy_apk_path.clone(),
+        ARTIFACT_MAX_SIZE_BYTES,
+        ArtifactUploadPolicy {
+            expected_office_climate_signing_cert_sha256: config
+                .artifacts
+                .office_climate_signing_cert_sha256
+                .clone(),
+            apksigner_path: config.artifacts.apksigner_path.clone(),
+        },
+    )
 }
 
 async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()> {
@@ -649,6 +754,7 @@ async fn run_validate(config: &AppConfig, target: ValidateTarget) -> Result<()> 
                     tunnel_launchd_plist: args.tunnel_launchd_plist,
                     tunnel_user: args.tunnel_user,
                     edge_user: args.edge_user,
+                    controller_user: args.controller_user,
                     secret_files: args.secret_files,
                     protected_paths: args.protected_paths,
                     tunnel_readable_paths: args.tunnel_readable_paths,

--- a/rust/office-automate-server/src/cloudflare.rs
+++ b/rust/office-automate-server/src/cloudflare.rs
@@ -1,0 +1,256 @@
+use anyhow::{Context, Result, bail};
+use reqwest::{Client, Method};
+use serde_json::{Map, Value, json};
+
+use crate::config::CloudflareAccessConfig;
+
+const EMPTY_DEVICE_COMMON_NAME: &str = "__office_automate_no_enrolled_devices__";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevicePolicyAction {
+    Allow,
+    Revoke,
+}
+
+pub async fn sync_device_common_name(
+    config: &CloudflareAccessConfig,
+    common_name: &str,
+    action: DevicePolicyAction,
+) -> Result<()> {
+    let Some(request) = DevicePolicyRequest::from_config(config, common_name, action) else {
+        return Ok(());
+    };
+    request.execute(&Client::new()).await
+}
+
+#[derive(Debug)]
+struct DevicePolicyRequest {
+    api_base_url: String,
+    account_id: String,
+    app_id: Option<String>,
+    policy_id: String,
+    api_token: String,
+    common_name: String,
+    action: DevicePolicyAction,
+}
+
+impl DevicePolicyRequest {
+    fn from_config(
+        config: &CloudflareAccessConfig,
+        common_name: &str,
+        action: DevicePolicyAction,
+    ) -> Option<Self> {
+        if !config.device_policy_sync_configured() {
+            return None;
+        }
+        Some(Self {
+            api_base_url: config.api_base_url.trim_end_matches('/').to_string(),
+            account_id: config.account_id.as_ref()?.trim().to_string(),
+            app_id: config.app_id.as_ref().map(|value| value.trim().to_string()),
+            policy_id: config.device_policy_id.as_ref()?.trim().to_string(),
+            api_token: config.api_token.as_ref()?.trim().to_string(),
+            common_name: common_name.trim().to_string(),
+            action,
+        })
+    }
+
+    async fn execute(&self, client: &Client) -> Result<()> {
+        if self.common_name.is_empty() {
+            bail!("Cloudflare device policy sync requires a non-empty common name");
+        }
+        let url = self.policy_url();
+        let current = self
+            .cloudflare_request(client, Method::GET, &url, None)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to fetch Cloudflare Access policy {}",
+                    self.policy_id
+                )
+            })?;
+        let mut policy = current
+            .get("result")
+            .cloned()
+            .context("Cloudflare Access policy response missing result")?;
+        mutate_policy_common_name_allowlist(&mut policy, &self.common_name, self.action)?;
+        let payload = policy_update_payload(policy)?;
+        self.cloudflare_request(client, Method::PUT, &url, Some(payload))
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to update Cloudflare Access policy {}",
+                    self.policy_id
+                )
+            })?;
+        Ok(())
+    }
+
+    fn policy_url(&self) -> String {
+        if let Some(app_id) = &self.app_id {
+            format!(
+                "{}/accounts/{}/access/apps/{}/policies/{}",
+                self.api_base_url, self.account_id, app_id, self.policy_id
+            )
+        } else {
+            format!(
+                "{}/accounts/{}/access/policies/{}",
+                self.api_base_url, self.account_id, self.policy_id
+            )
+        }
+    }
+
+    async fn cloudflare_request(
+        &self,
+        client: &Client,
+        method: Method,
+        url: &str,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let mut request = client
+            .request(method, url)
+            .bearer_auth(&self.api_token)
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request
+            .send()
+            .await
+            .context("Cloudflare API request failed")?;
+        let status = response.status();
+        let value = response
+            .json::<Value>()
+            .await
+            .context("Cloudflare API returned non-JSON response")?;
+        if !status.is_success() || value.get("success").and_then(Value::as_bool) != Some(true) {
+            bail!("Cloudflare API request failed with status {status}: {value}");
+        }
+        Ok(value)
+    }
+}
+
+fn mutate_policy_common_name_allowlist(
+    policy: &mut Value,
+    common_name: &str,
+    action: DevicePolicyAction,
+) -> Result<()> {
+    let include = policy
+        .get_mut("include")
+        .and_then(Value::as_array_mut)
+        .context("Cloudflare Access policy result missing include array")?;
+    include.retain(|rule| rule.get("certificate").is_none());
+    include.retain(|rule| {
+        common_name_from_rule(rule)
+            .map(|value| value != common_name && value != EMPTY_DEVICE_COMMON_NAME)
+            .unwrap_or(true)
+    });
+    if action == DevicePolicyAction::Allow {
+        include.push(json!({"common_name": {"common_name": common_name}}));
+    }
+    if !include
+        .iter()
+        .any(|rule| common_name_from_rule(rule).is_some())
+    {
+        include.push(json!({"common_name": {"common_name": EMPTY_DEVICE_COMMON_NAME}}));
+    }
+    Ok(())
+}
+
+fn common_name_from_rule(rule: &Value) -> Option<&str> {
+    rule.get("common_name")
+        .and_then(|value| value.get("common_name"))
+        .and_then(Value::as_str)
+}
+
+fn policy_update_payload(policy: Value) -> Result<Value> {
+    let object = policy
+        .as_object()
+        .context("Cloudflare Access policy result must be an object")?;
+    let mut payload = Map::new();
+    for key in [
+        "name",
+        "decision",
+        "include",
+        "exclude",
+        "require",
+        "precedence",
+        "session_duration",
+        "approval_groups",
+        "approval_required",
+        "purpose_justification_required",
+        "purpose_justification_prompt",
+        "isolation_required",
+    ] {
+        if let Some(value) = object.get(key) {
+            payload.insert(key.to_string(), value.clone());
+        }
+    }
+    if !payload.contains_key("name")
+        || !payload.contains_key("decision")
+        || !payload.contains_key("include")
+    {
+        bail!("Cloudflare Access policy result missing required update fields");
+    }
+    Ok(Value::Object(payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn common_name_sync_removes_valid_certificate_broad_allow() {
+        let mut policy = json!({
+            "include": [
+                {"certificate": {}},
+                {"common_name": {"common_name": "old-device"}}
+            ]
+        });
+
+        mutate_policy_common_name_allowlist(&mut policy, "new-device", DevicePolicyAction::Allow)
+            .expect("mutate");
+
+        assert_eq!(
+            policy["include"],
+            json!([
+                {"common_name": {"common_name": "old-device"}},
+                {"common_name": {"common_name": "new-device"}}
+            ])
+        );
+    }
+
+    #[test]
+    fn common_name_revoke_leaves_impossible_rule_when_empty() {
+        let mut policy = json!({
+            "include": [
+                {"common_name": {"common_name": "phone"}}
+            ]
+        });
+
+        mutate_policy_common_name_allowlist(&mut policy, "phone", DevicePolicyAction::Revoke)
+            .expect("mutate");
+
+        assert_eq!(
+            policy["include"],
+            json!([
+                {"common_name": {"common_name": EMPTY_DEVICE_COMMON_NAME}}
+            ])
+        );
+    }
+
+    #[test]
+    fn policy_update_payload_keeps_only_mutable_fields() {
+        let payload = policy_update_payload(json!({
+            "id": "readonly",
+            "name": "allow-device-mtls",
+            "decision": "non_identity",
+            "include": [{"common_name": {"common_name": "phone"}}],
+            "created_at": "readonly"
+        }))
+        .expect("payload");
+
+        assert!(payload.get("id").is_none());
+        assert!(payload.get("created_at").is_none());
+        assert_eq!(payload["decision"], "non_identity");
+    }
+}

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -12,6 +12,8 @@ pub struct AppConfig {
     pub presence: PresenceConfig,
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
+    pub artifacts: ArtifactConfig,
+    pub cloudflare_access: CloudflareAccessConfig,
     pub erv: ErvConfig,
     pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
@@ -108,6 +110,8 @@ impl Default for GoogleOAuthConfig {
 pub struct QingpingConfig {
     pub mqtt_broker: String,
     pub mqtt_port: u16,
+    pub mqtt_username: Option<String>,
+    pub mqtt_password: Option<String>,
     pub device_mac: Option<String>,
     pub report_interval: u64,
 }
@@ -117,9 +121,56 @@ impl Default for QingpingConfig {
         Self {
             mqtt_broker: "127.0.0.1".to_string(),
             mqtt_port: 1883,
+            mqtt_username: None,
+            mqtt_password: None,
             device_mac: None,
             report_interval: 60,
         }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(default)]
+pub struct ArtifactConfig {
+    pub office_climate_signing_cert_sha256: Option<String>,
+    pub apksigner_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct CloudflareAccessConfig {
+    pub account_id: Option<String>,
+    pub app_id: Option<String>,
+    pub device_policy_id: Option<String>,
+    pub api_token: Option<String>,
+    pub api_base_url: String,
+}
+
+impl Default for CloudflareAccessConfig {
+    fn default() -> Self {
+        Self {
+            account_id: None,
+            app_id: None,
+            device_policy_id: None,
+            api_token: None,
+            api_base_url: "https://api.cloudflare.com/client/v4".to_string(),
+        }
+    }
+}
+
+impl CloudflareAccessConfig {
+    pub fn device_policy_sync_configured(&self) -> bool {
+        self.account_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .device_policy_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .api_token
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
     }
 }
 
@@ -365,6 +416,8 @@ struct FileConfig {
     presence: PresenceConfig,
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
+    artifacts: ArtifactConfig,
+    cloudflare_access: CloudflareAccessConfig,
     erv: ErvConfig,
     mitsubishi: MitsubishiConfig,
     thresholds: ThresholdsConfig,
@@ -411,6 +464,14 @@ impl AppConfig {
             file_config.qingping.mqtt_port = port
                 .parse()
                 .with_context(|| format!("invalid OFFICE_AUTOMATE_MQTT_PORT value {port:?}"))?;
+        }
+
+        if let Some(username) = env_lookup("OFFICE_AUTOMATE_QINGPING_MQTT_USERNAME") {
+            file_config.qingping.mqtt_username = Some(username);
+        }
+
+        if let Some(password) = env_lookup("OFFICE_AUTOMATE_QINGPING_MQTT_PASSWORD") {
+            file_config.qingping.mqtt_password = Some(password);
         }
 
         if let Some(uaid) = env_lookup("OFFICE_AUTOMATE_YOLINK_UAID") {
@@ -480,6 +541,34 @@ impl AppConfig {
 
         if let Some(token) = env_lookup("OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN") {
             file_config.orchestrator.controller_ipc_token = Some(token);
+        }
+
+        if let Some(cert_sha256) = env_lookup("OFFICE_AUTOMATE_ANDROID_SIGNING_CERT_SHA256") {
+            file_config.artifacts.office_climate_signing_cert_sha256 = Some(cert_sha256);
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_APKSIGNER") {
+            file_config.artifacts.apksigner_path = Some(PathBuf::from(path));
+        }
+
+        if let Some(account_id) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_ACCOUNT_ID") {
+            file_config.cloudflare_access.account_id = Some(account_id);
+        }
+
+        if let Some(app_id) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_APP_ID") {
+            file_config.cloudflare_access.app_id = Some(app_id);
+        }
+
+        if let Some(policy_id) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_DEVICE_POLICY_ID") {
+            file_config.cloudflare_access.device_policy_id = Some(policy_id);
+        }
+
+        if let Some(api_token) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_API_TOKEN") {
+            file_config.cloudflare_access.api_token = Some(api_token);
+        }
+
+        if let Some(api_base_url) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_API_BASE_URL") {
+            file_config.cloudflare_access.api_base_url = api_base_url;
         }
 
         if let Some(admin_emails) = env_lookup("OFFICE_AUTOMATE_ADMIN_EMAILS") {
@@ -613,6 +702,8 @@ impl AppConfig {
             presence: file_config.presence,
             qingping: file_config.qingping,
             yolink: file_config.yolink,
+            artifacts: file_config.artifacts,
+            cloudflare_access: file_config.cloudflare_access,
             erv: file_config.erv,
             mitsubishi: file_config.mitsubishi,
             thresholds: file_config.thresholds,

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -17,7 +17,11 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
-use crate::db::{self, DeviceRegistration};
+use crate::{
+    cloudflare::{self, DevicePolicyAction},
+    config::CloudflareAccessConfig,
+    db::{self, DeviceRegistration},
+};
 
 const DEFAULT_DEVICE_CA_CERT: &str = "certs/device-ca.pem";
 const DEFAULT_DEVICE_CA_KEY: &str = "certs/device-ca.key";
@@ -28,6 +32,7 @@ struct PairingState {
     database_path: PathBuf,
     ca_cert_path: PathBuf,
     ca_key_path: PathBuf,
+    cloudflare_access: CloudflareAccessConfig,
     unknown_attempts: Arc<Mutex<u32>>,
 }
 
@@ -69,7 +74,23 @@ pub fn list_devices(database_path: &Path) -> Result<Vec<DeviceRegistration>> {
     db::list_device_registrations(database_path)
 }
 
-pub fn revoke_device(database_path: &Path, device_id: &str) -> Result<bool> {
+pub async fn revoke_device(
+    database_path: &Path,
+    cloudflare_access: &CloudflareAccessConfig,
+    device_id: &str,
+) -> Result<bool> {
+    if let Some(common_name) = db::list_device_registrations(database_path)?
+        .into_iter()
+        .find(|device| device.device_id == device_id)
+        .and_then(|device| device.common_name)
+    {
+        cloudflare::sync_device_common_name(
+            cloudflare_access,
+            &common_name,
+            DevicePolicyAction::Revoke,
+        )
+        .await?;
+    }
     db::revoke_device_registration(database_path, device_id)
 }
 
@@ -78,11 +99,13 @@ pub async fn serve_pairing_listener(
     bind_addr: SocketAddr,
     ca_cert_path: Option<PathBuf>,
     ca_key_path: Option<PathBuf>,
+    cloudflare_access: CloudflareAccessConfig,
 ) -> Result<()> {
     let state = PairingState {
         database_path,
         ca_cert_path: ca_cert_path.unwrap_or_else(default_device_ca_cert_path),
         ca_key_path: ca_key_path.unwrap_or_else(default_device_ca_key_path),
+        cloudflare_access,
         unknown_attempts: Arc::new(Mutex::new(0)),
     };
 
@@ -193,6 +216,19 @@ async fn complete_device_pairing(
                 .into_response();
         }
     };
+    if let Err(error) = cloudflare::sync_device_common_name(
+        &state.cloudflare_access,
+        &certificate_common_name,
+        DevicePolicyAction::Allow,
+    )
+    .await
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": error.to_string()})),
+        )
+            .into_response();
+    }
 
     match db::complete_device_registration(
         &state.database_path,

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -937,6 +937,8 @@ mod tests {
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv,
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -38,7 +38,7 @@ use tower_http::{
 
 use crate::{
     artifacts::ARTIFACT_MAX_SIZE_BYTES,
-    artifacts::{ArtifactStore, is_valid_artifact_hash},
+    artifacts::{ArtifactStore, ArtifactUploadPolicy, is_valid_artifact_hash},
     auth::{
         AuthManager, AuthenticatedUser, HttpAuthMode, OAUTH_CSRF_HEADER, OAuthCredentialSource,
         WebSocketAuth,
@@ -360,9 +360,17 @@ fn build_app_state(
 ) -> Result<(AppState, ErvPolicyCoordinator)> {
     db::migrate_database(&config.runtime.database_path)?;
     let auth = AuthManager::new(&config.orchestrator)?;
-    let artifacts = ArtifactStore::new(
+    let artifacts = ArtifactStore::with_upload_policy(
         config.runtime.artifacts_dir.clone(),
         config.runtime.legacy_apk_path.clone(),
+        ARTIFACT_MAX_SIZE_BYTES,
+        ArtifactUploadPolicy {
+            expected_office_climate_signing_cert_sha256: config
+                .artifacts
+                .office_climate_signing_cert_sha256
+                .clone(),
+            apksigner_path: config.artifacts.apksigner_path.clone(),
+        },
     );
     let temperature_band_defaults = TemperatureBands::from_config(&config);
     let temperature_bands = load_hvac_temperature_bands(&config, temperature_band_defaults);
@@ -2197,6 +2205,17 @@ async fn latest_app_artifact(State(state): State<AppState>, Path(app): Path<Stri
     if !is_valid_artifact_hash(&metadata.artifact_hash) {
         return StatusCode::NOT_FOUND.into_response();
     }
+    if metadata.revoked_at.is_some() {
+        return (
+            StatusCode::GONE,
+            Json(json!({
+                "error": "artifact revoked",
+                "artifact_hash": metadata.artifact_hash,
+                "replacement_artifact_hash": metadata.replacement_artifact_hash,
+            })),
+        )
+            .into_response();
+    }
 
     let mut response = Response::builder()
         .status(StatusCode::FOUND)
@@ -2365,6 +2384,7 @@ fn escape_html_text(value: &str) -> String {
         .collect()
 }
 
+#[cfg(test)]
 fn script_json_string(value: &str) -> String {
     serde_json::to_string(value)
         .expect("string serializes")
@@ -2726,6 +2746,8 @@ mod tests {
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
@@ -6113,6 +6135,71 @@ mod tests {
         assert_eq!(
             response.headers().get("x-content-type-options").unwrap(),
             "nosniff"
+        );
+    }
+
+    #[tokio::test]
+    async fn artifact_upload_rejects_revoked_hash() {
+        let config = oauth_config();
+        let token = AuthManager::new(&config.orchestrator)
+            .expect("auth")
+            .generate_jwt("engineer@rajeshgo.li")
+            .expect("token");
+        let boundary = "test-boundary";
+        let bytes = b"bad-apk-bytes";
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(multipart_body(boundary, bytes)))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        crate::artifacts::ArtifactStore::new(
+            config.runtime.artifacts_dir.clone(),
+            config.runtime.legacy_apk_path.clone(),
+        )
+        .revoke_current("office-climate", "bad release", None)
+        .await
+        .expect("revoke current")
+        .expect("metadata");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/deploy/office-climate")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::from(multipart_body(boundary, bytes)))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            value["error"]
+                .as_str()
+                .expect("error")
+                .contains("is revoked")
         );
     }
 

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -910,6 +910,8 @@ mod tests {
             presence: crate::config::PresenceConfig::default(),
             qingping: crate::config::QingpingConfig::default(),
             yolink: crate::config::YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: crate::config::ErvConfig::default(),
             mitsubishi: crate::config::MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod artifacts;
 pub mod auth;
 pub mod automation;
 pub mod cli;
+pub mod cloudflare;
 pub mod config;
 pub mod db;
 pub mod device;

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -883,6 +883,8 @@ mod tests {
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -2,9 +2,9 @@ use std::{
     collections::HashMap,
     net::{SocketAddr, ToSocketAddrs},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     thread::{self, JoinHandle},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, anyhow};
@@ -15,13 +15,20 @@ use rumqttd::{
 use tokio::time;
 
 use crate::{
-    config::AppConfig,
+    config::{AppConfig, QingpingConfig},
     db,
     qingping::{
-        MAX_QINGPING_PAYLOAD_BYTES, QingpingState, parse_qingping_payload, qingping_down_topic,
-        qingping_interval_payload, qingping_up_topic,
+        MAX_QINGPING_PAYLOAD_BYTES, QingpingReading, QingpingState, parse_qingping_payload,
+        qingping_down_topic, qingping_interval_payload, qingping_up_topic,
     },
 };
+
+const QINGPING_MIN_ACCEPT_INTERVAL: Duration = Duration::from_secs(2);
+const QINGPING_MAX_CO2_DELTA: i64 = 4_000;
+const QINGPING_MAX_TVOC_DELTA: i64 = 500;
+const QINGPING_MAX_PM_DELTA: i64 = 500;
+const QINGPING_MAX_TEMP_DELTA: f64 = 12.0;
+const QINGPING_MAX_HUMIDITY_DELTA: f64 = 50.0;
 
 pub struct MqttRuntime {
     _broker_thread: JoinHandle<()>,
@@ -42,6 +49,7 @@ pub async fn publish_qingping_interval(config: &AppConfig, interval_seconds: i64
     publish_local_qingping_command(
         &config.runtime.mqtt_host,
         config.runtime.mqtt_port,
+        &config.qingping,
         &topic,
         payload,
     )
@@ -53,6 +61,7 @@ pub async fn publish_qingping_interval(config: &AppConfig, interval_seconds: i64
 async fn publish_local_qingping_command(
     host: &str,
     port: u16,
+    qingping: &QingpingConfig,
     topic: &str,
     payload: Vec<u8>,
 ) -> Result<()> {
@@ -62,6 +71,9 @@ async fn publish_local_qingping_command(
     );
     let mut options = MqttOptions::new(client_id, (host.trim(), port));
     options.set_keep_alive(5);
+    if let Some((username, password)) = qingping_mqtt_credentials(qingping)? {
+        options.set_credentials(username, password);
+    }
 
     let (client, mut event_loop) = AsyncClient::builder(options).capacity(10).build();
     client
@@ -99,9 +111,14 @@ pub fn start_qingping_ingress(
     };
 
     let topic = qingping_up_topic(device_mac);
-    let broker_config = build_broker_config(&config.runtime.mqtt_host, config.runtime.mqtt_port)?;
+    let broker_config = build_broker_config(
+        &config.runtime.mqtt_host,
+        config.runtime.mqtt_port,
+        &config.qingping,
+    )?;
     let database_path = config.runtime.database_path.clone();
     let configured_mac = device_mac.to_string();
+    let guard = Arc::new(Mutex::new(QingpingIngressGuard::default()));
 
     let mut broker = Broker::new(broker_config);
     let (mut link_tx, mut link_rx) = broker
@@ -121,6 +138,7 @@ pub fn start_qingping_ingress(
                 &configured_mac,
                 database_path,
                 qingping,
+                guard,
                 reading_hook,
             );
         })
@@ -147,6 +165,7 @@ fn ingest_loop(
     configured_mac: &str,
     database_path: PathBuf,
     qingping: QingpingState,
+    guard: Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<SensorIngressHook>,
 ) {
     loop {
@@ -160,6 +179,7 @@ fn ingest_loop(
                     configured_mac,
                     &database_path,
                     &qingping,
+                    &guard,
                     reading_hook.as_ref(),
                 );
             }
@@ -177,10 +197,19 @@ fn handle_qingping_publish(
     configured_mac: &str,
     database_path: &Path,
     qingping: &QingpingState,
+    guard: &Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<&SensorIngressHook>,
 ) {
     match parse_qingping_payload(payload, configured_mac) {
         Ok(Some(reading)) => {
+            if let Err(error) = guard
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .accept(&reading)
+            {
+                tracing::warn!("rejected Qingping MQTT reading: {error}");
+                return;
+            }
             if let Err(error) = db::insert_sensor_reading(database_path, &reading) {
                 tracing::warn!("failed to store Qingping reading: {error:#}");
             }
@@ -198,8 +227,103 @@ fn handle_qingping_publish(
     }
 }
 
-pub(crate) fn build_broker_config(host: &str, port: u16) -> Result<BrokerConfig> {
+#[derive(Default)]
+struct QingpingIngressGuard {
+    last_accepted_at: Option<Instant>,
+    last_reading: Option<QingpingReading>,
+}
+
+impl QingpingIngressGuard {
+    fn accept(&mut self, reading: &QingpingReading) -> Result<()> {
+        let now = Instant::now();
+        if let Some(last_accepted_at) = self.last_accepted_at {
+            let elapsed = now.saturating_duration_since(last_accepted_at);
+            if elapsed < QINGPING_MIN_ACCEPT_INTERVAL {
+                anyhow::bail!(
+                    "Qingping payload rate limit exceeded: accepted interval {:?} < {:?}",
+                    elapsed,
+                    QINGPING_MIN_ACCEPT_INTERVAL
+                );
+            }
+        }
+        if let Some(previous) = &self.last_reading {
+            validate_delta_i64(
+                "co2",
+                previous.co2_ppm,
+                reading.co2_ppm,
+                QINGPING_MAX_CO2_DELTA,
+            )?;
+            validate_delta_i64("tvoc", previous.tvoc, reading.tvoc, QINGPING_MAX_TVOC_DELTA)?;
+            validate_delta_i64("pm25", previous.pm25, reading.pm25, QINGPING_MAX_PM_DELTA)?;
+            validate_delta_i64("pm10", previous.pm10, reading.pm10, QINGPING_MAX_PM_DELTA)?;
+            validate_delta_f64(
+                "temperature",
+                previous.temp_c,
+                reading.temp_c,
+                QINGPING_MAX_TEMP_DELTA,
+            )?;
+            validate_delta_f64(
+                "humidity",
+                previous.humidity,
+                reading.humidity,
+                QINGPING_MAX_HUMIDITY_DELTA,
+            )?;
+        }
+        self.last_accepted_at = Some(now);
+        self.last_reading = Some(reading.clone());
+        Ok(())
+    }
+}
+
+fn validate_delta_i64(
+    field: &str,
+    previous: Option<i64>,
+    current: Option<i64>,
+    max_delta: i64,
+) -> Result<()> {
+    if let (Some(previous), Some(current)) = (previous, current) {
+        let delta = previous.abs_diff(current);
+        if delta > max_delta as u64 {
+            anyhow::bail!("Qingping {field} delta {delta} exceeds accepted maximum {max_delta}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_delta_f64(
+    field: &str,
+    previous: Option<f64>,
+    current: Option<f64>,
+    max_delta: f64,
+) -> Result<()> {
+    if let (Some(previous), Some(current)) = (previous, current) {
+        let delta = (previous - current).abs();
+        if delta > max_delta {
+            anyhow::bail!(
+                "Qingping {field} delta {delta:.1} exceeds accepted maximum {max_delta:.1}"
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn build_broker_config(
+    host: &str,
+    port: u16,
+    qingping: &QingpingConfig,
+) -> Result<BrokerConfig> {
     let listen = resolve_listen_address(host, port)?;
+    let up_topic = qingping
+        .device_mac
+        .as_deref()
+        .map(qingping_up_topic)
+        .unwrap_or_else(|| "qingping/unconfigured/up".to_string());
+    let down_topic = qingping
+        .device_mac
+        .as_deref()
+        .map(qingping_down_topic)
+        .unwrap_or_else(|| "qingping/unconfigured/down".to_string());
+    let auth = qingping_mqtt_auth(qingping)?;
     let mut v4 = HashMap::new();
     v4.insert(
         "qingping".to_string(),
@@ -211,10 +335,10 @@ pub(crate) fn build_broker_config(host: &str, port: u16) -> Result<BrokerConfig>
             connections: ConnectionSettings {
                 connection_timeout_ms: 60_000,
                 max_payload_size: MAX_QINGPING_PAYLOAD_BYTES,
-                max_inflight_count: 100,
-                auth: None,
+                max_inflight_count: 4,
+                auth,
                 external_auth: None,
-                dynamic_filters: true,
+                dynamic_filters: false,
             },
         },
     );
@@ -222,12 +346,12 @@ pub(crate) fn build_broker_config(host: &str, port: u16) -> Result<BrokerConfig>
     Ok(BrokerConfig {
         id: 0,
         router: RouterConfig {
-            max_connections: 128,
+            max_connections: 8,
             max_outgoing_packet_count: 200,
             max_segment_size: 1024 * 1024,
             max_segment_count: 10,
             custom_segment: None,
-            initialized_filters: None,
+            initialized_filters: Some(vec![up_topic, down_topic]),
             shared_subscriptions_strategy: rumqttd::Strategy::RoundRobin,
         },
         v4: Some(v4),
@@ -239,6 +363,29 @@ pub(crate) fn build_broker_config(host: &str, port: u16) -> Result<BrokerConfig>
         prometheus: None,
         metrics: None,
     })
+}
+
+fn qingping_mqtt_auth(qingping: &QingpingConfig) -> Result<Option<HashMap<String, String>>> {
+    match qingping_mqtt_credentials(qingping)? {
+        Some((username, password)) => Ok(Some(HashMap::from([(username, password)]))),
+        None => Ok(None),
+    }
+}
+
+fn qingping_mqtt_credentials(qingping: &QingpingConfig) -> Result<Option<(String, String)>> {
+    match (
+        qingping.mqtt_username.as_deref().map(str::trim),
+        qingping.mqtt_password.as_deref().map(str::trim),
+    ) {
+        (Some(username), Some(password)) if !username.is_empty() && !password.is_empty() => {
+            Ok(Some((username.to_string(), password.to_string())))
+        }
+        (None, None) => Ok(None),
+        (Some(""), None) | (None, Some("")) | (Some(""), Some("")) => Ok(None),
+        _ => anyhow::bail!(
+            "Qingping MQTT auth requires both qingping.mqtt_username and qingping.mqtt_password"
+        ),
+    }
 }
 
 fn resolve_listen_address(host: &str, port: u16) -> Result<SocketAddr> {
@@ -259,7 +406,11 @@ mod tests {
 
     #[test]
     fn broker_config_uses_configured_listener() {
-        let config = build_broker_config("127.0.0.1", 2883).expect("broker config");
+        let qingping = QingpingConfig {
+            device_mac: Some("aa:bb:cc:dd:ee:ff".to_string()),
+            ..QingpingConfig::default()
+        };
+        let config = build_broker_config("127.0.0.1", 2883, &qingping).expect("broker config");
         let v4 = config.v4.expect("v4 config");
         let server = v4.get("qingping").expect("qingping server");
 
@@ -268,7 +419,15 @@ mod tests {
             server.connections.max_payload_size,
             MAX_QINGPING_PAYLOAD_BYTES
         );
-        assert_eq!(config.router.max_connections, 128);
+        assert_eq!(config.router.max_connections, 8);
+        assert_eq!(
+            config.router.initialized_filters.expect("filters"),
+            vec![
+                "qingping/AABBCCDDEEFF/up".to_string(),
+                "qingping/AABBCCDDEEFF/down".to_string()
+            ]
+        );
+        assert!(!server.connections.dynamic_filters);
     }
 
     #[test]
@@ -299,10 +458,75 @@ mod tests {
             "aa:bb:cc:dd:ee:ff",
             &database_path,
             &qingping,
+            &Arc::new(Mutex::new(QingpingIngressGuard::default())),
             Some(&hook),
         );
 
         assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
         assert_eq!(qingping.latest().expect("reading").co2_ppm, Some(2100));
+    }
+
+    #[test]
+    fn mqtt_config_requires_auth_pair_when_partially_configured() {
+        let qingping = QingpingConfig {
+            mqtt_username: Some("device".to_string()),
+            ..QingpingConfig::default()
+        };
+
+        let error = build_broker_config("127.0.0.1", 2883, &qingping)
+            .expect_err("partial auth should fail");
+
+        assert!(error.to_string().contains("requires both"));
+    }
+
+    #[test]
+    fn mqtt_command_publisher_uses_configured_credentials() {
+        let qingping = QingpingConfig {
+            mqtt_username: Some(" device ".to_string()),
+            mqtt_password: Some(" secret ".to_string()),
+            ..QingpingConfig::default()
+        };
+
+        assert_eq!(
+            qingping_mqtt_credentials(&qingping).expect("credentials"),
+            Some(("device".to_string(), "secret".to_string()))
+        );
+    }
+
+    #[test]
+    fn ingress_guard_rejects_bursts_and_large_deltas() {
+        let mut guard = QingpingIngressGuard::default();
+        let first = QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.0),
+            humidity: Some(40.0),
+            co2_ppm: Some(700),
+            pm25: Some(1),
+            pm10: Some(1),
+            tvoc: Some(10),
+            noise_db: None,
+            timestamp: "2026-06-07T00:00:00".to_string(),
+            raw_data: "{}".to_string(),
+        };
+        guard.accept(&first).expect("first reading accepted");
+        assert!(
+            guard
+                .accept(&first)
+                .expect_err("burst rejected")
+                .to_string()
+                .contains("rate limit")
+        );
+
+        guard.last_accepted_at = Some(Instant::now() - Duration::from_secs(60));
+        let mut bad_delta = first.clone();
+        bad_delta.co2_ppm = Some(6_000);
+        assert!(
+            guard
+                .accept(&bad_delta)
+                .expect_err("large delta rejected")
+                .to_string()
+                .contains("co2 delta")
+        );
     }
 }

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -253,6 +253,8 @@ mod tests {
                 ..QingpingConfig::default()
             },
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig {

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -31,7 +31,7 @@ use tokio_tungstenite::{
 };
 
 use crate::{
-    artifacts::{is_valid_artifact_hash, is_valid_sha256_digest},
+    artifacts::{is_valid_artifact_hash, is_valid_sha256_digest, normalize_cert_digest},
     auth::AuthManager,
     config::{AppConfig, OrchestratorConfig},
     db, edge, erv, http, hvac,
@@ -118,6 +118,7 @@ pub struct SecurityValidationOptions {
     pub tunnel_launchd_plist: Option<PathBuf>,
     pub tunnel_user: Option<String>,
     pub edge_user: Option<String>,
+    pub controller_user: Option<String>,
     pub secret_files: Vec<PathBuf>,
     pub protected_paths: Vec<PathBuf>,
     pub tunnel_readable_paths: Vec<PathBuf>,
@@ -307,6 +308,7 @@ pub async fn run_security_validation(
 
     validate_http_startup_config(config, public_url, &mut report)?;
     validate_security_file_permissions(config, &options, &mut report)?;
+    validate_security_runtime_hardening(config, &mut report)?;
     validate_security_edge_config(public_url, &options, &mut report)?;
     validate_security_cloudflare(config, public_url, &options, &mut report).await?;
     validate_security_launchd(public_url, &options, &mut report)?;
@@ -406,6 +408,57 @@ fn validate_security_file_permissions(
                 strict_paths.len()
             ),
         );
+    }
+
+    Ok(())
+}
+
+fn validate_security_runtime_hardening(
+    config: &AppConfig,
+    report: &mut ShadowValidationReport,
+) -> Result<()> {
+    if !config.cloudflare_access.device_policy_sync_configured() {
+        bail!(
+            "security validation requires Cloudflare device policy sync: set OFFICE_AUTOMATE_CLOUDFLARE_ACCOUNT_ID, OFFICE_AUTOMATE_CLOUDFLARE_DEVICE_POLICY_ID, and OFFICE_AUTOMATE_CLOUDFLARE_API_TOKEN"
+        );
+    }
+    report.push_pass(
+        "cloudflare-device-policy-sync",
+        "Android device enrollment is tied to a Cloudflare Access Common Name policy allowlist",
+    );
+
+    let signer = config
+        .artifacts
+        .office_climate_signing_cert_sha256
+        .as_deref()
+        .context(
+            "security validation requires OFFICE_AUTOMATE_ANDROID_SIGNING_CERT_SHA256 for upload-side APK verification",
+        )?;
+    normalize_cert_digest(signer)?;
+    report.push_pass(
+        "artifact-upload-signature-policy",
+        "office-climate APK uploads require expected signing certificate SHA-256 verification",
+    );
+
+    match (
+        config.qingping.mqtt_username.as_deref().map(str::trim),
+        config.qingping.mqtt_password.as_deref().map(str::trim),
+    ) {
+        (Some(username), Some(password)) if !username.is_empty() && !password.is_empty() => {
+            report.push_pass(
+                "qingping-mqtt-auth",
+                "Qingping MQTT broker requires configured username/password credentials",
+            );
+        }
+        _ if config.qingping.device_mac.is_some() => {
+            bail!(
+                "security validation requires Qingping MQTT credentials when qingping.device_mac is configured"
+            );
+        }
+        _ => report.push_skip(
+            "qingping-mqtt-auth",
+            "Qingping device is not configured; MQTT auth was not required",
+        ),
     }
 
     Ok(())
@@ -539,14 +592,23 @@ fn validate_security_launchd(
     options: &SecurityValidationOptions,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
-    if let Some(path) = options.server_launchd_plist.as_deref() {
-        validate_launchd_plist(path, "com.office-automate.server", None, &["serve"])?;
-        report.push_pass(
-            "server-launchd-plist",
-            format!("validated controller launchd plist {}", path.display()),
-        );
-    } else {
-        report.push_skip("server-launchd-plist", "no --server-launchd-plist supplied");
+    match options.server_launchd_plist.as_deref() {
+        Some(path) => {
+            validate_launchd_plist(
+                path,
+                "com.office-automate.server",
+                options.controller_user.as_deref(),
+                &["serve"],
+            )?;
+            report.push_pass(
+                "server-launchd-plist",
+                format!("validated controller launchd plist {}", path.display()),
+            );
+        }
+        None if public_url.is_some() => {
+            bail!("security validation for a public URL requires --server-launchd-plist");
+        }
+        None => report.push_skip("server-launchd-plist", "no --server-launchd-plist supplied"),
     }
 
     match options.edge_launchd_plist.as_deref() {
@@ -612,6 +674,10 @@ fn validate_security_role_boundaries(
         .edge_user
         .as_deref()
         .context("security validation for a public URL requires --edge-user")?;
+    let controller_user = options
+        .controller_user
+        .as_deref()
+        .context("security validation for a public URL requires --controller-user")?;
     if options.tunnel_origin_probes.is_empty() {
         bail!("security validation for {public_url} requires at least one --tunnel-origin-probe");
     }
@@ -700,6 +766,12 @@ fn validate_security_role_boundaries(
         edge_user,
         &options.denied_lan_probes,
         "edge-user-lan-denial",
+        report,
+    )?;
+    validate_control_connectivity(
+        Some(controller_user),
+        &options.denied_lan_probes,
+        "controller-device-egress-connectivity",
         report,
     )?;
 
@@ -1970,6 +2042,8 @@ struct CloudflareAccessPolicyEvidence {
     name: Option<String>,
     action: Option<String>,
     includes_public: Option<bool>,
+    includes_valid_certificate: Option<bool>,
+    includes_common_name: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2076,6 +2150,7 @@ fn validate_cloudflare_drift_evidence(
         bail!("Cloudflare evidence Access application must include at least one policy");
     }
     let mut has_forwarding_policy = false;
+    let mut has_device_common_name_policy = false;
     for policy in policies {
         let name = required_evidence_str(&policy.name, "access_application.policies[].name")?;
         let action = required_evidence_str(&policy.action, "access_application.policies[].action")?;
@@ -2091,9 +2166,24 @@ fn validate_cloudflare_drift_evidence(
         if matches!(normalized_action.as_str(), "allow" | "service_auth") {
             has_forwarding_policy = true;
         }
+        if normalized_action == "service_auth" {
+            if policy.includes_valid_certificate == Some(true) {
+                bail!(
+                    "Cloudflare evidence policy {name:?} includes a broad Valid Certificate selector; use per-device Common Name selectors"
+                );
+            }
+            if policy.includes_common_name == Some(true) {
+                has_device_common_name_policy = true;
+            }
+        }
     }
     if !has_forwarding_policy {
         bail!("Cloudflare evidence must include at least one Allow or Service Auth policy");
+    }
+    if !has_device_common_name_policy {
+        bail!(
+            "Cloudflare evidence must include a Service Auth policy using per-device Common Name selectors"
+        );
     }
 
     let dns = evidence
@@ -3317,6 +3407,8 @@ mod tests {
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
@@ -3892,6 +3984,10 @@ mod tests {
         let mut public_policy = valid_cloudflare_drift_evidence();
         public_policy["access_application"]["policies"][0]["includes_public"] = json!(true);
 
+        let mut broad_valid_certificate = valid_cloudflare_drift_evidence();
+        broad_valid_certificate["access_application"]["policies"][0]["includes_valid_certificate"] =
+            json!(true);
+
         let mut wildcard_dns = valid_cloudflare_drift_evidence();
         wildcard_dns["dns"]["wildcard_records"] = json!(["*.example.test"]);
 
@@ -3904,6 +4000,7 @@ mod tests {
         let cases = [
             (bypass_policy, "Bypass"),
             (public_policy, "includes_public=false"),
+            (broad_valid_certificate, "broad Valid Certificate"),
             (wildcard_dns, "wildcard DNS"),
             (private_route, "private network routes"),
             (missing_audit, "unauthenticated blocks"),
@@ -3984,7 +4081,9 @@ mod tests {
                     {
                         "name": "allow-device-mtls",
                         "action": "Service Auth",
-                        "includes_public": false
+                        "includes_public": false,
+                        "includes_common_name": true,
+                        "includes_valid_certificate": false
                     },
                     {
                         "name": "allow-rajesh",

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -926,6 +926,8 @@ mod tests {
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),
+            artifacts: crate::config::ArtifactConfig::default(),
+            cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig {
                 device_type: "tuya".to_string(),
                 ip: "192.0.2.10".to_string(),

--- a/scripts/launchd/primary-host/com.office-automate.server.plist.template
+++ b/scripts/launchd/primary-host/com.office-automate.server.plist.template
@@ -5,6 +5,12 @@
   <key>Label</key>
   <string>com.office-automate.server</string>
 
+  <key>UserName</key>
+  <string>__OFFICE_AUTOMATE_CONTROLLER_USER__</string>
+
+  <key>GroupName</key>
+  <string>__OFFICE_AUTOMATE_CONTROLLER_GROUP__</string>
+
   <key>ProgramArguments</key>
   <array>
     <string>__OFFICE_AUTOMATE_SERVER_BIN__</string>


### PR DESCRIPTION
## Summary
- Sync Android device enrollment/revocation to a Cloudflare Access Service Auth Common Name allowlist so revoked devices are removed at the edge and broad Valid Certificate policies are rejected by validation evidence.
- Harden Qingping MQTT ingestion with optional broker credentials, fixed filters, reduced broker limits, burst/delta rejection, and production validation that rejects anonymous device MQTT.
- Harden Android artifact publishing with upload-side APK signing certificate verification, revocation/rollback CLI commands, durable revoked-hash blocking, and Android client handling for revoked update metadata.
- Add controller launchd user validation and production security checks for controller boundary, artifact signing policy, Cloudflare device-policy sync, and per-device mTLS evidence.

## Spec Reference
- docs/working/100_security_threat_model.md

## Notes
- #108 is closed by making the current controller deployment boundary explicit and validated: the server launchd plist now carries a dedicated controller user, and production security validation requires `--controller-user` plus launchd and egress probes. This is the enforceable boundary step for the current all-in-one controller; it does not split every device ingester into separate binaries.
- I checked Cloudflare policy shape against Cloudflare's Access policy docs: Service Auth is represented as `decision: non_identity`, Common Name rules use `common_name.common_name`, and application policy APIs live under `/access/apps/{app_id}/policies/{policy_id}`.

## Test Plan
- [x] `cargo fmt --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `git diff --check`
- [ ] `cargo clippy --manifest-path rust/office-automate-server/Cargo.toml --all-targets -- -D warnings` is not currently a clean repo gate; it fails on pre-existing repo-wide style lints outside this branch. Branch-introduced clippy findings were fixed.

Fixes #105
Fixes #108
Fixes #109
Fixes #110