### PR TITLE
Use software EC Android client certs for Cloudflare mTLS

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,8 +41,8 @@ android {
         applicationId = "com.rajesh.officeclimate"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
         buildConfigField("String", "APK_HASH", "\"$officeClimateBuildHash\"")
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -6,12 +6,15 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.ByteArrayInputStream
 import java.net.Socket
+import java.security.KeyFactory
 import java.security.Principal
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedKeyManager
 import javax.net.ssl.TrustManagerFactory
@@ -54,8 +57,9 @@ class HttpClientFactory(
 
         val alias = settingsRepository.deviceCertificateAlias.first().trim()
         val certificateChainPem = settingsRepository.deviceCertificateChainPem.first().trim()
-        if (alias.isNotBlank() && certificateChainPem.isNotBlank()) {
-            runCatching { loadClientCertificate(alias, certificateChainPem) }
+        val privateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8.first().trim()
+        if (alias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
+            runCatching { loadClientCertificate(alias, certificateChainPem, privateKeyPkcs8) }
                 .onSuccess { sslConfig ->
                     sslConfig?.let { (sslSocketFactory, trustManager) ->
                         builder.sslSocketFactory(sslSocketFactory, trustManager)
@@ -72,12 +76,13 @@ class HttpClientFactory(
     private fun loadClientCertificate(
         alias: String,
         certificateChainPem: String,
+        privateKeyPkcs8: String,
     ): Pair<SSLSocketFactory, X509TrustManager>? {
         val certificateChain = decodeCertificates(certificateChainPem)
         if (certificateChain.isEmpty()) {
             return null
         }
-        val privateKey = loadPrivateKey(alias) ?: return null
+        val privateKey = decodePrivateKey(privateKeyPkcs8, certificateChain.first())
 
         val keyManager = SingleAliasKeyManager(
             alias = alias,
@@ -110,14 +115,15 @@ class HttpClientFactory(
             .filterIsInstance<X509Certificate>()
     }
 
-    private fun loadPrivateKey(alias: String): PrivateKey? =
-        KeyStore.getInstance(ANDROID_KEYSTORE)
-            .apply { load(null) }
-            .getKey(alias, null) as? PrivateKey
+    private fun decodePrivateKey(privateKeyPkcs8: String, certificate: X509Certificate): PrivateKey {
+        val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8)
+        val keySpec = PKCS8EncodedKeySpec(keyBytes)
+        val algorithm = certificate.publicKey.algorithm
+        return KeyFactory.getInstance(algorithm).generatePrivate(keySpec)
+    }
 
     private companion object {
         const val TAG = "HttpClientFactory"
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 
     private class SingleAliasKeyManager(
@@ -171,8 +177,8 @@ class HttpClientFactory(
         private fun supportsKeyType(keyType: String?): Boolean {
             val requested = keyType?.uppercase().orEmpty()
             return when (certificateKeyType) {
-                "EC", "ECDSA" -> requested == "EC" || requested == "ECDSA" || requested.startsWith("EC_")
-                "RSA" -> requested == "RSA" || requested == "RSASSA-PSS" || requested.startsWith("RSA_")
+                "EC", "ECDSA" -> requested.startsWith("EC") || requested.startsWith("ECDSA")
+                "RSA" -> requested.startsWith("RSA") || requested.startsWith("RSASSA-PSS")
                 else -> requested == certificateKeyType
             }
         }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -1,7 +1,5 @@
 package com.rajesh.officeclimate.data.repository
 
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -22,8 +20,8 @@ import java.io.StringWriter
 import java.net.URI
 import java.security.KeyPair
 import java.security.KeyPairGenerator
-import java.security.KeyStore
 import java.security.spec.ECGenParameterSpec
+import java.util.Base64
 import java.util.UUID
 
 @Serializable
@@ -64,7 +62,7 @@ class DeviceEnrollmentRepository(
     ): DeviceEnrollmentResult = withContext(Dispatchers.IO) {
         validatePairingUrl(pairingUrl)
         val alias = "office-device-${UUID.randomUUID()}"
-        val keyPair = generateKeyPair(alias)
+        val keyPair = generateKeyPair()
         try {
             val requestBody = DeviceEnrollmentRequest(
                 pairingCode = pairingCode.trim(),
@@ -98,8 +96,8 @@ class DeviceEnrollmentRepository(
 
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
                 settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
+                settingsRepository.saveDevicePrivateKeyPkcs8(encodePrivateKeyPkcs8(keyPair))
                 settingsRepository.saveDeviceCertificateAlias(alias)
-                settingsRepository.clearDevicePrivateKeyPkcs8()
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -109,23 +107,14 @@ class DeviceEnrollmentRepository(
                 )
             }
         } catch (e: Exception) {
-            clearDeviceCredential(alias)
+            clearDeviceCredential()
             throw e
         }
     }
 
-    private fun generateKeyPair(alias: String): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_EC,
-            ANDROID_KEYSTORE,
-        )
-        keyPairGenerator.initialize(
-            KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_SIGN)
-                .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
-                .setDigests(KeyProperties.DIGEST_SHA256)
-                .setUserAuthenticationRequired(false)
-                .build(),
-        )
+    private fun generateKeyPair(): KeyPair {
+        val keyPairGenerator = KeyPairGenerator.getInstance("EC")
+        keyPairGenerator.initialize(ECGenParameterSpec("secp256r1"))
         return keyPairGenerator.generateKeyPair()
     }
 
@@ -149,17 +138,13 @@ class DeviceEnrollmentRepository(
         return writer.toString()
     }
 
-    private suspend fun clearDeviceCredential(alias: String) {
-        deleteDeviceKey(alias)
+    private fun encodePrivateKeyPkcs8(keyPair: KeyPair): String =
+        Base64.getEncoder().encodeToString(keyPair.private.encoded)
+
+    private suspend fun clearDeviceCredential() {
         settingsRepository.clearDeviceCertificateAlias()
         settingsRepository.clearDeviceCertificateChainPem()
         settingsRepository.clearDevicePrivateKeyPkcs8()
-    }
-
-    private fun deleteDeviceKey(alias: String) {
-        runCatching {
-            KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
-        }
     }
 
     private fun validatePairingUrl(pairingUrl: String) {
@@ -178,7 +163,6 @@ class DeviceEnrollmentRepository(
     }
 
     private companion object {
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
         const val LOCAL_PAIRING_HOST = "192.168.5.10"
     }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -23,7 +23,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("device_certificate_alias")
         val DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("device_certificate_chain_pem")
-        val LEGACY_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
+        val DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
         val DISMISSED_APP_NOTIFICATION_IDS = stringSetPreferencesKey("dismissed_app_notification_ids")
     }
@@ -38,6 +38,10 @@ class SettingsRepository(private val context: Context) {
 
     val deviceCertificateChainPem: Flow<String> = context.dataStore.data.map { prefs ->
         prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
+    }
+
+    val devicePrivateKeyPkcs8: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] ?: ""
     }
 
     val jwtToken: Flow<String> = context.dataStore.data.map { prefs ->
@@ -86,6 +90,12 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
+    suspend fun saveDevicePrivateKeyPkcs8(privateKeyPkcs8: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
+        }
+    }
+
     suspend fun clearDeviceCertificateAlias() {
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
@@ -100,13 +110,12 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun clearDevicePrivateKeyPkcs8() {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
+            prefs.remove(Keys.DEVICE_PRIVATE_KEY_PKCS8)
         }
     }
 
     suspend fun clearLegacyAuthAndInvalidDeviceCredentialIfNeeded() {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
             if (
                 !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
                     !hasValidDeviceCredential(prefs)
@@ -155,17 +164,7 @@ class SettingsRepository(private val context: Context) {
     private fun hasValidDeviceCredential(prefs: Preferences): Boolean {
         val alias = prefs[Keys.DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
         val certificateChain = prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
-        return alias.isNotBlank() && certificateChain.isNotBlank() && hasDevicePrivateKey(alias)
-    }
-
-    private fun hasDevicePrivateKey(alias: String): Boolean =
-        runCatching {
-            KeyStore.getInstance(ANDROID_KEYSTORE)
-                .apply { load(null) }
-                .getKey(alias, null) != null
-        }.getOrDefault(false)
-
-    private companion object {
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        val privateKeyPkcs8 = prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+        return alias.isNotBlank() && certificateChain.isNotBlank() && privateKeyPkcs8.isNotBlank()
     }
 }


### PR DESCRIPTION
## Summary
- Restore Android enrollment to software EC client keys, matching the original working enrollment shape before the AndroidKeyStore migration.
- Store the enrolled device private key as PKCS#8 app data so OkHttp/Conscrypt can use it for Cloudflare client TLS authentication.
- Bump Android versionCode to 2/versionName to 1.0.1 so devices cannot silently keep the old failing APK.
- Keep the pairing protocol unchanged; existing AndroidKeyStore/RSA-paired devices must re-enroll after installing this APK.

## Published APK
- Published hotfix artifact: `63c26155`
- SHA-256: `63c261556da255b58bceffc132db313ccfb036f6ed9bd23d7f025eb7f65cdb9a`
- Supersedes bad emergency artifacts `f1bb8d26`, `1abe3b11`, and `4c8c75f3`.

## Verification
- `./gradlew :app:compileDebugKotlin :app:packageRelease`
- `./gradlew :app:packageRelease --rerun-tasks`
- `./scripts/security/release-provenance.sh android/app/build/outputs/apk/release/app-release.apk data/apps/office-climate/63c26155.apk data/apps/office-climate/latest.apk`