### PR TITLE
Use device certificate auth for Android app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,8 +41,8 @@ android {
         applicationId = "com.rajesh.officeclimate"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
         buildConfigField("String", "APK_HASH", "\"$officeClimateBuildHash\"")
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
 
     <application
         android:name=".OfficeClimateApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true"

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -1,17 +1,20 @@
 package com.rajesh.officeclimate.data.remote
 
 import android.util.Log
+import android.util.Base64
 import kotlinx.coroutines.flow.first
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.ByteArrayInputStream
 import java.net.Socket
+import java.security.KeyFactory
 import java.security.Principal
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedKeyManager
 import javax.net.ssl.TrustManagerFactory
@@ -54,8 +57,9 @@ class HttpClientFactory(
 
         val alias = settingsRepository.deviceCertificateAlias.first().trim()
         val certificateChainPem = settingsRepository.deviceCertificateChainPem.first().trim()
-        if (alias.isNotBlank() && certificateChainPem.isNotBlank()) {
-            runCatching { loadClientCertificate(alias, certificateChainPem) }
+        val privateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8()
+        if (alias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
+            runCatching { loadClientCertificate(alias, certificateChainPem, privateKeyPkcs8) }
                 .onSuccess { sslConfig ->
                     sslConfig?.let { (sslSocketFactory, trustManager) ->
                         builder.sslSocketFactory(sslSocketFactory, trustManager)
@@ -72,12 +76,13 @@ class HttpClientFactory(
     private fun loadClientCertificate(
         alias: String,
         certificateChainPem: String,
+        privateKeyPkcs8: String,
     ): Pair<SSLSocketFactory, X509TrustManager>? {
         val certificateChain = decodeCertificates(certificateChainPem)
         if (certificateChain.isEmpty()) {
             return null
         }
-        val privateKey = loadPrivateKey(alias) ?: return null
+        val privateKey = decodePrivateKey(privateKeyPkcs8) ?: return null
 
         val keyManager = SingleAliasKeyManager(
             alias = alias,
@@ -110,14 +115,14 @@ class HttpClientFactory(
             .filterIsInstance<X509Certificate>()
     }
 
-    private fun loadPrivateKey(alias: String): PrivateKey? =
-        KeyStore.getInstance(ANDROID_KEYSTORE)
-            .apply { load(null) }
-            .getKey(alias, null) as? PrivateKey
+    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey? =
+        runCatching {
+            val keyBytes = Base64.decode(privateKeyPkcs8, Base64.DEFAULT)
+            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+        }.getOrNull()
 
     private companion object {
         const val TAG = "HttpClientFactory"
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 
     private class SingleAliasKeyManager(

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -57,12 +57,21 @@ class HttpClientFactory(
 
         val alias = settingsRepository.deviceCertificateAlias.first().trim()
         val certificateChainPem = settingsRepository.deviceCertificateChainPem.first().trim()
-        val privateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8()
-        if (alias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
-            runCatching { loadClientCertificate(alias, certificateChainPem, privateKeyPkcs8) }
+        if (alias.isNotBlank() && certificateChainPem.isNotBlank()) {
+            val legacyPrivateKeyPkcs8 = settingsRepository.devicePrivateKeyPkcs8()
+            runCatching {
+                loadClientCertificate(
+                    alias = alias,
+                    certificateChainPem = certificateChainPem,
+                    legacyPrivateKeyPkcs8 = legacyPrivateKeyPkcs8,
+                )
+            }
                 .onSuccess { sslConfig ->
                     sslConfig?.let { (sslSocketFactory, trustManager) ->
                         builder.sslSocketFactory(sslSocketFactory, trustManager)
+                        if (legacyPrivateKeyPkcs8.isNotBlank()) {
+                            settingsRepository.clearDevicePrivateKeyPkcs8()
+                        }
                     }
                 }
                 .onFailure { error ->
@@ -76,13 +85,16 @@ class HttpClientFactory(
     private fun loadClientCertificate(
         alias: String,
         certificateChainPem: String,
-        privateKeyPkcs8: String,
+        legacyPrivateKeyPkcs8: String,
     ): Pair<SSLSocketFactory, X509TrustManager>? {
         val certificateChain = decodeCertificates(certificateChainPem)
         if (certificateChain.isEmpty()) {
             return null
         }
-        val privateKey = decodePrivateKey(privateKeyPkcs8) ?: return null
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val privateKey = loadPrivateKeyFromStore(keyStore, alias)
+            ?: importLegacyPrivateKey(keyStore, alias, certificateChain, legacyPrivateKeyPkcs8)
+            ?: return null
 
         val keyManager = SingleAliasKeyManager(
             alias = alias,
@@ -121,8 +133,32 @@ class HttpClientFactory(
             KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
         }.getOrNull()
 
+    private fun loadPrivateKeyFromStore(keyStore: KeyStore, alias: String): PrivateKey? =
+        runCatching { keyStore.getKey(alias, null) as? PrivateKey }.getOrNull()
+
+    private fun importLegacyPrivateKey(
+        keyStore: KeyStore,
+        alias: String,
+        certificateChain: List<X509Certificate>,
+        privateKeyPkcs8: String,
+    ): PrivateKey? {
+        if (privateKeyPkcs8.isBlank()) {
+            return null
+        }
+        val privateKey = decodePrivateKey(privateKeyPkcs8) ?: return null
+        return runCatching {
+            keyStore.setEntry(
+                alias,
+                KeyStore.PrivateKeyEntry(privateKey, certificateChain.toTypedArray()),
+                null,
+            )
+            loadPrivateKeyFromStore(keyStore, alias)
+        }.getOrNull()
+    }
+
     private companion object {
         const val TAG = "HttpClientFactory"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 
     private class SingleAliasKeyManager(

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -116,14 +116,7 @@ class ClimateRepository(
                     _apiConnected.value = true
                     _error.value = null
                 } catch (e: HttpException) {
-                    if (e.code() == 401) {
-                        Log.w(TAG, "Auth expired (401), clearing token")
-                        settingsRepository.clearAuth()
-                        _authExpired.value = true
-                        stop()
-                        return@launch
-                    }
-                    if (e.code() == 302 || e.code() == 403) {
+                    if (e.code() == 302 || e.code() == 401 || e.code() == 403) {
                         Log.w(TAG, "Cloudflare Access blocked request (${e.code()})")
                         _apiConnected.value = false
                         _error.value = "Cloudflare Access blocked this device. Enroll it with oa register-device."

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -1,7 +1,6 @@
 package com.rajesh.officeclimate.data.repository
 
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
+import android.util.Base64
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -98,7 +97,7 @@ class DeviceEnrollmentRepository(
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
                 settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
                 settingsRepository.saveDeviceCertificateAlias(alias)
-                settingsRepository.clearDevicePrivateKeyPkcs8()
+                settingsRepository.saveDevicePrivateKeyPkcs8(privateKeyPkcs8(keyPair.private))
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -113,30 +112,9 @@ class DeviceEnrollmentRepository(
         }
     }
 
-    private fun generateKeyPair(alias: String): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_RSA,
-            ANDROID_KEYSTORE,
-        )
-        keyPairGenerator.initialize(
-            KeyGenParameterSpec.Builder(
-                alias,
-                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_DECRYPT,
-            )
-                .setKeySize(2048)
-                .setDigests(
-                    KeyProperties.DIGEST_SHA256,
-                    KeyProperties.DIGEST_SHA384,
-                    KeyProperties.DIGEST_SHA512,
-                )
-                .setSignaturePaddings(
-                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
-                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
-                )
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                .setUserAuthenticationRequired(false)
-                .build(),
-        )
+    private fun generateKeyPair(@Suppress("UNUSED_PARAMETER") alias: String): KeyPair {
+        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+        keyPairGenerator.initialize(2048)
         return keyPairGenerator.generateKeyPair()
     }
 
@@ -172,6 +150,9 @@ class DeviceEnrollmentRepository(
             KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
         }
     }
+
+    private fun privateKeyPkcs8(privateKey: java.security.PrivateKey): String =
+        Base64.encodeToString(privateKey.encoded, Base64.NO_WRAP)
 
     private fun validatePairingUrl(pairingUrl: String) {
         val uri = runCatching { URI(pairingUrl.trim()) }.getOrNull()

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -1,6 +1,7 @@
 package com.rajesh.officeclimate.data.repository
 
-import android.util.Base64
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -97,7 +98,7 @@ class DeviceEnrollmentRepository(
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
                 settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
                 settingsRepository.saveDeviceCertificateAlias(alias)
-                settingsRepository.saveDevicePrivateKeyPkcs8(privateKeyPkcs8(keyPair.private))
+                settingsRepository.clearDevicePrivateKeyPkcs8()
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -112,9 +113,30 @@ class DeviceEnrollmentRepository(
         }
     }
 
-    private fun generateKeyPair(@Suppress("UNUSED_PARAMETER") alias: String): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-        keyPairGenerator.initialize(2048)
+    private fun generateKeyPair(alias: String): KeyPair {
+        deleteDeviceKey(alias)
+        val keyPairGenerator = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA,
+            ANDROID_KEYSTORE,
+        )
+        keyPairGenerator.initialize(
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+            )
+                .setKeySize(2048)
+                .setDigests(
+                    KeyProperties.DIGEST_SHA256,
+                    KeyProperties.DIGEST_SHA384,
+                    KeyProperties.DIGEST_SHA512,
+                )
+                .setSignaturePaddings(
+                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
+                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
+                )
+                .setUserAuthenticationRequired(false)
+                .build(),
+        )
         return keyPairGenerator.generateKeyPair()
     }
 
@@ -150,9 +172,6 @@ class DeviceEnrollmentRepository(
             KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
         }
     }
-
-    private fun privateKeyPkcs8(privateKey: java.security.PrivateKey): String =
-        Base64.encodeToString(privateKey.encoded, Base64.NO_WRAP)
 
     private fun validatePairingUrl(pairingUrl: String) {
         val uri = runCatching { URI(pairingUrl.trim()) }.getOrNull()

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -23,7 +23,6 @@ import java.net.URI
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
-import java.security.spec.ECGenParameterSpec
 import java.util.UUID
 
 @Serializable
@@ -116,13 +115,25 @@ class DeviceEnrollmentRepository(
 
     private fun generateKeyPair(alias: String): KeyPair {
         val keyPairGenerator = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_EC,
+            KeyProperties.KEY_ALGORITHM_RSA,
             ANDROID_KEYSTORE,
         )
         keyPairGenerator.initialize(
-            KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_SIGN)
-                .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
-                .setDigests(KeyProperties.DIGEST_SHA256)
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setKeySize(2048)
+                .setDigests(
+                    KeyProperties.DIGEST_SHA256,
+                    KeyProperties.DIGEST_SHA384,
+                    KeyProperties.DIGEST_SHA512,
+                )
+                .setSignaturePaddings(
+                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
+                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
+                )
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                 .setUserAuthenticationRequired(false)
                 .build(),
         )
@@ -132,7 +143,7 @@ class DeviceEnrollmentRepository(
     private fun buildCsrPem(keyPair: KeyPair, deviceName: String): String {
         val subject = X500Name("CN=${deviceName.ifBlank { "Office Automate Device" }}")
         val builder = JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
-        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private)
         val csr: PKCS10CertificationRequest = builder.build(signer)
         val writer = StringWriter()
         JcaPEMWriter(writer).use { pemWriter ->

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -10,9 +10,9 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
 import java.io.ByteArrayInputStream
 import java.net.URI
-import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
@@ -26,7 +26,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("device_certificate_alias")
         val DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("device_certificate_chain_pem")
-        val LEGACY_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
+        val DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("device_private_key_pkcs8")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
         val DISMISSED_APP_NOTIFICATION_IDS = stringSetPreferencesKey("dismissed_app_notification_ids")
     }
@@ -101,21 +101,30 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun clearDevicePrivateKeyPkcs8() {
+    suspend fun saveDevicePrivateKeyPkcs8(privateKeyPkcs8: String) {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
+            prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
         }
     }
 
+    suspend fun clearDevicePrivateKeyPkcs8() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(Keys.DEVICE_PRIVATE_KEY_PKCS8)
+        }
+    }
+
+    suspend fun devicePrivateKeyPkcs8(): String =
+        context.dataStore.data.first()[Keys.DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+
     suspend fun clearLegacyAuthAndInvalidDeviceCredentialIfNeeded() {
         context.dataStore.edit { prefs ->
-            prefs.remove(Keys.LEGACY_DEVICE_PRIVATE_KEY_PKCS8)
             if (
                 !prefs[Keys.DEVICE_CERTIFICATE_ALIAS].isNullOrBlank() &&
                     !hasValidDeviceCredential(prefs)
             ) {
                 prefs.remove(Keys.DEVICE_CERTIFICATE_ALIAS)
                 prefs.remove(Keys.DEVICE_CERTIFICATE_CHAIN_PEM)
+                prefs.remove(Keys.DEVICE_PRIVATE_KEY_PKCS8)
                 prefs.remove(Keys.JWT_TOKEN)
                 prefs.remove(Keys.USER_EMAIL)
             }
@@ -158,9 +167,10 @@ class SettingsRepository(private val context: Context) {
     private fun hasValidDeviceCredential(prefs: Preferences): Boolean {
         val alias = prefs[Keys.DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
         val certificateChain = prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
+        val privateKeyPkcs8 = prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
         return alias.isNotBlank() &&
             certificateChain.isNotBlank() &&
-            hasDevicePrivateKey(alias) &&
+            privateKeyPkcs8.isNotBlank() &&
             hasRsaDeviceCertificate(certificateChain)
     }
 
@@ -172,14 +182,4 @@ class SettingsRepository(private val context: Context) {
             certificates.firstOrNull()?.publicKey?.algorithm.equals("RSA", ignoreCase = true)
         }.getOrDefault(false)
 
-    private fun hasDevicePrivateKey(alias: String): Boolean =
-        runCatching {
-            KeyStore.getInstance(ANDROID_KEYSTORE)
-                .apply { load(null) }
-                .getKey(alias, null) != null
-        }.getOrDefault(false)
-
-    private companion object {
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
-    }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -10,8 +10,11 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.io.ByteArrayInputStream
 import java.net.URI
 import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
@@ -155,8 +158,19 @@ class SettingsRepository(private val context: Context) {
     private fun hasValidDeviceCredential(prefs: Preferences): Boolean {
         val alias = prefs[Keys.DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
         val certificateChain = prefs[Keys.DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
-        return alias.isNotBlank() && certificateChain.isNotBlank() && hasDevicePrivateKey(alias)
+        return alias.isNotBlank() &&
+            certificateChain.isNotBlank() &&
+            hasDevicePrivateKey(alias) &&
+            hasRsaDeviceCertificate(certificateChain)
     }
+
+    private fun hasRsaDeviceCertificate(certificateChainPem: String): Boolean =
+        runCatching {
+            val certificates = CertificateFactory.getInstance("X.509")
+                .generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+                .filterIsInstance<X509Certificate>()
+            certificates.firstOrNull()?.publicKey?.algorithm.equals("RSA", ignoreCase = true)
+        }.getOrDefault(false)
 
     private fun hasDevicePrivateKey(alias: String): Boolean =
         runCatching {

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
 import java.io.ByteArrayInputStream
 import java.net.URI
+import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
@@ -170,8 +171,8 @@ class SettingsRepository(private val context: Context) {
         val privateKeyPkcs8 = prefs[Keys.DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
         return alias.isNotBlank() &&
             certificateChain.isNotBlank() &&
-            privateKeyPkcs8.isNotBlank() &&
-            hasRsaDeviceCertificate(certificateChain)
+            hasRsaDeviceCertificate(certificateChain) &&
+            (deviceKeyExists(alias) || privateKeyPkcs8.isNotBlank())
     }
 
     private fun hasRsaDeviceCertificate(certificateChainPem: String): Boolean =
@@ -182,4 +183,13 @@ class SettingsRepository(private val context: Context) {
             certificates.firstOrNull()?.publicKey?.algorithm.equals("RSA", ignoreCase = true)
         }.getOrDefault(false)
 
+    private fun deviceKeyExists(alias: String): Boolean =
+        runCatching {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            keyStore.getKey(alias, null) != null
+        }.getOrDefault(false)
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    }
 }

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -53,7 +53,7 @@ class SettingsRepository(private val context: Context) {
     }
 
     val isAuthenticated: Flow<Boolean> = context.dataStore.data.map { prefs ->
-        hasValidDeviceCredential(prefs) && !prefs[Keys.JWT_TOKEN].isNullOrBlank()
+        hasValidDeviceCredential(prefs)
     }
 
     val dismissedUpdateArtifactHash: Flow<String?> = context.dataStore.data.map { prefs ->

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/navigation/AppNavigation.kt
@@ -21,6 +21,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -66,7 +69,15 @@ fun AppNavigation(authCallbackCount: Int = 0) {
     val navController = rememberNavController()
     val context = LocalContext.current
     val settingsRepo = SettingsRepository(context)
+    var cleanupComplete by remember { mutableStateOf(false) }
     val isAuthenticated by settingsRepo.isAuthenticated.collectAsState(initial = null)
+
+    LaunchedEffect(Unit) {
+        settingsRepo.clearLegacyAuthAndInvalidDeviceCredentialIfNeeded()
+        cleanupComplete = true
+    }
+
+    if (!cleanupComplete) return
 
     val startDestination = when (isAuthenticated) {
         true -> Routes.DASHBOARD

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -72,8 +73,7 @@ fun SettingsScreen(
 
         Text(
             text = when {
-                state.isLoggedIn && state.userEmail.isNotBlank() -> "Signed in as ${state.userEmail}"
-                state.hasDeviceCredential -> "Device enrolled. Google sign-in required."
+                state.isLoggedIn -> "Device enrolled"
                 else -> "Enroll this device"
             },
             style = MaterialTheme.typography.bodyMedium,
@@ -132,7 +132,7 @@ fun SettingsScreen(
 
         Button(
             onClick = viewModel::enrollDevice,
-            enabled = !state.enrolling && !state.signingIn && state.pairingUrl.isNotBlank() && state.pairingCode.isNotBlank(),
+            enabled = !state.enrolling && state.pairingUrl.isNotBlank() && state.pairingCode.isNotBlank(),
             modifier = Modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(containerColor = Emerald),
         ) {
@@ -149,37 +149,7 @@ fun SettingsScreen(
 
         Spacer(Modifier.height(12.dp))
 
-        if (state.hasDeviceCredential && !state.isLoggedIn) {
-            Button(
-                onClick = viewModel::signInWithGoogle,
-                enabled = !state.enrolling && !state.signingIn,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = Emerald),
-            ) {
-                if (state.signingIn) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.height(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.background,
-                    )
-                } else {
-                    Text("Sign in with Google", color = MaterialTheme.colorScheme.background)
-                }
-            }
-
-            Spacer(Modifier.height(12.dp))
-        }
-
         state.enrollmentStatus?.let { message ->
-            Text(
-                text = message,
-                style = MaterialTheme.typography.bodySmall,
-                color = Emerald,
-            )
-        }
-
-        state.signInStatus?.let { message ->
-            Spacer(Modifier.height(12.dp))
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodySmall,
@@ -197,6 +167,12 @@ fun SettingsScreen(
             }
 
             Spacer(Modifier.height(12.dp))
+        }
+
+        LaunchedEffect(state.enrollmentStatus) {
+            if (state.isLoggedIn && state.enrollmentStatus != null) {
+                onNavigateToDashboard()
+            }
         }
 
         state.error?.let { error ->

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/settings/SettingsViewModel.kt
@@ -1,12 +1,9 @@
 package com.rajesh.officeclimate.ui.settings
 
 import android.app.Application
-import android.content.Intent
-import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.rajesh.officeclimate.data.repository.DeviceEnrollmentRepository
-import com.rajesh.officeclimate.data.repository.OfficeAuthRepository
 import com.rajesh.officeclimate.data.repository.SettingsRepository
 import com.rajesh.officeclimate.util.Defaults
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,21 +15,17 @@ data class SettingsUiState(
     val serverUrl: String = Defaults.SERVER_URL,
     val isLoggedIn: Boolean = false,
     val hasDeviceCredential: Boolean = false,
-    val userEmail: String = "",
     val deviceCertificateAlias: String = "",
     val pairingUrl: String = Defaults.DEVICE_PAIRING_URL,
     val pairingCode: String = "",
     val enrolling: Boolean = false,
-    val signingIn: Boolean = false,
     val error: String? = null,
     val enrollmentStatus: String? = null,
-    val signInStatus: String? = null,
 )
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepo = SettingsRepository(application)
     private val deviceEnrollmentRepository = DeviceEnrollmentRepository(settingsRepo)
-    private val officeAuthRepository = OfficeAuthRepository(settingsRepo)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -41,12 +34,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             settingsRepo.clearLegacyAuthAndInvalidDeviceCredentialIfNeeded()
             val hasDeviceCredential = settingsRepo.hasDeviceCredential.first()
-            val jwtToken = settingsRepo.jwtToken.first()
             _uiState.value = _uiState.value.copy(
                 serverUrl = settingsRepo.serverUrl.first(),
                 hasDeviceCredential = hasDeviceCredential,
-                isLoggedIn = hasDeviceCredential && jwtToken.isNotBlank(),
-                userEmail = settingsRepo.userEmail.first(),
+                isLoggedIn = hasDeviceCredential,
                 deviceCertificateAlias = settingsRepo.deviceCertificateAlias.first(),
                 pairingUrl = Defaults.DEVICE_PAIRING_URL,
             )
@@ -96,7 +87,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                     enrolling = false,
                     deviceCertificateAlias = result.alias,
                     hasDeviceCredential = true,
-                    isLoggedIn = false,
+                    isLoggedIn = true,
                     enrollmentStatus = "Device enrolled as ${result.deviceName}.",
                     error = null,
                 )
@@ -107,38 +98,5 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 )
             }
         }
-    }
-
-    fun signInWithGoogle() {
-        val state = _uiState.value
-        if (!state.hasDeviceCredential) {
-            _uiState.value = state.copy(error = "Enroll this device before signing in.")
-            return
-        }
-
-        _uiState.value = state.copy(signingIn = true, error = null, signInStatus = null)
-        viewModelScope.launch {
-            try {
-                settingsRepo.saveServerUrl(_uiState.value.serverUrl)
-                val login = officeAuthRepository.startBrowserLogin()
-                _uiState.value = _uiState.value.copy(
-                    signingIn = false,
-                    signInStatus = "Complete Google sign-in in the browser.",
-                )
-                openVerificationUrl(login.authorizationUrl)
-            } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    signingIn = false,
-                    error = "Sign-in failed: ${e.message}",
-                )
-            }
-        }
-    }
-
-    private fun openVerificationUrl(url: String) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        getApplication<Application>().startActivity(intent)
     }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,7 @@ artifacts:
 cloudflare_access:
   account_id: "cloudflare-account-id"
   app_id: "optional-access-application-id"
+  jwt_audience: "cloudflare-access-application-aud-tag"
   device_policy_id: "cloudflare-device-mtls-policy-id"
   api_token: "cloudflare-api-token-with-access-apps-policies-write"
 

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -258,11 +258,12 @@ For remote Android access, configure the Cloudflare Access Service Auth policy a
 ```bash
 export OFFICE_AUTOMATE_CLOUDFLARE_ACCOUNT_ID="..."
 export OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_APP_ID="..."        # optional for reusable policies
+export OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_JWT_AUDIENCE="..."  # Access application AUD tag
 export OFFICE_AUTOMATE_CLOUDFLARE_DEVICE_POLICY_ID="..."
 export OFFICE_AUTOMATE_CLOUDFLARE_API_TOKEN="..."
 ```
 
-When those values are configured, pairing adds the new device certificate CN to the Cloudflare policy before completing local enrollment. Revocation removes the CN from Cloudflare before marking the local registration revoked. If the Cloudflare update fails, the command fails instead of silently leaving stale edge access.
+When those values are configured, pairing adds the new device certificate CN to the Cloudflare policy before completing local enrollment. Revocation removes the CN from Cloudflare before marking the local registration revoked. If the Cloudflare update fails, the command fails instead of silently leaving stale edge access. The origin requires `OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_JWT_AUDIENCE` to match the Access application AUD tag before accepting a Cloudflare mTLS assertion as device auth.
 
 The default device mTLS CA files are repo-local and gitignored:
 

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -85,11 +85,12 @@ export async function checkTrustedNetwork(): Promise<boolean> {
 
 export async function startLogin(): Promise<{ authorization_url: string }> {
   clearAuthToken();
-  const response = await authFetch(`${API_BASE}/auth/login`);
-  if (!response.ok) {
-    throw new Error('Failed to initiate login');
-  }
-  return response.json();
+  const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}` || '/';
+  const params = new URLSearchParams({
+    redirect: '1',
+    return_to: returnTo,
+  });
+  return { authorization_url: `${API_BASE}/auth/login?${params.toString()}` };
 }
 
 export async function logout(): Promise<void> {

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -570,7 +570,10 @@ impl AuthManager {
         let Some(id_token) = token_response.id_token.as_deref() else {
             return Ok(None);
         };
-        let Some(email) = self.verify_google_id_token(oauth, id_token).await? else {
+        let Some(email) = self
+            .verify_google_id_token(oauth, id_token, &oauth.client_id)
+            .await?
+        else {
             return Ok(None);
         };
         let jwt = self.generate_jwt(&email)?;
@@ -667,7 +670,10 @@ impl AuthManager {
             let Some(id_token) = body.get("id_token").and_then(Value::as_str) else {
                 return Ok(json!({"status": "error", "message": "Missing id_token"}));
             };
-            let Some(email) = self.verify_google_id_token(oauth, id_token).await? else {
+            let Some(email) = self
+                .verify_google_id_token(oauth, id_token, &oauth.client_id)
+                .await?
+            else {
                 return Ok(json!({"status": "forbidden", "message": "Email not allowed"}));
             };
             let jwt = self.generate_jwt(&email)?;
@@ -689,13 +695,14 @@ impl AuthManager {
             return Ok(json!({"status": "pending", "message": "User has not authorized yet"}));
         }
 
-        if status == StatusCode::BAD_REQUEST {
+        if status == StatusCode::BAD_REQUEST || status == StatusCode::FORBIDDEN {
             let error = body.get("error").and_then(Value::as_str).unwrap_or("error");
             return Ok(match error {
                 "authorization_pending" => {
                     json!({"status": "pending", "message": "Waiting for user authorization"})
                 }
                 "slow_down" => json!({"status": "slow_down", "message": "Polling too fast"}),
+                "access_denied" => json!({"status": "forbidden", "message": "Access denied"}),
                 _ => json!({"status": "error", "message": error}),
             });
         }
@@ -707,6 +714,7 @@ impl AuthManager {
         &self,
         oauth: &OAuthRuntime,
         id_token: &str,
+        expected_audience: &str,
     ) -> Result<Option<String>> {
         let info: GoogleTokenInfo = self
             .inner
@@ -722,7 +730,7 @@ impl AuthManager {
             .await
             .context("Google tokeninfo response was not JSON")?;
 
-        if info.aud.as_deref() != Some(oauth.client_id.as_str()) {
+        if info.aud.as_deref() != Some(expected_audience) {
             return Ok(None);
         }
 

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -72,6 +72,7 @@ pub struct PendingOAuthState {
     pub code_verifier: String,
     pub redirect_uri: String,
     pub platform: Option<String>,
+    pub return_to: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -478,6 +479,7 @@ impl AuthManager {
         host: &str,
         forwarded_proto: Option<&str>,
         platform: Option<String>,
+        return_to: Option<String>,
     ) -> Result<Value> {
         let oauth = self
             .inner
@@ -501,6 +503,7 @@ impl AuthManager {
                     code_verifier,
                     redirect_uri: redirect_uri.clone(),
                     platform,
+                    return_to,
                 },
             );
 
@@ -582,6 +585,7 @@ impl AuthManager {
             email,
             jwt,
             platform: pending.platform,
+            return_to: pending.return_to,
             secure_cookie: pending.redirect_uri.starts_with("https://"),
             refresh_token: token_response.refresh_token,
             access_token: token_response.access_token,
@@ -747,6 +751,7 @@ pub struct FinishedOAuthLogin {
     pub email: String,
     pub jwt: String,
     pub platform: Option<String>,
+    pub return_to: Option<String>,
     pub secure_cookie: bool,
     pub access_token: Option<String>,
     pub refresh_token: Option<String>,
@@ -927,6 +932,7 @@ mod tests {
                 "office.example.com",
                 Some("https"),
                 Some("android".to_string()),
+                Some("/apps/office-climate/latest.apk".to_string()),
             )
             .expect("login");
         let url = payload["authorization_url"].as_str().expect("url");
@@ -936,6 +942,10 @@ mod tests {
         assert_eq!(
             manager.pending_state(state).expect("stored").platform,
             Some("android".to_string())
+        );
+        assert_eq!(
+            manager.pending_state(state).expect("stored").return_to,
+            Some("/apps/office-climate/latest.apk".to_string())
         );
     }
 

--- a/rust/office-automate-server/src/auth.rs
+++ b/rust/office-automate-server/src/auth.rs
@@ -274,7 +274,12 @@ impl AuthManager {
     pub async fn verify_cloudflare_access_assertion(
         &self,
         token: &str,
+        expected_audience: &str,
     ) -> Option<CloudflareAccessClaims> {
+        let expected_audience = expected_audience.trim();
+        if expected_audience.is_empty() {
+            return None;
+        }
         let header = decode_header(token).ok()?;
         let kid = header.kid.as_deref()?;
         let untrusted_claims = Self::decode_cloudflare_access_assertion_unverified(token)?;
@@ -294,7 +299,7 @@ impl AuthManager {
             .ok()?;
         let key = DecodingKey::from_jwk(jwks.find(kid)?).ok()?;
         let mut validation = Validation::new(Algorithm::RS256);
-        validation.validate_aud = false;
+        validation.set_audience(&[expected_audience]);
         validation.set_issuer(&[issuer.as_str().trim_end_matches('/')]);
         decode::<CloudflareAccessClaims>(token, &key, &validation)
             .ok()

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -141,6 +141,7 @@ pub struct ArtifactConfig {
 pub struct CloudflareAccessConfig {
     pub account_id: Option<String>,
     pub app_id: Option<String>,
+    pub jwt_audience: Option<String>,
     pub device_policy_id: Option<String>,
     pub api_token: Option<String>,
     pub api_base_url: String,
@@ -151,6 +152,7 @@ impl Default for CloudflareAccessConfig {
         Self {
             account_id: None,
             app_id: None,
+            jwt_audience: None,
             device_policy_id: None,
             api_token: None,
             api_base_url: "https://api.cloudflare.com/client/v4".to_string(),
@@ -171,6 +173,13 @@ impl CloudflareAccessConfig {
                 .api_token
                 .as_deref()
                 .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    pub fn access_jwt_audience(&self) -> Option<&str> {
+        self.jwt_audience
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
     }
 }
 
@@ -559,6 +568,10 @@ impl AppConfig {
             file_config.cloudflare_access.app_id = Some(app_id);
         }
 
+        if let Some(audience) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_JWT_AUDIENCE") {
+            file_config.cloudflare_access.jwt_audience = Some(audience);
+        }
+
         if let Some(policy_id) = env_lookup("OFFICE_AUTOMATE_CLOUDFLARE_DEVICE_POLICY_ID") {
             file_config.cloudflare_access.device_policy_id = Some(policy_id);
         }
@@ -853,6 +866,7 @@ thresholds:
             "OFFICE_AUTOMATE_TELEMETRY_DAYS" => Some("14".to_string()),
             "OFFICE_AUTOMATE_PUBLIC_URL" => Some("https://office.example.com".to_string()),
             "OFFICE_AUTOMATE_CONTROLLER_IPC_TOKEN" => Some("edge-ipc-token".to_string()),
+            "OFFICE_AUTOMATE_CLOUDFLARE_ACCESS_JWT_AUDIENCE" => Some("access-aud".to_string()),
             "OFFICE_AUTOMATE_ADMIN_EMAILS" => {
                 Some("rajesh@example.com,ops@example.com".to_string())
             }
@@ -954,6 +968,10 @@ thresholds:
             Some("edge-ipc-token")
         );
         assert_eq!(
+            config.cloudflare_access.access_jwt_audience(),
+            Some("access-aud")
+        );
+        assert_eq!(
             config.orchestrator.admin_emails,
             vec!["rajesh@example.com", "ops@example.com"]
         );
@@ -962,6 +980,23 @@ thresholds:
         assert_eq!(config.thresholds.hvac_cool_on_temp_f, 82);
         assert_eq!(config.thresholds.expected_occupancy_start, "08:30");
         assert_eq!(config.thresholds.expected_occupancy_end, "18:45");
+    }
+
+    #[test]
+    fn cloudflare_access_jwt_audience_ignores_blank_values() {
+        let config = CloudflareAccessConfig {
+            jwt_audience: Some("  ".to_string()),
+            ..CloudflareAccessConfig::default()
+        };
+
+        assert_eq!(config.access_jwt_audience(), None);
+
+        let config = CloudflareAccessConfig {
+            jwt_audience: Some(" aud-tag ".to_string()),
+            ..CloudflareAccessConfig::default()
+        };
+
+        assert_eq!(config.access_jwt_audience(), Some("aud-tag"));
     }
 
     #[test]

--- a/rust/office-automate-server/src/device.rs
+++ b/rust/office-automate-server/src/device.rs
@@ -216,6 +216,17 @@ async fn complete_device_pairing(
                 .into_response();
         }
     };
+    let certificate_chain_pem =
+        match build_certificate_chain_pem(&certificate_pem, &state.ca_cert_path) {
+            Ok(chain) => chain,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": error.to_string()})),
+                )
+                    .into_response();
+            }
+        };
     if let Err(error) = cloudflare::sync_device_common_name(
         &state.cloudflare_access,
         &certificate_common_name,
@@ -243,7 +254,7 @@ async fn complete_device_pairing(
             pairing_code: registration.pairing_code,
             common_name: registration.common_name,
             certificate_pem: certificate_pem.clone(),
-            certificate_chain_pem: certificate_pem.clone(),
+            certificate_chain_pem,
             expires_at: registration.expires_at,
         })
         .into_response(),
@@ -421,6 +432,16 @@ authorityKeyIdentifier = keyid,issuer
     fs::read_to_string(&cert_path).context("failed to read signed certificate")
 }
 
+fn build_certificate_chain_pem(certificate_pem: &str, ca_cert_path: &Path) -> Result<String> {
+    let ca_cert_pem =
+        fs::read_to_string(ca_cert_path).context("failed to read device CA certificate")?;
+    Ok(format!(
+        "{}\n{}",
+        certificate_pem.trim(),
+        ca_cert_pem.trim()
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -433,5 +454,27 @@ mod tests {
         assert_eq!(payload.pairing_code, "ABC123");
         assert_eq!(payload.csr_pem, "");
         assert_eq!(payload.public_key_pem, "");
+    }
+
+    #[test]
+    fn build_certificate_chain_appends_ca_certificate() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let ca_path = temp_dir.path().join("device-ca.pem");
+        fs::write(
+            &ca_path,
+            "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----\n",
+        )
+        .expect("write ca");
+
+        let chain = build_certificate_chain_pem(
+            "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n\n",
+            &ca_path,
+        )
+        .expect("chain");
+
+        assert_eq!(
+            chain,
+            "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"
+        );
     }
 }

--- a/rust/office-automate-server/src/edge.rs
+++ b/rust/office-automate-server/src/edge.rs
@@ -370,6 +370,9 @@ async fn edge_auth_middleware(
         } else {
             "Invalid or expired token"
         };
+        if should_redirect_browser_to_oauth_login(request.method(), &headers) {
+            return browser_oauth_login_redirect(request.uri()).into_response();
+        }
         return (
             StatusCode::UNAUTHORIZED,
             Json(json!({"error": message, "login_url": "/auth/login"})),
@@ -402,6 +405,42 @@ async fn edge_auth_middleware(
 
     request.extensions_mut().insert(user);
     next.run(request).await
+}
+
+fn should_redirect_browser_to_oauth_login(method: &Method, headers: &HeaderMap) -> bool {
+    if *method != Method::GET && *method != Method::HEAD {
+        return false;
+    }
+    if headers.contains_key(header::AUTHORIZATION) {
+        return false;
+    }
+    let sec_fetch_mode = headers
+        .get("sec-fetch-mode")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if sec_fetch_mode.eq_ignore_ascii_case("navigate") {
+        return true;
+    }
+    headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|accept| accept.contains("text/html"))
+}
+
+fn browser_oauth_login_redirect(uri: &Uri) -> Response {
+    let return_to = uri
+        .path_and_query()
+        .map(|path| path.as_str())
+        .unwrap_or("/");
+    let location = format!(
+        "/auth/login?redirect=1&return_to={}",
+        urlencoding::encode(return_to)
+    );
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, location)
+        .body(Body::empty())
+        .expect("valid OAuth login redirect")
 }
 
 async fn forward_get(State(state): State<EdgeState>, OriginalUri(uri): OriginalUri) -> Response {
@@ -865,11 +904,35 @@ async fn auth_login(
         .get("platform")
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty());
+    let return_to = query
+        .get("return_to")
+        .and_then(|value| sanitize_oauth_return_to(value));
+    let redirect_to_provider = query
+        .get("redirect")
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"));
     let forwarded_proto = headers
         .get("x-forwarded-proto")
         .and_then(|value| value.to_str().ok());
 
-    match state.auth.begin_login(host, forwarded_proto, platform) {
+    match state
+        .auth
+        .begin_login(host, forwarded_proto, platform, return_to)
+    {
+        Ok(payload) if redirect_to_provider => {
+            let Some(authorization_url) = payload.get("authorization_url").and_then(Value::as_str)
+            else {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "Failed to start OAuth"})),
+                )
+                    .into_response();
+            };
+            Response::builder()
+                .status(StatusCode::FOUND)
+                .header(header::LOCATION, authorization_url)
+                .body(Body::empty())
+                .expect("valid OAuth provider redirect")
+        }
         Ok(payload) => Json(payload).into_response(),
         Err(error) => {
             tracing::error!("failed to start OAuth login: {error:#}");
@@ -914,7 +977,12 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt, login.secure_cookie),
+        Ok(Some(login)) => browser_login_response(
+            &state.auth,
+            &login.jwt,
+            login.secure_cookie,
+            login.return_to.as_deref().unwrap_or("/"),
+        ),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -1044,10 +1112,27 @@ fn escape_html_text(value: &str) -> String {
         .collect()
 }
 
-fn browser_login_response(auth: &AuthManager, token: &str, secure_cookie: bool) -> Response {
+fn sanitize_oauth_return_to(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty()
+        || !value.starts_with('/')
+        || value.starts_with("//")
+        || value.chars().any(char::is_control)
+    {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+fn browser_login_response(
+    auth: &AuthManager,
+    token: &str,
+    secure_cookie: bool,
+    return_to: &str,
+) -> Response {
     let mut response = Response::builder()
         .status(StatusCode::FOUND)
-        .header(header::LOCATION, "/")
+        .header(header::LOCATION, return_to)
         .body(Body::empty())
         .expect("valid browser login response");
     if let Some(cookies) = auth.issue_oauth_session_cookies(token, secure_cookie) {

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2237,6 +2237,10 @@ async fn deploy_app(
 }
 
 async fn latest_app_artifact(State(state): State<AppState>, Path(app): Path<String>) -> Response {
+    latest_app_artifact_redirect(&state, &app).await
+}
+
+async fn latest_app_artifact_redirect(state: &AppState, app: &str) -> Response {
     let metadata = match state.artifacts.read_metadata(&app).await {
         Ok(Some(metadata)) => metadata,
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
@@ -2283,6 +2287,9 @@ async fn hashed_app_artifact(
     let Some(artifact_hash) = artifact_file.strip_suffix(".apk") else {
         return StatusCode::NOT_FOUND.into_response();
     };
+    if is_download_alias(artifact_hash) {
+        return latest_app_artifact_redirect(&state, &app).await;
+    }
     match state
         .artifacts
         .serve_hashed_artifact(&app, artifact_hash)
@@ -2295,6 +2302,13 @@ async fn hashed_app_artifact(
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
+}
+
+fn is_download_alias(value: &str) -> bool {
+    let Some(attempt) = value.strip_prefix("attempt") else {
+        return false;
+    };
+    !attempt.is_empty() && attempt.len() <= 4 && attempt.chars().all(|ch| ch.is_ascii_digit())
 }
 
 async fn app_artifact_meta(State(state): State<AppState>, Path(app): Path<String>) -> Response {
@@ -6335,6 +6349,23 @@ mod tests {
             .oneshot(
                 HttpRequest::builder()
                     .uri("/apps/office-climate/latest.apk")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_no_store_headers(response.headers());
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            &format!("/apps/office-climate/{artifact_hash}.apk")
+        );
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/office-climate/attempt2.apk")
                     .header(header::AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .expect("request"),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -640,8 +640,20 @@ async fn auth_middleware(
         return next.run(request).await;
     }
 
-    match cloudflare_access_service_auth(&state, &headers, remote_addr).await {
-        CloudflareAccessServiceAuth::DeviceAllowed => {}
+    let cloudflare_service_auth =
+        cloudflare_access_service_auth(&state, &headers, remote_addr).await;
+    let route_class = route_authorization_class(request.method(), request.uri().path());
+
+    match cloudflare_service_auth {
+        CloudflareAccessServiceAuth::DeviceAllowed(identity)
+            if route_class != RouteAuthorizationClass::AdminUpload =>
+        {
+            request.extensions_mut().insert(AuthenticatedUser {
+                email: format!("cloudflare_mtls:{identity}"),
+            });
+            return next.run(request).await;
+        }
+        CloudflareAccessServiceAuth::DeviceAllowed(_) => {}
         CloudflareAccessServiceAuth::Rejected => {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -651,8 +663,6 @@ async fn auth_middleware(
         }
         CloudflareAccessServiceAuth::AbsentOrUserAccess => {}
     }
-
-    let route_class = route_authorization_class(request.method(), request.uri().path());
 
     if should_skip_auth(route_class, auth_mode) {
         return next.run(request).await;
@@ -842,7 +852,7 @@ fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 enum CloudflareAccessServiceAuth {
-    DeviceAllowed,
+    DeviceAllowed(String),
     Rejected,
     AbsentOrUserAccess,
 }
@@ -886,7 +896,7 @@ async fn cloudflare_access_service_auth(
             return CloudflareAccessServiceAuth::Rejected;
         }
     };
-    CloudflareAccessServiceAuth::DeviceAllowed
+    CloudflareAccessServiceAuth::DeviceAllowed(identity)
 }
 
 async fn status(State(state): State<AppState>) -> Json<Status> {

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2271,7 +2271,8 @@ async fn latest_app_artifact(State(state): State<AppState>, Path(app): Path<Stri
         .expect("valid redirect response");
     response
         .headers_mut()
-        .insert(header::CACHE_CONTROL, "no-cache".parse().expect("header"));
+        .insert(header::CACHE_CONTROL, no_store_header_value());
+    apply_no_store_headers(&mut response);
     response
 }
 
@@ -2298,7 +2299,11 @@ async fn hashed_app_artifact(
 
 async fn app_artifact_meta(State(state): State<AppState>, Path(app): Path<String>) -> Response {
     match state.artifacts.read_metadata(&app).await {
-        Ok(Some(metadata)) => Json(metadata).into_response(),
+        Ok(Some(metadata)) => {
+            let mut response = Json(metadata).into_response();
+            apply_no_store_headers(&mut response);
+            response
+        }
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
         Err(error) => {
             tracing::error!("artifact metadata read failed: {error:#}");
@@ -2316,6 +2321,25 @@ async fn legacy_apk(State(state): State<AppState>) -> Response {
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
+}
+
+fn no_store_header_value() -> HeaderValue {
+    HeaderValue::from_static("no-store, max-age=0")
+}
+
+fn apply_no_store_headers(response: &mut Response) {
+    let headers = response.headers_mut();
+    headers.insert(header::CACHE_CONTROL, no_store_header_value());
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+    headers.insert(header::EXPIRES, HeaderValue::from_static("0"));
+    headers.insert(
+        HeaderName::from_static("cdn-cache-control"),
+        HeaderValue::from_static("no-store"),
+    );
+    headers.insert(
+        HeaderName::from_static("cloudflare-cdn-cache-control"),
+        HeaderValue::from_static("no-store"),
+    );
 }
 
 async fn auth_login(
@@ -3193,6 +3217,20 @@ mod tests {
         body.extend_from_slice(bytes);
         body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
         body
+    }
+
+    fn assert_no_store_headers(headers: &HeaderMap) {
+        assert_eq!(
+            headers.get(header::CACHE_CONTROL).unwrap(),
+            "no-store, max-age=0"
+        );
+        assert_eq!(headers.get(header::PRAGMA).unwrap(), "no-cache");
+        assert_eq!(headers.get(header::EXPIRES).unwrap(), "0");
+        assert_eq!(headers.get("cdn-cache-control").unwrap(), "no-store");
+        assert_eq!(
+            headers.get("cloudflare-cdn-cache-control").unwrap(),
+            "no-store"
+        );
     }
 
     #[tokio::test]
@@ -6280,6 +6318,7 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(response.status(), StatusCode::OK);
+        assert_no_store_headers(response.headers());
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("read body");
@@ -6291,6 +6330,23 @@ mod tests {
         assert_eq!(metadata["uploaded_by"], "engineer@rajeshgo.li");
         assert_eq!(metadata["version_code"], 7);
         assert_eq!(metadata["version_name"], "1.2.0");
+
+        let response = app(config.clone())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/office-climate/latest.apk")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_no_store_headers(response.headers());
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            &format!("/apps/office-climate/{artifact_hash}.apk")
+        );
 
         let response = app(config)
             .oneshot(

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -692,6 +692,9 @@ async fn auth_middleware(
                 } else {
                     "Invalid or expired token"
                 };
+                if should_redirect_browser_to_oauth_login(request.method(), &headers) {
+                    return browser_oauth_login_redirect(request.uri()).into_response();
+                }
                 return (
                     StatusCode::UNAUTHORIZED,
                     Json(json!({"error": message, "login_url": "/auth/login"})),
@@ -734,6 +737,42 @@ async fn auth_middleware(
             response
         }
     }
+}
+
+fn should_redirect_browser_to_oauth_login(method: &Method, headers: &HeaderMap) -> bool {
+    if *method != Method::GET && *method != Method::HEAD {
+        return false;
+    }
+    if headers.contains_key(header::AUTHORIZATION) {
+        return false;
+    }
+    let sec_fetch_mode = headers
+        .get("sec-fetch-mode")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if sec_fetch_mode.eq_ignore_ascii_case("navigate") {
+        return true;
+    }
+    headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|accept| accept.contains("text/html"))
+}
+
+fn browser_oauth_login_redirect(uri: &axum::http::Uri) -> Response {
+    let return_to = uri
+        .path_and_query()
+        .map(|path| path.as_str())
+        .unwrap_or("/");
+    let location = format!(
+        "/auth/login?redirect=1&return_to={}",
+        urlencoding::encode(return_to)
+    );
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, location)
+        .body(Body::empty())
+        .expect("valid OAuth login redirect")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2306,11 +2345,35 @@ async fn auth_login(
         .get("platform")
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty());
+    let return_to = query
+        .get("return_to")
+        .and_then(|value| sanitize_oauth_return_to(value));
+    let redirect_to_provider = query
+        .get("redirect")
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes"));
     let forwarded_proto = headers
         .get("x-forwarded-proto")
         .and_then(|value| value.to_str().ok());
 
-    match state.auth.begin_login(host, forwarded_proto, platform) {
+    match state
+        .auth
+        .begin_login(host, forwarded_proto, platform, return_to)
+    {
+        Ok(payload) if redirect_to_provider => {
+            let Some(authorization_url) = payload.get("authorization_url").and_then(Value::as_str)
+            else {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "Failed to start OAuth"})),
+                )
+                    .into_response();
+            };
+            Response::builder()
+                .status(StatusCode::FOUND)
+                .header(header::LOCATION, authorization_url)
+                .body(Body::empty())
+                .expect("valid OAuth provider redirect")
+        }
         Ok(payload) => Json(payload).into_response(),
         Err(error) => {
             tracing::error!("failed to start OAuth login: {error:#}");
@@ -2359,7 +2422,12 @@ async fn auth_callback(
             )
             .body(Body::empty())
             .expect("valid android redirect response"),
-        Ok(Some(login)) => browser_login_response(&state.auth, &login.jwt, login.secure_cookie),
+        Ok(Some(login)) => browser_login_response(
+            &state.auth,
+            &login.jwt,
+            login.secure_cookie,
+            login.return_to.as_deref().unwrap_or("/"),
+        ),
         Ok(None) => (
             StatusCode::FORBIDDEN,
             Html("<html><body><h1>Login Failed</h1><p>Email not authorized</p></body></html>"),
@@ -2398,10 +2466,27 @@ fn script_json_string(value: &str) -> String {
         .replace('&', "\\u0026")
 }
 
-fn browser_login_response(auth: &AuthManager, token: &str, secure_cookie: bool) -> Response {
+fn sanitize_oauth_return_to(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty()
+        || !value.starts_with('/')
+        || value.starts_with("//")
+        || value.chars().any(char::is_control)
+    {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+fn browser_login_response(
+    auth: &AuthManager,
+    token: &str,
+    secure_cookie: bool,
+    return_to: &str,
+) -> Response {
     let mut response = Response::builder()
         .status(StatusCode::FOUND)
-        .header(header::LOCATION, "/")
+        .header(header::LOCATION, return_to)
         .body(Body::empty())
         .expect("valid browser login response");
     if let Some(cookies) = auth.issue_oauth_session_cookies(token, secure_cookie) {
@@ -3350,12 +3435,33 @@ mod tests {
         assert_eq!(value["login_url"], "/auth/login");
     }
 
+    #[tokio::test]
+    async fn oauth_middleware_redirects_browser_artifact_navigation_to_login() {
+        let response = app(oauth_config())
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/apps/office-climate/latest.apk")
+                    .header(header::ACCEPT, "text/html,application/xhtml+xml")
+                    .header("sec-fetch-mode", "navigate")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response.headers().get(header::LOCATION).expect("location"),
+            "/auth/login?redirect=1&return_to=%2Fapps%2Foffice-climate%2Flatest.apk"
+        );
+    }
+
     #[test]
     fn browser_login_response_sets_httponly_session_and_csrf_cookies() {
         let config = oauth_config();
         let auth = AuthManager::new(&config.orchestrator).expect("auth");
         let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
-        let response = browser_login_response(&auth, &token, true);
+        let response = browser_login_response(&auth, &token, true, "/");
 
         assert_eq!(response.status(), StatusCode::FOUND);
         assert_eq!(
@@ -3391,8 +3497,13 @@ mod tests {
         let config = oauth_config();
         let auth = AuthManager::new(&config.orchestrator).expect("auth");
         let token = auth.generate_jwt("engineer@rajeshgo.li").expect("token");
-        let response = browser_login_response(&auth, &token, false);
+        let response =
+            browser_login_response(&auth, &token, false, "/apps/office-climate/latest.apk");
 
+        assert_eq!(
+            response.headers().get(header::LOCATION).expect("location"),
+            "/apps/office-climate/latest.apk"
+        );
         let cookies = response
             .headers()
             .get_all(header::SET_COOKIE)

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -911,9 +911,15 @@ async fn cloudflare_access_service_auth(
     else {
         return CloudflareAccessServiceAuth::AbsentOrUserAccess;
     };
+    let Some(expected_audience) = state.config.cloudflare_access.access_jwt_audience() else {
+        tracing::warn!(
+            "Cloudflare mTLS assertion rejected: cloudflare_access.jwt_audience is not configured"
+        );
+        return CloudflareAccessServiceAuth::Rejected;
+    };
     let Some(claims) = state
         .auth
-        .verify_cloudflare_access_assertion(assertion)
+        .verify_cloudflare_access_assertion(assertion, expected_audience)
         .await
     else {
         return CloudflareAccessServiceAuth::Rejected;

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2670,9 +2670,24 @@ async fn serve_static_or_index(state: &AppState, path: &str) -> Response {
     match tokio::fs::read(&target).await {
         Ok(bytes) => Response::builder()
             .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, static_content_type(&target))
             .body(Body::from(bytes))
             .expect("static response"),
         Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn static_content_type(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("html") => "text/html; charset=utf-8",
+        Some("js") => "text/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("webmanifest") => "application/manifest+json; charset=utf-8",
+        Some("png") => "image/png",
+        Some("svg") => "image/svg+xml",
+        Some("ico") => "image/x-icon",
+        _ => "application/octet-stream",
     }
 }
 
@@ -6668,6 +6683,50 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn frontend_static_routes_set_content_type() {
+        let config = test_config();
+        tokio::fs::create_dir_all(&config.runtime.frontend_dist)
+            .await
+            .expect("create frontend dist");
+        tokio::fs::write(
+            config.runtime.frontend_dist.join("index.html"),
+            b"spa-index",
+        )
+        .await
+        .expect("write index");
+        tokio::fs::write(config.runtime.frontend_dist.join("manifest.json"), b"{}")
+            .await
+            .expect("write manifest");
+        tokio::fs::write(config.runtime.frontend_dist.join("icon-192.png"), b"png")
+            .await
+            .expect("write icon");
+
+        for (path, expected_content_type) in [
+            ("/", "text/html; charset=utf-8"),
+            ("/dashboard", "text/html; charset=utf-8"),
+            ("/manifest.json", "application/json; charset=utf-8"),
+            ("/icon-192.png", "image/png"),
+        ] {
+            let response = app(config.clone())
+                .oneshot(
+                    HttpRequest::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+            assert_eq!(
+                response.headers().get(header::CONTENT_TYPE).unwrap(),
+                expected_content_type,
+                "{path}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Let enrolled Cloudflare mTLS devices satisfy origin auth for normal Android app/API routes while keeping /deploy admin-only
- Remove Android Google sign-in/device-flow UX; enrollment now unlocks the app
- Treat 401/302/403 as Cloudflare/device-access failures instead of clearing JWT auth on Android

## Test Plan
- cargo test --manifest-path rust/office-automate-server/Cargo.toml auth::tests --quiet
- cargo test --manifest-path rust/office-automate-server/Cargo.toml http::tests::websocket_middleware_authenticated_user_receives_initial_status_immediately --quiet
- ./gradlew :app:assembleDebug
- ./gradlew :app:assembleRelease -x lintVitalAnalyzeRelease -x lintVitalReportRelease

Note: release lint-vital still hits existing Gradle verification metadata gaps for lint-only artifacts, so release APK packaging excludes those lint-vital tasks.