### PR TITLE
Back off ERV local Tuya retries

### DIFF
--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -133,6 +133,9 @@ impl ErvPolicyCoordinator {
                 reason,
                 ..
             } => {
+                if !self.erv.local_retry_allowed(now) {
+                    return Ok(());
+                }
                 self.apply_policy_erv_speed(
                     erv_speed_from_ventilation(target_speed),
                     &reason,
@@ -251,6 +254,7 @@ impl ErvPolicyCoordinator {
             || !self.config.erv.active_control_enabled
             || !self.config.erv.is_configured()
             || snapshot.local_key_invalid
+            || !self.erv.local_retry_allowed(unix_timestamp_now())
         {
             return false;
         }
@@ -349,7 +353,15 @@ fn unix_timestamp_now() -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, path::PathBuf, sync::Mutex, time::Duration};
+    use std::{
+        collections::VecDeque,
+        path::PathBuf,
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use anyhow::Result;
     use serde_json::json;
@@ -369,6 +381,7 @@ mod tests {
 
     struct FakeErvWriter {
         smoke_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        smoke_calls: AtomicUsize,
         writes: Mutex<Vec<ErvFanSpeed>>,
         set_delay: Duration,
     }
@@ -377,6 +390,7 @@ mod tests {
         fn new(smoke_results: Vec<Result<ErvDeviceStatus>>) -> Self {
             Self {
                 smoke_results: Mutex::new(smoke_results.into()),
+                smoke_calls: AtomicUsize::new(0),
                 writes: Mutex::new(Vec::new()),
                 set_delay: Duration::ZERO,
             }
@@ -390,6 +404,10 @@ mod tests {
         fn writes(&self) -> Vec<ErvFanSpeed> {
             self.writes.lock().expect("writes lock").clone()
         }
+
+        fn smoke_calls(&self) -> usize {
+            self.smoke_calls.load(Ordering::SeqCst)
+        }
     }
 
     impl ErvSpeedWriter for FakeErvWriter {
@@ -397,6 +415,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
         ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.smoke_calls.fetch_add(1, Ordering::SeqCst);
             let result = self
                 .smoke_results
                 .lock()
@@ -687,6 +706,53 @@ mod tests {
                 .air_quality_sample_counts(),
             (1, 1)
         );
+    }
+
+    #[tokio::test]
+    async fn automated_policy_write_respects_local_failure_backoff() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let config = test_config(database_path.clone());
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            1_000.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, 1_001.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Err(anyhow::anyhow!(
+            "Connection reset by peer"
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect_err("first automated write should fail");
+        assert_eq!(writer.smoke_calls(), 1);
+        assert!(writer.writes().is_empty());
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("second policy evaluation respects backoff");
+        assert_eq!(writer.smoke_calls(), 1);
+        assert!(writer.writes().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -22,6 +22,8 @@ const DP_POWER: &str = "1";
 const DP_SUPPLY_SPEED: &str = "101";
 const DP_EXHAUST_SPEED: &str = "102";
 const LOCAL_KEY_ERROR_THRESHOLD: u64 = 5;
+const LOCAL_FAILURE_BASE_RETRY_SECONDS: f64 = 5.0 * 60.0;
+const LOCAL_FAILURE_MAX_RETRY_SECONDS: f64 = 60.0 * 60.0;
 pub const ERV_MANUAL_OVERRIDE_SECONDS: i64 = 30 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,6 +165,8 @@ struct ErvInner {
     notification: Option<AppNotification>,
     last_speed_changed_at: Option<f64>,
     manual_override: Option<ErvManualOverride>,
+    consecutive_local_failures: u64,
+    next_local_retry_at: Option<f64>,
 }
 
 impl ErvState {
@@ -305,6 +309,14 @@ impl ErvState {
             last_speed_changed_at: inner.last_speed_changed_at,
             local_key_invalid: inner.control.local_key_invalid,
         }
+    }
+
+    pub fn local_retry_allowed(&self, now: f64) -> bool {
+        self.inner
+            .read()
+            .expect("ERV state lock poisoned")
+            .next_local_retry_at
+            .map_or(true, |retry_at| now >= retry_at)
     }
 
     pub async fn smoke_status_with<W>(
@@ -475,7 +487,9 @@ impl ErvState {
             inner.control.using_cloud = false;
             inner.control.local_key_invalid = false;
             inner.control.local_key_invalid_since = None;
+            inner.consecutive_local_failures = 0;
             inner.control.consecutive_local_key_errors = 0;
+            inner.next_local_retry_at = None;
 
             if was_invalid {
                 inner.notification = Some(recovered_notification(&now));
@@ -505,6 +519,11 @@ impl ErvState {
             inner.control.last_error = Some(format!("Local status failed: {message}"));
             inner.control.last_error_at = Some(now.clone());
             inner.control.using_cloud = false;
+            inner.consecutive_local_failures = inner.consecutive_local_failures.saturating_add(1);
+            inner.next_local_retry_at = Some(
+                unix_timestamp_now()
+                    + local_failure_retry_delay_seconds(inner.consecutive_local_failures),
+            );
 
             if !is_local_key_error(message) {
                 inner.control.consecutive_local_key_errors = 0;
@@ -560,6 +579,11 @@ impl ErvState {
     }
 }
 
+fn local_failure_retry_delay_seconds(consecutive_failures: u64) -> f64 {
+    let exponent = consecutive_failures.saturating_sub(1).min(8) as i32;
+    (LOCAL_FAILURE_BASE_RETRY_SECONDS * 2f64.powi(exponent)).min(LOCAL_FAILURE_MAX_RETRY_SECONDS)
+}
+
 pub fn start_erv_status_poll(config: &AppConfig, erv: ErvState) -> Option<JoinHandle<()>> {
     if !config.erv.is_configured() {
         tracing::info!("ERV local Tuya config is incomplete; read-only ERV polling disabled");
@@ -572,6 +596,9 @@ pub fn start_erv_status_poll(config: &AppConfig, erv: ErvState) -> Option<JoinHa
         let mut interval = time::interval(Duration::from_secs(config.poll_interval_seconds.max(5)));
         loop {
             interval.tick().await;
+            if !erv.local_retry_allowed(unix_timestamp_now()) {
+                continue;
+            }
             if let Err(error) = erv.refresh_with(&config, &reader).await {
                 tracing::warn!("ERV read-only status poll failed: {error:#}");
             }
@@ -1066,6 +1093,29 @@ mod tests {
             .await
             .expect("broadcast timeout")
             .expect("broadcast message");
+    }
+
+    #[tokio::test]
+    async fn local_status_failure_sets_immediate_retry_backoff() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let reader = FakeErvReader::new(vec![
+            Err(anyhow!("Connection reset by peer")),
+            Err(anyhow!("Connection reset by peer")),
+        ]);
+
+        assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+
+        let now = unix_timestamp_now();
+        assert!(!state.local_retry_allowed(now));
+        assert!(state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
+
+        assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+        let now = unix_timestamp_now();
+        assert!(!state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
+        assert!(state.local_retry_allowed(now + (LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) + 1.0));
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1144,7 +1144,7 @@ async fn apply_occupancy_signal(
                 transition,
                 now,
                 transition.is_some(),
-                true,
+                transition.is_some(),
             ))
         })
         .await;
@@ -4215,6 +4215,55 @@ mod tests {
         let history = db::read_history(&config.runtime.database_path, 1, 10).expect("history");
         assert_eq!(history.occupancy_history[0]["state"], "present");
         assert_eq!(history.occupancy_history[0]["trigger"], "internal_presence");
+    }
+
+    #[tokio::test]
+    async fn internal_presence_heartbeat_without_transition_does_not_probe_erv() {
+        let mut config = configured_erv_config(true);
+        config.mitsubishi = configured_hvac_config(false).mitsubishi;
+        let qingping = qingping_with_co2(450);
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now - 10.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 5.0);
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Err(anyhow::anyhow!("should not smoke ERV"))],
+            vec![],
+        ));
+        let (state, _) = build_app_state(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            HvacState::default(),
+            erv_writer.clone(),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app state");
+
+        apply_presence_snapshot(
+            &state,
+            PresenceSnapshot {
+                last_active_timestamp: now,
+                external_monitor: true,
+                idle_seconds: 0.1,
+                display_count: 2,
+                external_displays: vec!["Studio Display".to_string()],
+            },
+        )
+        .await
+        .expect("presence heartbeat");
+
+        assert_eq!(erv_writer.smoke_calls(), 0);
+        assert!(erv_writer.write_speeds().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Stop same-state internal presence heartbeats from re-running ERV policy.
- Add an exponential local Tuya retry circuit breaker after any ERV local read/write failure.
- Skip automated policy writes and read-only status polls while local retry backoff is active; manual commands still try explicitly.

## Why
Production logs showed one ERV local failure turning into repeated local Tuya attempts roughly every 5 seconds. Smart Life sharing reported no key rotation needed, so this points to the device rejecting local sessions while the controller kept retrying.

The retry policy is now conservative: 5 minutes, then 10, 20, and capped at 60 minutes until a successful local operation resets it.

## Validation
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml internal_presence_heartbeat_without_transition_does_not_probe_erv`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml local_status_failure_sets_immediate_retry_backoff`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml automated_policy_write_respects_local_failure_backoff`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml automation::tests`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml erv::tests`
- `cargo build --manifest-path rust/office-automate-server/Cargo.toml --release`
- Production release binary restarted locally; logs show only the startup ERV probe and no repeated ERV attempts across subsequent Qingping cycles.

## Review
- Codex review clean: https://github.com/rajeshgoli/office-automation/pull/140#issuecomment-4654312166

## Notes
- This does not rotate any ERV secrets.
- Smart Life sharing recovery script reported `no rotation needed`; if local control is still rejected, the device-side local Tuya state may need the documented re-pair/local-key recovery path.