### PR TITLE
Add room mode status scaffold

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,15 @@ qingping:
   mqtt_password: "replace-with-random-device-password"
   device_mac: "AA:BB:CC:DD:EE:FF"
 
+# Room operating mode. Defaults preserve normal office behavior. During
+# renovation, keep raw telemetry flowing but mark moved sensors as untrusted and
+# disable automated climate writes.
+room_mode:
+  renovation: false
+  climate_automation_enabled: true
+  contact_sensors_enabled: true
+  air_quality_sensors_enabled: true
+
 # Android artifact upload hardening. Set this to the SHA-256 digest of the
 # office-climate release signing certificate. The deploy endpoint rejects APKs
 # signed by any other cert when this is configured.

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -457,6 +457,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
+    pub room_mode: RoomModeConfig,
     pub presence: PresenceConfig,
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
@@ -19,6 +20,26 @@ pub struct AppConfig {
     pub thresholds: ThresholdsConfig,
     pub telemetry: TelemetryConfig,
     pub runtime: RuntimeConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RoomModeConfig {
+    pub renovation: bool,
+    pub climate_automation_enabled: bool,
+    pub contact_sensors_enabled: bool,
+    pub air_quality_sensors_enabled: bool,
+}
+
+impl Default for RoomModeConfig {
+    fn default() -> Self {
+        Self {
+            renovation: false,
+            climate_automation_enabled: true,
+            contact_sensors_enabled: true,
+            air_quality_sensors_enabled: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -430,6 +451,7 @@ pub struct RuntimeConfig {
 #[serde(default)]
 struct FileConfig {
     orchestrator: OrchestratorConfig,
+    room_mode: RoomModeConfig,
     presence: PresenceConfig,
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
@@ -604,6 +626,26 @@ impl AppConfig {
             file_config.cloudflare_access.api_base_url = api_base_url;
         }
 
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_RENOVATION_MODE") {
+            file_config.room_mode.renovation =
+                parse_bool_env("OFFICE_AUTOMATE_RENOVATION_MODE", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED") {
+            file_config.room_mode.climate_automation_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED") {
+            file_config.room_mode.contact_sensors_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED") {
+            file_config.room_mode.air_quality_sensors_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED", &enabled)?;
+        }
+
         if let Some(admin_emails) = env_lookup("OFFICE_AUTOMATE_ADMIN_EMAILS") {
             file_config.orchestrator.admin_emails = admin_emails
                 .split(',')
@@ -732,6 +774,7 @@ impl AppConfig {
 
         Ok(Self {
             orchestrator: file_config.orchestrator,
+            room_mode: file_config.room_mode,
             presence: file_config.presence,
             qingping: file_config.qingping,
             yolink: file_config.yolink,
@@ -795,6 +838,11 @@ orchestrator:
   port: 9001
 presence:
   poll_interval_seconds: 7
+room_mode:
+  renovation: false
+  climate_automation_enabled: true
+  contact_sensors_enabled: true
+  air_quality_sensors_enabled: true
 telemetry:
   repos:
     - "/yaml/repo"
@@ -843,6 +891,10 @@ thresholds:
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
             "OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_RENOVATION_MODE" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED" => Some("false".to_string()),
+            "OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED" => Some("false".to_string()),
+            "OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED" => Some("false".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS" => Some("3".to_string()),
             "OFFICE_AUTOMATE_TELEMETRY_REPOS" => Some("/env/repo-a,/env/repo-b".to_string()),
@@ -896,6 +948,10 @@ thresholds:
 
         assert_eq!(config.orchestrator.host, "127.0.0.1");
         assert_eq!(config.orchestrator.port, 9001);
+        assert!(config.room_mode.renovation);
+        assert!(!config.room_mode.climate_automation_enabled);
+        assert!(!config.room_mode.contact_sensors_enabled);
+        assert!(!config.room_mode.air_quality_sensors_enabled);
         assert!(config.presence.enabled);
         assert_eq!(config.presence.poll_interval_seconds, 7);
         assert_eq!(config.presence.command_timeout_seconds, 3);

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1391,6 +1391,7 @@ mod tests {
     fn app_config(erv: ErvConfig) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -3007,6 +3007,7 @@ mod tests {
         let root = temp_dir.keep();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -907,6 +907,7 @@ mod tests {
 
         let mut status = Status::read_only_default(&crate::config::AppConfig {
             orchestrator: crate::config::OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: crate::config::QingpingConfig::default(),
             yolink: crate::config::YoLinkConfig::default(),

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -880,6 +880,7 @@ mod tests {
     fn test_config(root: &Path, config_path: PathBuf, database_path: PathBuf) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/qingping.rs
+++ b/rust/office-automate-server/src/qingping.rs
@@ -70,7 +70,9 @@ impl QingpingState {
         status.air_quality.noise_db = reading.noise_db.map(|value| value as f64);
         status.air_quality.last_update = Some(reading.timestamp);
 
-        if let Some(co2_ppm) = status.air_quality.co2_ppm {
+        if status.air_quality.trusted_office_reading
+            && let Some(co2_ppm) = status.air_quality.co2_ppm
+        {
             status.sensors.co2_ppm = co2_ppm;
         }
     }
@@ -390,6 +392,7 @@ mod tests {
             erv_should_run: false,
             verifying_departure: false,
             in_door_open_mode: false,
+            room_mode: crate::status::RoomModeStatus::default(),
             sensors: crate::status::SensorsStatus::default(),
             air_quality: crate::status::AirQualityStatus::default(),
             erv: crate::status::ErvStatus::default(),
@@ -404,6 +407,61 @@ mod tests {
         state.mark_interval_configured();
         state.overlay_status(&mut status);
         assert!(status.air_quality.interval_configured);
+    }
+
+    #[test]
+    fn ignored_air_quality_does_not_overwrite_trusted_sensor_co2() {
+        let state = QingpingState::default();
+        state.apply_reading(QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(900),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: "2026-06-22T07:30:00".to_string(),
+            raw_data: "{}".to_string(),
+        });
+        let mut status = Status {
+            state: "away".to_string(),
+            is_present: false,
+            presence_signal_active: false,
+            safety_interlock: false,
+            erv_should_run: false,
+            verifying_departure: false,
+            in_door_open_mode: false,
+            room_mode: crate::status::RoomModeStatus {
+                renovation: true,
+                climate_automation_enabled: false,
+                contact_sensors_enabled: false,
+                air_quality_sensors_enabled: false,
+            },
+            sensors: crate::status::SensorsStatus {
+                co2_ppm: 400,
+                air_quality_sensors_enabled: false,
+                air_quality_sensors_ignored: true,
+                ..crate::status::SensorsStatus::default()
+            },
+            air_quality: crate::status::AirQualityStatus {
+                trusted_office_reading: false,
+                ignored_reason: Some("renovation_air_quality_sensor_moved".to_string()),
+                ..crate::status::AirQualityStatus::default()
+            },
+            erv: crate::status::ErvStatus::default(),
+            hvac: crate::status::HvacStatus::default(),
+            manual_override: crate::status::ManualOverrideStatus::default(),
+            notifications: Vec::new(),
+        };
+
+        state.overlay_status(&mut status);
+
+        assert_eq!(status.air_quality.co2_ppm, Some(900));
+        assert_eq!(status.air_quality.temp_c, Some(22.5));
+        assert!(!status.air_quality.trusted_office_reading);
+        assert_eq!(status.sensors.co2_ppm, 400);
     }
 
     #[test]

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -11,6 +11,7 @@ pub struct Status {
     pub erv_should_run: bool,
     pub verifying_departure: bool,
     pub in_door_open_mode: bool,
+    pub room_mode: RoomModeStatus,
     pub sensors: SensorsStatus,
     pub air_quality: AirQualityStatus,
     pub erv: ErvStatus,
@@ -28,7 +29,20 @@ impl Status {
         config: &AppConfig,
         temperature_bands: TemperatureBands,
     ) -> Self {
-        let sensors = SensorsStatus::default();
+        let sensors = SensorsStatus {
+            contact_sensors_enabled: config.room_mode.contact_sensors_enabled,
+            contact_sensors_ignored: !config.room_mode.contact_sensors_enabled,
+            air_quality_sensors_enabled: config.room_mode.air_quality_sensors_enabled,
+            air_quality_sensors_ignored: !config.room_mode.air_quality_sensors_enabled,
+            ..SensorsStatus::default()
+        };
+        let air_quality = AirQualityStatus {
+            report_interval: config.qingping.report_interval,
+            trusted_office_reading: config.room_mode.air_quality_sensors_enabled,
+            ignored_reason: (!config.room_mode.air_quality_sensors_enabled)
+                .then(|| "renovation_air_quality_sensor_moved".to_string()),
+            ..AirQualityStatus::default()
+        };
 
         Self {
             state: "away".to_string(),
@@ -38,11 +52,9 @@ impl Status {
             erv_should_run: sensors.co2_ppm > config.thresholds.co2_refresh_target_ppm,
             verifying_departure: false,
             in_door_open_mode: false,
+            room_mode: RoomModeStatus::from_config(config),
             sensors,
-            air_quality: AirQualityStatus {
-                report_interval: config.qingping.report_interval,
-                ..AirQualityStatus::default()
-            },
+            air_quality,
             erv: ErvStatus {
                 away_stale_flush_enabled: config.thresholds.away_stale_flush_enabled,
                 ..ErvStatus::default()
@@ -58,6 +70,36 @@ impl Status {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomModeStatus {
+    pub renovation: bool,
+    pub climate_automation_enabled: bool,
+    pub contact_sensors_enabled: bool,
+    pub air_quality_sensors_enabled: bool,
+}
+
+impl RoomModeStatus {
+    fn from_config(config: &AppConfig) -> Self {
+        Self {
+            renovation: config.room_mode.renovation,
+            climate_automation_enabled: config.room_mode.climate_automation_enabled,
+            contact_sensors_enabled: config.room_mode.contact_sensors_enabled,
+            air_quality_sensors_enabled: config.room_mode.air_quality_sensors_enabled,
+        }
+    }
+}
+
+impl Default for RoomModeStatus {
+    fn default() -> Self {
+        Self {
+            renovation: false,
+            climate_automation_enabled: true,
+            contact_sensors_enabled: true,
+            air_quality_sensors_enabled: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SensorsStatus {
     pub mac_last_active: f64,
@@ -68,6 +110,10 @@ pub struct SensorsStatus {
     pub door_last_changed: f64,
     pub window_open: bool,
     pub co2_ppm: i64,
+    pub contact_sensors_enabled: bool,
+    pub contact_sensors_ignored: bool,
+    pub air_quality_sensors_enabled: bool,
+    pub air_quality_sensors_ignored: bool,
 }
 
 impl Default for SensorsStatus {
@@ -81,6 +127,10 @@ impl Default for SensorsStatus {
             door_last_changed: 0.0,
             window_open: false,
             co2_ppm: 400,
+            contact_sensors_enabled: true,
+            contact_sensors_ignored: false,
+            air_quality_sensors_enabled: true,
+            air_quality_sensors_ignored: false,
         }
     }
 }
@@ -97,6 +147,8 @@ pub struct AirQualityStatus {
     pub last_update: Option<String>,
     pub report_interval: u64,
     pub interval_configured: bool,
+    pub trusted_office_reading: bool,
+    pub ignored_reason: Option<String>,
 }
 
 impl Default for AirQualityStatus {
@@ -112,6 +164,8 @@ impl Default for AirQualityStatus {
             last_update: None,
             report_interval: 60,
             interval_configured: false,
+            trusted_office_reading: true,
+            ignored_reason: None,
         }
     }
 }
@@ -243,12 +297,13 @@ mod tests {
     use super::*;
     use crate::config::{
         ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-        RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
+        RoomModeConfig, RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig {
                 report_interval: 45,
@@ -302,6 +357,7 @@ mod tests {
             "erv_should_run",
             "verifying_departure",
             "in_door_open_mode",
+            "room_mode",
             "sensors",
             "air_quality",
             "erv",
@@ -316,8 +372,16 @@ mod tests {
         assert_eq!(value["sensors"]["mac_last_active"], 0.0);
         assert_eq!(value["sensors"]["mac_active"], false);
         assert_eq!(value["sensors"]["co2_ppm"], 400);
+        assert_eq!(value["room_mode"]["renovation"], false);
+        assert_eq!(value["room_mode"]["climate_automation_enabled"], true);
+        assert_eq!(value["sensors"]["contact_sensors_enabled"], true);
+        assert_eq!(value["sensors"]["contact_sensors_ignored"], false);
+        assert_eq!(value["sensors"]["air_quality_sensors_enabled"], true);
+        assert_eq!(value["sensors"]["air_quality_sensors_ignored"], false);
         assert_eq!(value["air_quality"]["report_interval"], 45);
         assert_eq!(value["air_quality"]["interval_configured"], false);
+        assert_eq!(value["air_quality"]["trusted_office_reading"], true);
+        assert!(value["air_quality"]["ignored_reason"].is_null());
         assert_eq!(value["erv"]["speed"], "off");
         assert_eq!(value["erv"]["away_stale_flush_enabled"], false);
         assert!(value["erv"]["control"]["last_ok_at"].is_null());

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -3404,6 +3404,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -951,6 +951,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),


### PR DESCRIPTION
## Summary
Add the shared renovation room-mode contract without changing runtime behavior:

- Add `RoomModeConfig` with default-safe trust and automation flags.
- Expose `room_mode`, contact-sensor trust flags, and air-quality trust flags in status serialization.
- Document the config block in `config.example.yaml`.
- Update test fixtures for the new config field.

## Spec Reference
`docs/working/147_renovation_mode.md`

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `git diff --check`

Refs #147