### PR TITLE
Fix Android OAuth callback sign-in

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,10 +16,21 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.OfficeClimate">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="officeclimate"
+                    android:host="auth" />
             </intent-filter>
         </activity>
         <provider

--- a/android/app/src/main/java/com/rajesh/officeclimate/MainActivity.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/MainActivity.kt
@@ -1,20 +1,46 @@
 package com.rajesh.officeclimate
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.lifecycle.lifecycleScope
+import com.rajesh.officeclimate.data.repository.SettingsRepository
 import com.rajesh.officeclimate.ui.navigation.AppNavigation
 import com.rajesh.officeclimate.ui.theme.OfficeClimateTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+    private val authCallbackCount = mutableIntStateOf(0)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        handleAuthIntent(intent)
         enableEdgeToEdge()
         setContent {
             OfficeClimateTheme {
-                AppNavigation()
+                AppNavigation(authCallbackCount.intValue)
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleAuthIntent(intent)
+    }
+
+    private fun handleAuthIntent(intent: Intent?) {
+        val uri = intent?.data ?: return
+        if (uri.scheme != "officeclimate" || uri.host != "auth") return
+        val token = uri.getQueryParameter("token")?.trim().orEmpty()
+        val email = uri.getQueryParameter("email")?.trim().orEmpty()
+        if (token.isBlank() || email.isBlank()) return
+        lifecycleScope.launch {
+            SettingsRepository(applicationContext).saveAuth(token, email)
+            authCallbackCount.intValue += 1
         }
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/model/AuthModels.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/model/AuthModels.kt
@@ -4,6 +4,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class BrowserLoginStartResponse(
+    @SerialName("authorization_url") val authorizationUrl: String,
+    val state: String,
+)
+
+@Serializable
 data class DeviceFlowStartResponse(
     @SerialName("device_code") val deviceCode: String,
     @SerialName("user_code") val userCode: String,

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -2,6 +2,7 @@ package com.rajesh.officeclimate.data.remote
 
 import com.rajesh.officeclimate.data.model.ApiStatus
 import com.rajesh.officeclimate.data.model.AppArtifactMetadata
+import com.rajesh.officeclimate.data.model.BrowserLoginStartResponse
 import com.rajesh.officeclimate.data.model.DailyStatsResponse
 import com.rajesh.officeclimate.data.model.DeviceFlowPollRequest
 import com.rajesh.officeclimate.data.model.DeviceFlowPollResponse
@@ -27,6 +28,9 @@ interface ApiService {
 
     @GET("apps/office-climate/meta.json")
     suspend fun getAppArtifactMetadata(): AppArtifactMetadata
+
+    @GET("auth/login")
+    suspend fun startBrowserLogin(@Query("platform") platform: String = "android"): BrowserLoginStartResponse
 
     @POST("auth/device/start")
     suspend fun startDeviceFlow(): DeviceFlowStartResponse

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -171,8 +171,8 @@ class HttpClientFactory(
         private fun supportsKeyType(keyType: String?): Boolean {
             val requested = keyType?.uppercase().orEmpty()
             return when (certificateKeyType) {
-                "EC", "ECDSA" -> requested == "EC" || requested == "ECDSA"
-                "RSA" -> requested == "RSA" || requested == "RSASSA-PSS"
+                "EC", "ECDSA" -> requested == "EC" || requested == "ECDSA" || requested.startsWith("EC_")
+                "RSA" -> requested == "RSA" || requested == "RSASSA-PSS" || requested.startsWith("RSA_")
                 else -> requested == certificateKeyType
             }
         }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/OfficeAuthRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/OfficeAuthRepository.kt
@@ -1,5 +1,6 @@
 package com.rajesh.officeclimate.data.repository
 
+import com.rajesh.officeclimate.data.model.BrowserLoginStartResponse
 import com.rajesh.officeclimate.data.model.DeviceFlowPollRequest
 import com.rajesh.officeclimate.data.model.DeviceFlowPollResponse
 import com.rajesh.officeclimate.data.model.DeviceFlowStartResponse
@@ -16,6 +17,9 @@ class OfficeAuthRepository(
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
     private val httpClientFactory = HttpClientFactory(settingsRepository)
+
+    suspend fun startBrowserLogin(): BrowserLoginStartResponse =
+        apiService().startBrowserLogin()
 
     suspend fun startDeviceFlow(): DeviceFlowStartResponse =
         apiService().startDeviceFlow()

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Insights
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -61,7 +62,7 @@ private val navItems = listOf(
 )
 
 @Composable
-fun AppNavigation() {
+fun AppNavigation(authCallbackCount: Int = 0) {
     val navController = rememberNavController()
     val context = LocalContext.current
     val settingsRepo = SettingsRepository(context)
@@ -81,6 +82,14 @@ fun AppNavigation() {
         Routes.PRODUCTIVITY,
         Routes.PROJECTS,
     )
+
+    LaunchedEffect(authCallbackCount, isAuthenticated) {
+        if (authCallbackCount > 0 && isAuthenticated == true && currentRoute == Routes.SETTINGS) {
+            navController.navigate(Routes.DASHBOARD) {
+                popUpTo(Routes.SETTINGS) { inclusive = true }
+            }
+        }
+    }
 
     Scaffold(
         containerColor = Background,

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
@@ -5,12 +5,10 @@ import android.content.Intent
 import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.rajesh.officeclimate.data.model.DeviceFlowStartResponse
 import com.rajesh.officeclimate.data.repository.DeviceEnrollmentRepository
 import com.rajesh.officeclimate.data.repository.OfficeAuthRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
 import com.rajesh.officeclimate.util.Defaults
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -122,12 +120,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             try {
                 settingsRepo.saveServerUrl(_uiState.value.serverUrl)
-                val flow = officeAuthRepository.startDeviceFlow()
+                val login = officeAuthRepository.startBrowserLogin()
                 _uiState.value = _uiState.value.copy(
-                    signInStatus = "Complete Google sign-in with code ${flow.userCode}.",
+                    signingIn = false,
+                    signInStatus = "Complete Google sign-in in the browser.",
                 )
-                openVerificationUrl(flow)
-                pollDeviceFlow(flow)
+                openVerificationUrl(login.authorizationUrl)
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     signingIn = false,
@@ -137,54 +135,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    private fun openVerificationUrl(flow: DeviceFlowStartResponse) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(flow.verificationUrl)).apply {
+    private fun openVerificationUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         getApplication<Application>().startActivity(intent)
-    }
-
-    private suspend fun pollDeviceFlow(flow: DeviceFlowStartResponse) {
-        val expiresAt = System.currentTimeMillis() + flow.expiresIn * 1000L
-        var intervalMillis = flow.interval.coerceAtLeast(1) * 1000L
-
-        while (System.currentTimeMillis() < expiresAt) {
-            delay(intervalMillis)
-            val response = officeAuthRepository.pollDeviceFlow(flow.deviceCode)
-            when (response.status) {
-                "success" -> {
-                    val token = response.accessToken
-                        ?: throw IllegalStateException("OAuth response did not include a token")
-                    val email = response.email
-                        ?: throw IllegalStateException("OAuth response did not include an email")
-                    settingsRepo.saveAuth(token, email)
-                    _uiState.value = _uiState.value.copy(
-                        signingIn = false,
-                        isLoggedIn = true,
-                        userEmail = email,
-                        signInStatus = "Signed in as $email.",
-                        error = null,
-                    )
-                    return
-                }
-                "pending" -> {
-                    _uiState.value = _uiState.value.copy(
-                        signInStatus = "Waiting for Google sign-in code ${flow.userCode}.",
-                    )
-                }
-                "slow_down" -> {
-                    intervalMillis += 5_000L
-                    _uiState.value = _uiState.value.copy(
-                        signInStatus = "Google asked us to poll more slowly.",
-                    )
-                }
-                "expired" -> throw IllegalStateException("Google sign-in code expired")
-                "forbidden" -> throw IllegalStateException(response.message ?: "Email not allowed")
-                "invalid" -> throw IllegalStateException(response.message ?: "Unknown device code")
-                else -> throw IllegalStateException(response.message ?: "Google sign-in failed")
-            }
-        }
-
-        throw IllegalStateException("Google sign-in code expired")
     }
 }


### PR DESCRIPTION
## Summary
- Switch Android Google sign-in back to the existing browser OAuth start endpoint (`/auth/login?platform=android`) instead of Google device-code flow, which rejects the current web OAuth client.
- Register and handle the `officeclimate://auth` callback so the app stores the Office JWT returned by the Rust origin.
- Navigate out of settings only for the OAuth callback transition and broaden Android mTLS EC key-type matching for Cloudflare/Conscrypt TLS handshakes.

## Published APK
- Published hotfix artifact: `4c8c75f3`
- SHA-256: `4c8c75f3273d0dbd21186804b323051cee51f3f891c67ecc967f8a88b7cbd62e`
- Supersedes emergency artifact `f557266e`.

## Cloudflare Assumption
- The Access application for `office.rajeshgo.li` must retain both policies: `allow-device-mtls` Service Auth for enrolled app/API clients and `allow-rajesh` human browser access for the Google OAuth browser callback.
- If the app is changed to mTLS-only for all browser paths, this callback flow will not work; that deployment shape would need a Google device-flow client type or native Android OAuth instead.

## Verification
- `./gradlew :app:compileDebugKotlin :app:packageRelease`
- `./scripts/security/release-provenance.sh android/app/build/outputs/apk/release/app-release.apk data/apps/office-climate/4c8c75f3.apk data/apps/office-climate/latest.apk`

Note: `assembleRelease` still has the pre-existing lint dependency verification gap tracked in #137; `packageRelease` produced the signed APK used for publish.