### PR TITLE
Require OAuth after Cloudflare mTLS

### DIFF
--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AuthModels.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AuthModels.kt
@@ -1,0 +1,27 @@
+package com.rajesh.officeclimate.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeviceFlowStartResponse(
+    @SerialName("device_code") val deviceCode: String,
+    @SerialName("user_code") val userCode: String,
+    @SerialName("verification_url") val verificationUrl: String,
+    @SerialName("expires_in") val expiresIn: Int,
+    val interval: Int = 5,
+)
+
+@Serializable
+data class DeviceFlowPollRequest(
+    @SerialName("device_code") val deviceCode: String,
+)
+
+@Serializable
+data class DeviceFlowPollResponse(
+    val status: String,
+    val message: String? = null,
+    val email: String? = null,
+    @SerialName("access_token") val accessToken: String? = null,
+    @SerialName("expires_in") val expiresIn: Int? = null,
+)

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -3,6 +3,9 @@ package com.rajesh.officeclimate.data.remote
 import com.rajesh.officeclimate.data.model.ApiStatus
 import com.rajesh.officeclimate.data.model.AppArtifactMetadata
 import com.rajesh.officeclimate.data.model.DailyStatsResponse
+import com.rajesh.officeclimate.data.model.DeviceFlowPollRequest
+import com.rajesh.officeclimate.data.model.DeviceFlowPollResponse
+import com.rajesh.officeclimate.data.model.DeviceFlowStartResponse
 import com.rajesh.officeclimate.data.model.LeverageResponse
 import com.rajesh.officeclimate.data.model.OHLCResponse
 import com.rajesh.officeclimate.data.model.OpeningsResponse
