### PR TITLE
Fix presence transitions and session accounting

### DIFF
--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -359,7 +359,7 @@ impl Default for ThresholdsConfig {
     fn default() -> Self {
         Self {
             motion_timeout_seconds: 60,
-            departure_verification_seconds: 10,
+            departure_verification_seconds: 120,
             door_open_threshold_minutes: 5,
             door_open_away_timeout_minutes: 5,
             co2_critical_ppm: 2000,

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1035,20 +1035,41 @@ pub fn read_office_sessions(database_path: &Path, days: i64) -> Result<Value> {
     let connection = Connection::open(database_path)
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
     let now = Local::now().naive_local();
-    let cutoff = format_timestamp(now - Duration::days(days));
+    let cutoff_at = now - Duration::days(days);
+    let cutoff = format_timestamp(cutoff_at);
+    let previous = connection
+        .query_row(
+            "SELECT timestamp, state FROM occupancy_log WHERE timestamp <= ? ORDER BY timestamp DESC LIMIT 1",
+            params![&cutoff],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
     let rows = query_text_pairs(
         &connection,
         "SELECT timestamp, state FROM occupancy_log WHERE timestamp > ? ORDER BY timestamp ASC",
         &cutoff,
     )?;
 
-    let mut by_date: BTreeMap<String, Vec<(NaiveDateTime, String)>> = BTreeMap::new();
+    let mut transitions = Vec::new();
+    if let Some((_, state)) = previous {
+        transitions.push((cutoff_at, state));
+    }
     for (timestamp, state) in rows {
         if let Some(parsed) = parse_timestamp(&timestamp) {
-            by_date
-                .entry(parsed.date().to_string())
-                .or_default()
-                .push((parsed, state));
+            transitions.push((parsed, state));
+        }
+    }
+    transitions.sort_by_key(|(timestamp, _)| *timestamp);
+
+    let mut by_date: BTreeMap<NaiveDate, Vec<(NaiveDateTime, NaiveDateTime)>> = BTreeMap::new();
+    for index in 0..transitions.len() {
+        let (start, state) = &transitions[index];
+        let end = transitions
+            .get(index + 1)
+            .map(|(timestamp, _)| *timestamp)
+            .unwrap_or(now);
+        if state == "present" {
+            add_office_session_interval(&mut by_date, (*start).max(cutoff_at), end);
         }
     }
 
@@ -1056,51 +1077,45 @@ pub fn read_office_sessions(database_path: &Path, days: i64) -> Result<Value> {
     let mut arrival_minutes = Vec::new();
     let mut departure_minutes = Vec::new();
 
-    for (date, transitions) in by_date {
-        let Some(arrival) = transitions.iter().find_map(|(timestamp, state)| {
-            (state == "present" && timestamp.hour() >= 5).then_some(*timestamp)
-        }) else {
+    for (date, intervals) in by_date {
+        let Some((arrival, _)) = intervals.first().copied() else {
+            continue;
+        };
+        let Some((_, departure)) = intervals.last().copied() else {
             continue;
         };
 
-        let (mut departure, departure_state) = transitions
-            .last()
-            .map(|(timestamp, state)| (*timestamp, state.as_str()))
-            .expect("non-empty transitions");
-        if departure_state == "present" && arrival.date() == now.date() {
-            departure = now;
-        }
-
-        let mut duration_hours = (departure - arrival).num_seconds() as f64 / 3600.0;
+        let duration_hours = intervals
+            .iter()
+            .map(|(start, end)| (*end - *start).num_seconds().max(0) as f64 / 3600.0)
+            .sum::<f64>();
         let mut gaps = Vec::new();
-        let mut gap_start = None;
-        for (timestamp, state) in &transitions {
-            if *timestamp <= arrival || *timestamp > departure {
-                continue;
-            }
-            if state == "away" && gap_start.is_none() {
-                gap_start = Some(*timestamp);
-            } else if state == "present" {
-                if let Some(start) = gap_start.take() {
-                    let duration_min = (timestamp.signed_duration_since(start).num_seconds() as f64
-                        / 60.0)
-                        .round() as i64;
-                    if duration_min >= 2 {
-                        gaps.push(json!({
-                            "left": start.format("%H:%M:%S").to_string(),
-                            "returned": timestamp.format("%H:%M:%S").to_string(),
-                            "duration_min": duration_min,
-                        }));
-                        duration_hours -= duration_min as f64 / 60.0;
-                    }
-                }
+        for window in intervals.windows(2) {
+            let left = window[0].1;
+            let returned = window[1].0;
+            let duration_min =
+                (returned.signed_duration_since(left).num_seconds() as f64 / 60.0).round() as i64;
+            if duration_min >= 2 {
+                gaps.push(json!({
+                    "left": left.format("%H:%M:%S").to_string(),
+                    "returned": returned.format("%H:%M:%S").to_string(),
+                    "duration_min": duration_min,
+                }));
             }
         }
 
-        arrival_minutes.push((arrival.hour() * 60 + arrival.minute()) as f64);
-        departure_minutes.push((departure.hour() * 60 + departure.minute()) as f64);
+        let mut arrival_minute = (arrival.hour() * 60 + arrival.minute()) as f64;
+        if arrival.date() > date {
+            arrival_minute += 24.0 * 60.0;
+        }
+        arrival_minutes.push(arrival_minute);
+        let mut departure_minute = (departure.hour() * 60 + departure.minute()) as f64;
+        if departure.date() > date {
+            departure_minute += 24.0 * 60.0;
+        }
+        departure_minutes.push(departure_minute);
         sessions.push(json!({
-            "date": date,
+            "date": date.to_string(),
             "arrival": arrival.format("%H:%M:%S").to_string(),
             "departure": departure.format("%H:%M:%S").to_string(),
             "duration_hours": round1(duration_hours),
@@ -1136,6 +1151,41 @@ pub fn read_office_sessions(database_path: &Path, days: i64) -> Result<Value> {
     };
 
     Ok(json!({"sessions": sessions, "summary": summary}))
+}
+
+fn add_office_session_interval(
+    by_date: &mut BTreeMap<NaiveDate, Vec<(NaiveDateTime, NaiveDateTime)>>,
+    mut start: NaiveDateTime,
+    end: NaiveDateTime,
+) {
+    while start < end {
+        let boundary = next_office_day_boundary(start);
+        let segment_end = end.min(boundary);
+        by_date
+            .entry(office_session_date(start))
+            .or_default()
+            .push((start, segment_end));
+        start = segment_end;
+    }
+}
+
+fn office_session_date(timestamp: NaiveDateTime) -> NaiveDate {
+    if timestamp.hour() < 5 {
+        timestamp.date() - Duration::days(1)
+    } else {
+        timestamp.date()
+    }
+}
+
+fn next_office_day_boundary(timestamp: NaiveDateTime) -> NaiveDateTime {
+    let boundary_date = if timestamp.hour() < 5 {
+        timestamp.date()
+    } else {
+        timestamp.date() + Duration::days(1)
+    };
+    boundary_date
+        .and_hms_opt(5, 0, 0)
+        .expect("valid office day boundary")
 }
 
 pub fn read_co2_ohlc(database_path: &Path, hours: i64, bucket_minutes: i64) -> Result<Value> {
@@ -2050,7 +2100,7 @@ fn stddev(values: &[f64], average: f64) -> f64 {
 }
 
 fn minutes_to_time(minutes: f64) -> String {
-    let minutes = minutes as i64;
+    let minutes = (minutes as i64).rem_euclid(24 * 60);
     format!("{:02}:{:02}:00", minutes / 60, minutes % 60)
 }
 
@@ -2928,6 +2978,95 @@ mod tests {
         assert_eq!(history.occupancy_history[0]["state"], "present");
         assert_eq!(history.occupancy_history[0]["trigger"], "manual");
         assert_eq!(history.occupancy_history[0]["co2_ppm"], 500);
+    }
+
+    #[test]
+    fn office_sessions_sum_present_intervals_across_midnight() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let session_date = Local::now().naive_local().date() - Duration::days(2);
+        let next_date = session_date + Duration::days(1);
+        let rows = [
+            (
+                format!("{} 18:00:00", session_date.format("%Y-%m-%d")),
+                "present",
+            ),
+            (
+                format!("{} 19:00:00", session_date.format("%Y-%m-%d")),
+                "away",
+            ),
+            (
+                format!("{} 20:00:00", session_date.format("%Y-%m-%d")),
+                "present",
+            ),
+            (format!("{} 00:30:00", next_date.format("%Y-%m-%d")), "away"),
+        ];
+        let connection = Connection::open(&db_path).expect("open database");
+        for (timestamp, state) in rows {
+            connection
+                .execute(
+                    "INSERT INTO occupancy_log (timestamp, state) VALUES (?, ?)",
+                    params![timestamp, state],
+                )
+                .expect("insert occupancy row");
+        }
+
+        let payload = read_office_sessions(&db_path, 7).expect("sessions");
+        let sessions = payload["sessions"].as_array().expect("sessions array");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["date"], session_date.to_string());
+        assert_eq!(sessions[0]["arrival"], "18:00:00");
+        assert_eq!(sessions[0]["departure"], "00:30:00");
+        assert_eq!(sessions[0]["duration_hours"], 5.5);
+        assert_eq!(sessions[0]["gaps"][0]["duration_min"], 60);
+        assert_eq!(payload["summary"]["avg_departure"], "00:30:00");
+        assert_eq!(payload["summary"]["avg_duration_hours"], 5.5);
+        assert_eq!(payload["summary"]["total_hours_week"], 5.5);
+    }
+
+    #[test]
+    fn office_sessions_normalize_pre_dawn_arrivals_for_summary() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let first_date = Local::now().naive_local().date() - Duration::days(4);
+        let second_date = first_date + Duration::days(1);
+        let third_date = second_date + Duration::days(1);
+        let rows = [
+            (
+                format!("{} 23:00:00", first_date.format("%Y-%m-%d")),
+                "present",
+            ),
+            (
+                format!("{} 23:30:00", first_date.format("%Y-%m-%d")),
+                "away",
+            ),
+            (
+                format!("{} 02:00:00", third_date.format("%Y-%m-%d")),
+                "present",
+            ),
+            (
+                format!("{} 02:30:00", third_date.format("%Y-%m-%d")),
+                "away",
+            ),
+        ];
+        let connection = Connection::open(&db_path).expect("open database");
+        for (timestamp, state) in rows {
+            connection
+                .execute(
+                    "INSERT INTO occupancy_log (timestamp, state) VALUES (?, ?)",
+                    params![timestamp, state],
+                )
+                .expect("insert occupancy row");
+        }
+
+        let payload = read_office_sessions(&db_path, 7).expect("sessions");
+
+        assert_eq!(payload["summary"]["avg_arrival"], "00:30:00");
     }
 
     #[test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -659,7 +659,7 @@ fn door_grace_policy_delay(state: &AppState) -> Option<Duration> {
         }
         let deadline = state_status.sensors.door_closed_at
             + state.config.thresholds.erv_door_close_grace_seconds as f64;
-        return (deadline > now).then_some(Duration::from_secs_f64(deadline - now));
+        return (deadline > now).then(|| Duration::from_secs_f64(deadline - now));
     }
 
     if state_status.sensors.door_opened_at <= 0.0 {
@@ -2041,14 +2041,17 @@ fn status_for_state(state: &AppState) -> Status {
     let mut status =
         Status::read_only_with_temperature_bands(&state.config, active_temperature_bands(state));
     let now = unix_timestamp_now();
-    let state_status = {
+    let (state_status, timer_transition) = {
         let mut machine = state
             .state_machine
             .write()
             .expect("state machine lock poisoned");
-        machine.advance_timers(now);
-        machine.status_at(now)
+        let transition = machine.advance_timers(now);
+        (machine.status_at(now), transition)
     };
+    if let Err(error) = log_state_transition(state, timer_transition, "internal_presence") {
+        tracing::warn!("failed to persist timer-driven status transition: {error:#}");
+    }
 
     status.state = state_status.state;
     status.is_present = state_status.is_present;
@@ -3558,6 +3561,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn door_grace_policy_delay_handles_expired_closed_away_deadline() {
+        let mut config = test_config();
+        configure_fake_erv(&mut config);
+        config.thresholds.erv_door_close_grace_seconds = 30;
+        let closed_at = unix_timestamp_now() - 60.0;
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            closed_at - 10.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state lock");
+            machine.update_door(true, closed_at - 5.0);
+            machine.update_door(false, closed_at);
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        let (_router, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app");
+
+        assert!(door_grace_policy_delay(&state).is_none());
+    }
+
+    #[tokio::test]
     async fn status_route_returns_compatibility_skeleton() {
         let response = app(test_config())
             .oneshot(
@@ -3582,6 +3618,55 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn status_route_persists_timer_driven_departure_transition() {
+        let mut config = test_config();
+        config.thresholds.departure_verification_seconds = 10;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+            &config.thresholds,
+            now - 100.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state lock");
+            machine.set_manual_presence(true, now - 40.0);
+            machine.update_door(true, now - 30.0);
+            machine.update_motion(false, now - 21.0);
+            machine.update_door(false, now - 20.0);
+            assert!(machine.verifying_departure());
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        let (router, _state) = try_app_with_erv_writer_and_coordinator(
+            config.clone(),
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app");
+
+        let response = router
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let history = db::read_history(&config.runtime.database_path, 1, 10).expect("history");
+        assert_eq!(history.occupancy_history.len(), 1);
+        assert_eq!(history.occupancy_history[0]["state"], "away");
+        assert_eq!(history.occupancy_history[0]["trigger"], "internal_presence");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -45,7 +45,7 @@ impl Default for StateConfig {
     fn default() -> Self {
         Self {
             motion_timeout_seconds: 60.0,
-            departure_verification_seconds: 10.0,
+            departure_verification_seconds: 120.0,
             door_open_threshold_minutes: 5.0,
             door_open_away_timeout_minutes: 5.0,
             co2_critical_ppm: 2000,
@@ -260,22 +260,22 @@ impl StateMachine {
         external_monitor: bool,
         now: f64,
     ) -> Option<StateTransition> {
-        let timer_transition = self.advance_timers(now);
-
         self.sensors.external_monitor = external_monitor;
         self.sensors.mac_last_active = last_active_timestamp;
         self.sensors.last_updated = now;
 
-        if last_active_timestamp > self.sensors.door_last_changed && self.verifying_departure() {
+        if external_monitor
+            && last_active_timestamp > self.sensors.door_last_changed
+            && self.verifying_departure()
+        {
             self.cancel_departure_verification();
         }
 
+        let timer_transition = self.advance_timers(now);
         self.evaluate_at(now).or(timer_transition)
     }
 
     pub fn update_motion(&mut self, detected: bool, now: f64) -> Option<StateTransition> {
-        let timer_transition = self.advance_timers(now);
-
         self.sensors.motion_detected = detected;
         if detected {
             self.sensors.motion_last_seen = now;
@@ -286,6 +286,7 @@ impl StateMachine {
         }
         self.sensors.last_updated = now;
 
+        let timer_transition = self.advance_timers(now);
         self.evaluate_at(now).or(timer_transition)
     }
 
@@ -310,7 +311,11 @@ impl StateMachine {
             self.suppress_next_door_close_departure = false;
         } else if was_open == Some(true) && !is_open {
             self.cancel_door_open_away_timer();
-            self.start_departure_verification(now);
+            if self.presence_signal_active_at(now) {
+                self.cancel_departure_verification();
+            } else {
+                self.start_departure_verification(now);
+            }
         }
 
         timer_transition.or_else(|| self.evaluate_at(now))
@@ -446,6 +451,13 @@ impl StateMachine {
 mod tests {
     use super::*;
 
+    fn fast_departure_config() -> StateConfig {
+        StateConfig {
+            departure_verification_seconds: 10.0,
+            ..StateConfig::default()
+        }
+    }
+
     #[test]
     fn mac_activity_after_door_event_transitions_to_present() {
         let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
@@ -483,10 +495,45 @@ mod tests {
     }
 
     #[test]
-    fn departure_verification_expires_to_away_and_resets_motion() {
+    fn active_motion_before_door_close_does_not_count_as_inside_presence() {
         let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+
+        machine.update_door(true, 1_010.0);
+        assert_eq!(machine.update_motion(true, 1_012.0), None);
+
+        let transition = machine.update_door(false, 1_020.0);
+
+        assert_eq!(transition, None);
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn motion_after_door_close_counts_as_inside_presence() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(true, 1_012.0);
+        machine.update_door(false, 1_020.0);
+
+        let transition = machine.update_motion(true, 1_021.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Present);
+    }
+
+    #[test]
+    fn departure_verification_expires_to_away_and_resets_motion() {
+        let mut machine = StateMachine::new(fast_departure_config(), 1_000.0);
         machine.set_manual_presence(true, 1_001.0);
         machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
         machine.update_door(false, 1_020.0);
 
         assert!(machine.verifying_departure());
@@ -511,8 +558,10 @@ mod tests {
         let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
         machine.set_manual_presence(true, 1_001.0);
         machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
         machine.update_door(false, 1_020.0);
 
+        assert!(machine.verifying_departure());
         machine.update_mac_occupancy(1_021.0, true, 1_022.0);
 
         assert!(!machine.verifying_departure());
@@ -521,14 +570,84 @@ mod tests {
     }
 
     #[test]
-    fn fresh_mac_update_after_departure_timer_restores_present() {
+    fn fresh_mac_update_after_departure_deadline_cancels_before_away() {
+        let mut machine = StateMachine::new(fast_departure_config(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        let transition = machine.update_mac_occupancy(1_031.0, true, 1_031.0);
+
+        assert_eq!(transition, None);
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn mac_update_without_external_monitor_does_not_cancel_departure_verification() {
+        let mut machine = StateMachine::new(fast_departure_config(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        let transition = machine.update_mac_occupancy(1_031.0, false, 1_031.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn door_close_with_only_stale_active_motion_starts_departure_verification() {
         let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
         machine.set_manual_presence(true, 1_001.0);
         machine.update_door(true, 1_010.0);
+        machine.update_motion(true, 1_012.0);
+
+        let transition = machine.update_door(false, 1_020.0);
+
+        assert_eq!(transition, None);
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(machine.verifying_departure());
+    }
+
+    #[test]
+    fn motion_after_door_close_cancels_departure_verification() {
+        let mut machine = StateMachine::new(StateConfig::default(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(true, 1_012.0);
         machine.update_door(false, 1_020.0);
 
-        machine.update_mac_occupancy(1_031.0, true, 1_031.0);
+        assert!(machine.verifying_departure());
+        assert_eq!(machine.update_motion(true, 1_021.0), None);
+        assert!(!machine.verifying_departure());
+        assert_eq!(machine.advance_timers(1_040.0), None);
+        assert_eq!(machine.state, OccupancyState::Present);
+    }
 
+    #[test]
+    fn fresh_motion_after_departure_deadline_cancels_before_away() {
+        let mut machine = StateMachine::new(fast_departure_config(), 1_000.0);
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        let transition = machine.update_motion(true, 1_031.0);
+
+        assert_eq!(transition, None);
         assert_eq!(machine.state, OccupancyState::Present);
         assert!(!machine.verifying_departure());
     }

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -281,6 +281,12 @@ impl YoLinkState {
             }
         };
 
+        if let Err(error) = self.log_occupancy_transition(transition) {
+            tracing::warn!(
+                "failed to persist YoLink occupancy transition after state update: {error:#}"
+            );
+        }
+
         if let Err(error) = db::log_device_event(
             &self.database_path,
             device_type,
@@ -300,6 +306,25 @@ impl YoLinkState {
             device_name: validated.device_name,
             transition,
         }))
+    }
+
+    fn log_occupancy_transition(&self, transition: Option<StateTransition>) -> Result<()> {
+        let Some(transition) = transition else {
+            return Ok(());
+        };
+        let co2_ppm = self
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned")
+            .sensors
+            .co2_ppm;
+        db::log_occupancy_change(
+            &self.database_path,
+            transition.new_state.as_str(),
+            Some("yolink"),
+            Some(co2_ppm),
+            Some(&json!({"old_state": transition.old_state.as_str()})),
+        )
     }
 
     fn validate_event(
@@ -1338,6 +1363,37 @@ mod tests {
             db::get_latest_device_state(&db_path, "motion").expect("motion state"),
             Some("detected".to_string())
         );
+    }
+
+    #[test]
+    fn persists_yolink_occupancy_transitions() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let yolink = test_state(db_path.clone());
+        yolink.apply_devices(sample_devices());
+
+        yolink
+            .apply_event("door-1", json!({"state": "open"}), 1_010.0)
+            .expect("door open")
+            .expect("applied");
+        yolink
+            .apply_event("motion-1", json!({"state": "alert"}), 1_012.0)
+            .expect("motion detected")
+            .expect("applied");
+        yolink
+            .apply_event("door-1", json!({"state": "closed"}), 1_020.0)
+            .expect("door closed")
+            .expect("applied");
+        yolink
+            .apply_event("motion-1", json!({"state": "alert"}), 1_021.0)
+            .expect("motion detected after close")
+            .expect("applied");
+
+        let history = db::read_history(&db_path, 24, 10).expect("history");
+        assert_eq!(history.occupancy_history.len(), 1);
+        assert_eq!(history.occupancy_history[0]["state"], "present");
+        assert_eq!(history.occupancy_history[0]["trigger"], "yolink");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat only post-door-close motion or Mac activity as true inside presence.
- Delay departure verification to human-scale timing and process fresh activity before timers can expire.
- Persist YoLink occupancy transitions immediately and repair office-session aggregation to sum actual present intervals across office days.
- Guard expired door-grace duration calculation from negative Duration panics.

## Validation
- cargo test --manifest-path rust/office-automate-server/Cargo.toml --lib

## Notes
- Replayed local SQLite occupancy history separately from this PR using raw YoLink events. That DB repair is not part of the tracked code changes.