@@ -24,6 +27,12 @@ interface ApiService {
 
     @GET("apps/office-climate/meta.json")
     suspend fun getAppArtifactMetadata(): AppArtifactMetadata
+
+    @POST("auth/device/start")
+    suspend fun startDeviceFlow(): DeviceFlowStartResponse
+
+    @POST("auth/device/poll")
+    suspend fun pollDeviceFlow(@Body body: DeviceFlowPollRequest): DeviceFlowPollResponse
 
     @POST("erv")
     suspend fun setErvSpeed(@Body body: Map<String, String>): JsonObject

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -24,6 +24,7 @@ class HttpClientFactory(
 ) {
     suspend fun create(
         includeLogging: Boolean = false,
+        includeBearerAuth: Boolean = true,
         connectTimeoutSeconds: Long = 10,
         readTimeoutSeconds: Long = 30,
     ): OkHttpClient {
@@ -39,6 +40,16 @@ class HttpClientFactory(
                     level = HttpLoggingInterceptor.Level.BASIC
                 }
             )
+        }
+
+        val jwtToken = settingsRepository.jwtToken.first().trim()
+        if (includeBearerAuth && jwtToken.isNotBlank()) {
+            builder.addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("Authorization", "Bearer $jwtToken")
+                    .build()
+                chain.proceed(request)
+            }
         }
 
         val alias = settingsRepository.deviceCertificateAlias.first().trim()

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/WebSocketManager.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/WebSocketManager.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit
 class WebSocketManager(
     private val client: OkHttpClient,
     private val json: Json,
+    private val authToken: String,
 ) {
     private var webSocket: WebSocket? = null
     private var reconnectDelay = Defaults.WS_RECONNECT_BASE_MS
@@ -37,7 +38,11 @@ class WebSocketManager(
             .replace("http://", "ws://")
             .trimEnd('/') + "/ws"
 
-        val request = Request.Builder().url(wsUrl).build()
+        val requestBuilder = Request.Builder().url(wsUrl)
+        if (authToken.isNotBlank()) {
+            requestBuilder.header("Authorization", "Bearer $authToken")
+        }
+        val request = requestBuilder.build()
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 Log.d(TAG, "WebSocket connected")

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -87,6 +87,7 @@ class ClimateRepository(
 
     private suspend fun rebuild(url: String) {
         currentUrl = url
+        val authToken = settingsRepository.jwtToken.first().trim()
 
         val client = httpClientFactory.create(
             includeLogging = true,
@@ -102,7 +103,7 @@ class ClimateRepository(
             .build()
 
         apiService = retrofit.create(ApiService::class.java)
-        wsManager = WebSocketManager(client, json)
+        wsManager = WebSocketManager(client, json, authToken)
     }
 
     private fun startPolling() {

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -79,7 +79,11 @@ class DeviceEnrollmentRepository(
                 )
                 .build()
 
-            val response = httpClientFactory.create(connectTimeoutSeconds = 10, readTimeoutSeconds = 20)
+            val response = httpClientFactory.create(
+                includeBearerAuth = false,
+                connectTimeoutSeconds = 10,
+                readTimeoutSeconds = 20,
+            )
                 .newCall(request)
                 .execute()
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/OfficeAuthRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/OfficeAuthRepository.kt
@@ -1,0 +1,40 @@
+package com.rajesh.officeclimate.data.repository
+
+import com.rajesh.officeclimate.data.model.DeviceFlowPollRequest
+import com.rajesh.officeclimate.data.model.DeviceFlowPollResponse
+import com.rajesh.officeclimate.data.model.DeviceFlowStartResponse
+import com.rajesh.officeclimate.data.remote.ApiService
+import com.rajesh.officeclimate.data.remote.HttpClientFactory
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+class OfficeAuthRepository(
+    private val settingsRepository: SettingsRepository,
+) {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
+
+    suspend fun startDeviceFlow(): DeviceFlowStartResponse =
+        apiService().startDeviceFlow()
+
+    suspend fun pollDeviceFlow(deviceCode: String): DeviceFlowPollResponse =
+        apiService().pollDeviceFlow(DeviceFlowPollRequest(deviceCode))
+
+    private suspend fun apiService(): ApiService {
+        val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
+        val client = httpClientFactory.create(
+            includeLogging = true,
+            connectTimeoutSeconds = 10,
+            readTimeoutSeconds = 30,
+        )
+        return Retrofit.Builder()
+            .baseUrl("$serverUrl/")
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(ApiService::class.java)
+    }
+}

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -40,8 +40,20 @@ class SettingsRepository(private val context: Context) {
         prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
     }
 
-    val isAuthenticated: Flow<Boolean> = context.dataStore.data.map { prefs ->
+    val jwtToken: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.JWT_TOKEN] ?: ""
+    }
+
+    val userEmail: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.USER_EMAIL] ?: ""
+    }
+
+    val hasDeviceCredential: Flow<Boolean> = context.dataStore.data.map { prefs ->
         hasValidDeviceCredential(prefs)
+    }
+
+    val isAuthenticated: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        hasValidDeviceCredential(prefs) && !prefs[Keys.JWT_TOKEN].isNullOrBlank()
     }
 
     val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->
@@ -94,8 +106,6 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun clearLegacyAuthAndInvalidDeviceCredentialIfNeeded() {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.JWT_TOKEN)
-            prefs.remove(Keys.USER_EMAIL)
             prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
             if (
                 !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
@@ -103,7 +113,16 @@ class SettingsRepository(private val context: Context) {
             ) {
                 prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
                 prefs.remove(Keys.DEVICE_CERTIFICATE_CHAIN_PEM)
+                prefs.remove(Keys.JWT_TOKEN)
+                prefs.remove(Keys.USER_EMAIL)
             }
+        }
+    }
+
+    suspend fun saveAuth(token: String, email: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.JWT_TOKEN] = token.trim()
+            prefs[Keys.USER_EMAIL] = email.trim()
         }
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
@@ -72,8 +72,8 @@ fun SettingsScreen(
 
         Text(
             text = when {
-                state.deviceCertificateAlias.isNotBlank() -> "Device enrolled as ${state.deviceCertificateAlias}"
-                state.isLoggedIn -> "Device enrolled"
+                state.isLoggedIn && state.userEmail.isNotBlank() -> "Signed in as ${state.userEmail}"
+                state.hasDeviceCredential -> "Device enrolled. Google sign-in required."
                 else -> "Enroll this device"
             },
             style = MaterialTheme.typography.bodyMedium,
@@ -132,7 +132,7 @@ fun SettingsScreen(
 
         Button(
             onClick = viewModel::enrollDevice,
-            enabled = !state.enrolling && state.pairingUrl.isNotBlank() && state.pairingCode.isNotBlank(),
+            enabled = !state.enrolling && !state.signingIn && state.pairingUrl.isNotBlank() && state.pairingCode.isNotBlank(),
             modifier = Modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(containerColor = Emerald),
         ) {
@@ -149,7 +149,37 @@ fun SettingsScreen(
 
         Spacer(Modifier.height(12.dp))
 
+        if (state.hasDeviceCredential && !state.isLoggedIn) {
+            Button(
+                onClick = viewModel::signInWithGoogle,
+                enabled = !state.enrolling && !state.signingIn,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = Emerald),
+            ) {
+                if (state.signingIn) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.background,
+                    )
+                } else {
+                    Text("Sign in with Google", color = MaterialTheme.colorScheme.background)
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+        }
+
         state.enrollmentStatus?.let { message ->
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = Emerald,
+            )
+        }
+
+        state.signInStatus?.let { message ->
+            Spacer(Modifier.height(12.dp))
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
@@ -1,11 +1,16 @@
 package com.rajesh.officeclimate.ui.settings
 
 import android.app.Application
+import android.content.Intent
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.rajesh.officeclimate.data.model.DeviceFlowStartResponse
 import com.rajesh.officeclimate.data.repository.DeviceEnrollmentRepository
+import com.rajesh.officeclimate.data.repository.OfficeAuthRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
 import com.rajesh.officeclimate.util.Defaults
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -14,17 +19,22 @@ import kotlinx.coroutines.launch
 data class SettingsUiState(
     val serverUrl: String = Defaults.SERVER_URL,
     val isLoggedIn: Boolean = false,
+    val hasDeviceCredential: Boolean = false,
+    val userEmail: String = "",
     val deviceCertificateAlias: String = "",
     val pairingUrl: String = Defaults.DEVICE_PAIRING_URL,
     val pairingCode: String = "",
     val enrolling: Boolean = false,
+    val signingIn: Boolean = false,
     val error: String? = null,
     val enrollmentStatus: String? = null,
+    val signInStatus: String? = null,
 )
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepo = SettingsRepository(application)
     private val deviceEnrollmentRepository = DeviceEnrollmentRepository(settingsRepo)
+    private val officeAuthRepository = OfficeAuthRepository(settingsRepo)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -32,9 +42,13 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     init {
         viewModelScope.launch {
             settingsRepo.clearLegacyAuthAndInvalidDeviceCredentialIfNeeded()
+            val hasDeviceCredential = settingsRepo.hasDeviceCredential.first()
+            val jwtToken = settingsRepo.jwtToken.first()
             _uiState.value = _uiState.value.copy(
                 serverUrl = settingsRepo.serverUrl.first(),
-                isLoggedIn = settingsRepo.isAuthenticated.first(),
+                hasDeviceCredential = hasDeviceCredential,
+                isLoggedIn = hasDeviceCredential && jwtToken.isNotBlank(),
+                userEmail = settingsRepo.userEmail.first(),
                 deviceCertificateAlias = settingsRepo.deviceCertificateAlias.first(),
                 pairingUrl = Defaults.DEVICE_PAIRING_URL,
             )
@@ -83,7 +97,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 _uiState.value = _uiState.value.copy(
                     enrolling = false,
                     deviceCertificateAlias = result.alias,
-                    isLoggedIn = true,
+                    hasDeviceCredential = true,
+                    isLoggedIn = false,
                     enrollmentStatus = "Device enrolled as ${result.deviceName}.",
                     error = null,
                 )
@@ -96,4 +111,80 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
+    fun signInWithGoogle() {
+        val state = _uiState.value
+        if (!state.hasDeviceCredential) {
+            _uiState.value = state.copy(error = "Enroll this device before signing in.")
+            return
+        }
+
+        _uiState.value = state.copy(signingIn = true, error = null, signInStatus = null)
+        viewModelScope.launch {
+            try {
+                settingsRepo.saveServerUrl(_uiState.value.serverUrl)
+                val flow = officeAuthRepository.startDeviceFlow()
+                _uiState.value = _uiState.value.copy(
+                    signInStatus = "Complete Google sign-in with code ${flow.userCode}.",
+                )
+                openVerificationUrl(flow)
+                pollDeviceFlow(flow)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    signingIn = false,
+                    error = "Sign-in failed: ${e.message}",
+                )
+            }
+        }
+    }
+
+    private fun openVerificationUrl(flow: DeviceFlowStartResponse) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(flow.verificationUrl)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        getApplication<Application>().startActivity(intent)
+    }
+
+    private suspend fun pollDeviceFlow(flow: DeviceFlowStartResponse) {
+        val expiresAt = System.currentTimeMillis() + flow.expiresIn * 1000L
+        var intervalMillis = flow.interval.coerceAtLeast(1) * 1000L
+
+        while (System.currentTimeMillis() < expiresAt) {
+            delay(intervalMillis)
+            val response = officeAuthRepository.pollDeviceFlow(flow.deviceCode)
+            when (response.status) {
+                "success" -> {
+                    val token = response.accessToken
+                        ?: throw IllegalStateException("OAuth response did not include a token")
+                    val email = response.email
+                        ?: throw IllegalStateException("OAuth response did not include an email")
+                    settingsRepo.saveAuth(token, email)
+                    _uiState.value = _uiState.value.copy(
+                        signingIn = false,
+                        isLoggedIn = true,
+                        userEmail = email,
+                        signInStatus = "Signed in as $email.",
+                        error = null,
+                    )
+                    return
+                }
+                "pending" -> {
+                    _uiState.value = _uiState.value.copy(
+                        signInStatus = "Waiting for Google sign-in code ${flow.userCode}.",
+                    )
+                }
+                "slow_down" -> {
+                    intervalMillis += 5_000L
+                    _uiState.value = _uiState.value.copy(
+                        signInStatus = "Google asked us to poll more slowly.",
+                    )
+                }
+                "expired" -> throw IllegalStateException("Google sign-in code expired")
+                "forbidden" -> throw IllegalStateException(response.message ?: "Email not allowed")
+                "invalid" -> throw IllegalStateException(response.message ?: "Unknown device code")
+                else -> throw IllegalStateException(response.message ?: "Google sign-in failed")
+            }
+        }
+
+        throw IllegalStateException("Google sign-in code expired")
+    }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -641,10 +641,7 @@ async fn auth_middleware(
     }
 
     match cloudflare_access_service_auth(&state, &headers, remote_addr).await {
-        CloudflareAccessServiceAuth::Authenticated(user) => {
-            request.extensions_mut().insert(user);
-            return next.run(request).await;
-        }
+        CloudflareAccessServiceAuth::DeviceAllowed => {}
         CloudflareAccessServiceAuth::Rejected => {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -778,14 +775,14 @@ fn route_authorization_class(method: &Method, path: &str) -> RouteAuthorizationC
 }
 
 fn should_skip_auth(route_class: RouteAuthorizationClass, auth_mode: HttpAuthMode) -> bool {
-    matches!(
-        route_class,
-        RouteAuthorizationClass::Preflight | RouteAuthorizationClass::PublicArtifact
-    ) || (matches!(auth_mode, HttpAuthMode::OAuth)
-        && matches!(
-            route_class,
-            RouteAuthorizationClass::MobileBootstrap | RouteAuthorizationClass::PublicStatic
-        ))
+    matches!(route_class, RouteAuthorizationClass::Preflight)
+        || (matches!(auth_mode, HttpAuthMode::Open)
+            && matches!(route_class, RouteAuthorizationClass::PublicArtifact))
+        || (matches!(auth_mode, HttpAuthMode::OAuth)
+            && matches!(
+                route_class,
+                RouteAuthorizationClass::MobileBootstrap | RouteAuthorizationClass::PublicStatic
+            ))
 }
 
 fn requires_csrf(method: &Method) -> bool {
@@ -845,7 +842,7 @@ fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 enum CloudflareAccessServiceAuth {
-    Authenticated(AuthenticatedUser),
+    DeviceAllowed,
     Rejected,
     AbsentOrUserAccess,
 }
@@ -878,7 +875,7 @@ async fn cloudflare_access_service_auth(
     else {
         return CloudflareAccessServiceAuth::AbsentOrUserAccess;
     };
-    let device = match db::find_active_device_registration_by_common_name(
+    let _device = match db::find_active_device_registration_by_common_name(
         &state.config.runtime.database_path,
         &identity,
     ) {
@@ -889,9 +886,7 @@ async fn cloudflare_access_service_auth(
             return CloudflareAccessServiceAuth::Rejected;
         }
     };
-    CloudflareAccessServiceAuth::Authenticated(AuthenticatedUser {
-        email: format!("cloudflare_mtls:{}", device.device_id),
-    })
+    CloudflareAccessServiceAuth::DeviceAllowed
 }
 
 async fn status(State(state): State<AppState>) -> Json<Status> {
@@ -3538,6 +3533,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn oauth_mode_requires_auth_for_artifact_routes() {
+        assert!(should_skip_auth(
+            RouteAuthorizationClass::PublicArtifact,
+            HttpAuthMode::Open
+        ));
+        assert!(!should_skip_auth(
+            RouteAuthorizationClass::PublicArtifact,
+            HttpAuthMode::OAuth
+        ));
+        assert!(!should_skip_auth(
+            RouteAuthorizationClass::PublicArtifact,
+            HttpAuthMode::Basic
+        ));
+    }
+
     #[tokio::test]
     async fn controller_ipc_token_allows_local_edge_calls() {
         let mut config = oauth_config();
@@ -6092,6 +6103,7 @@ mod tests {
             .oneshot(
                 HttpRequest::builder()
                     .uri("/apps/office-climate/meta.json")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .expect("request"),
             )
@@ -6114,6 +6126,7 @@ mod tests {
             .oneshot(
                 HttpRequest::builder()
                     .uri(format!("/apps/office-climate/{artifact_hash}.apk"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .expect("request"),
             )


### PR DESCRIPTION
## Summary
- Treat Cloudflare mTLS as the public transport/device gate, not as origin user authentication.
- Require Office OAuth bearer/session auth for protected API, websocket, and app artifact routes after Cloudflare Access admits the request.
- Restore Android OAuth device-flow sign-in and attach the Office JWT to HTTPS and websocket requests.

## Spec Reference
- docs/working/100_security_threat_model.md
- Follow-up from Cloudflare device mTLS cutover: app and browser surfaces should be gated by origin OAuth after Cloudflare.

## Test Plan
- [x] `cargo fmt --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `git diff --check`
