### PR TITLE
Implement contact sensor trust mode

### DIFF
--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -16,6 +16,8 @@ use sha2::{Digest, Sha256};
 use crate::{config::AppConfig, qingping::QingpingReading};
 
 pub const DEVICE_PAIRING_MAX_FAILED_ATTEMPTS: i64 = 5;
+const TRUSTED_CONTACT_EVENT_FILTER: &str =
+    "(details IS NULL OR COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0)";
 
 const SESSION_OUTPUT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS session_output (
@@ -1263,15 +1265,26 @@ pub fn read_daily_stats(database_path: &Path, days: i64) -> Result<Vec<Value>> {
     let labels = day_labels(now.date(), days);
 
     let mut door_counts = HashMap::new();
-    let mut statement = connection.prepare(
-        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type = 'door' GROUP BY date(timestamp)",
-    )?;
+    let mut statement = connection.prepare(&format!(
+        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type = 'door' AND {TRUSTED_CONTACT_EVENT_FILTER} GROUP BY date(timestamp)",
+    ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
     })?;
     for row in rows {
         let (date, count) = row?;
         door_counts.insert(date, count);
+    }
+    let mut ignored_contact_counts = HashMap::new();
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type IN ('door', 'window') AND json_extract(details, '$.contact_sensor_trusted') = 0 GROUP BY date(timestamp)",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (date, count) = row?;
+        ignored_contact_counts.insert(date, count);
     }
 
     let presence = durations_from_state_table(
@@ -1314,6 +1327,7 @@ pub fn read_daily_stats(database_path: &Path, days: i64) -> Result<Vec<Value>> {
             json!({
                 "date": date,
                 "door_events": door_counts.get(&date).copied().unwrap_or_default(),
+                "ignored_contact_events": ignored_contact_counts.get(&date).copied().unwrap_or_default(),
                 "erv_runtime_min": erv.get(&date).copied().unwrap_or_default().round() as i64,
                 "hvac_runtime_min": hvac.get(&date).copied().unwrap_or_default().round() as i64,
                 "presence_hours": round1(presence.get(&date).copied().unwrap_or_default()),
@@ -1475,7 +1489,9 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
     for device_type in ["door", "window"] {
         let last_before: Option<String> = connection
             .query_row(
-                "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? ORDER BY timestamp DESC LIMIT 1",
+                &format!(
+                    "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp DESC, id DESC LIMIT 1"
+                ),
                 params![cutoff, device_type],
                 |row| row.get(0),
             )
@@ -1483,7 +1499,9 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
         let mut open_start = (last_before.as_deref() == Some("open")).then_some(start);
 
         let mut statement = connection.prepare(
-            "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? ORDER BY timestamp ASC",
+            &format!(
+                "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp ASC, id ASC"
+            ),
         )?;
         let rows = statement.query_map(params![cutoff, device_type], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -2007,6 +2025,7 @@ pub fn get_latest_contact_device_state_with_timestamp(
             SELECT event, timestamp FROM device_events
             WHERE device_type = ?
               AND event IN ('open', 'closed')
+              AND (details IS NULL OR COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0)
             ORDER BY timestamp DESC, id DESC
             LIMIT 1
             "#,
@@ -3190,5 +3209,138 @@ mod tests {
             )
             .expect("read details");
         assert_eq!(details, Some(r#"{"state":"open"}"#.to_string()));
+    }
+
+    #[test]
+    fn latest_contact_state_ignores_untrusted_contact_events() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        log_device_event(
+            &db_path,
+            "door",
+            "closed",
+            Some("Office Door"),
+            Some(&serde_json::json!({
+                "state": "closed",
+                "contact_sensor_trusted": true,
+            })),
+        )
+        .expect("log trusted closed");
+        log_device_event(
+            &db_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&serde_json::json!({
+                "state": "open",
+                "contact_sensor_trusted": false,
+                "ignored_reason": "renovation_contact_sensors_disabled",
+            })),
+        )
+        .expect("log ignored open");
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                UPDATE device_events
+                SET timestamp = CASE event
+                    WHEN 'closed' THEN '2026-06-01 12:00:00'
+                    WHEN 'open' THEN '2026-06-01 13:00:00'
+                END
+                WHERE device_type = 'door'
+                "#,
+                [],
+            )
+            .expect("update timestamps");
+
+        assert_eq!(
+            get_latest_device_state(&db_path, "door").expect("latest raw"),
+            Some("open".to_string())
+        );
+        assert_eq!(
+            get_latest_contact_device_state(&db_path, "door").expect("latest trusted contact"),
+            Some("closed".to_string())
+        );
+    }
+
+    #[test]
+    fn daily_stats_separates_ignored_contact_events() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let today = Local::now().naive_local().date();
+        let trusted_timestamp = format_timestamp(day_start(today) + Duration::hours(9));
+        let ignored_timestamp = format_timestamp(day_start(today) + Duration::hours(10));
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+                VALUES (?, 'door', 'Office Door', 'closed', ?),
+                       (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'window', 'Office Window', 'open', ?)
+                "#,
+                params![
+                    trusted_timestamp,
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": true})
+                        .to_string(),
+                    ignored_timestamp,
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                    ignored_timestamp,
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                ],
+            )
+            .expect("insert contact events");
+
+        let stats = read_daily_stats(&db_path, 1).expect("daily stats");
+
+        assert_eq!(stats[0]["date"], today.to_string());
+        assert_eq!(stats[0]["door_events"], 1);
+        assert_eq!(stats[0]["ignored_contact_events"], 2);
+    }
+
+    #[test]
+    fn openings_exclude_ignored_contact_intervals() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let today = Local::now().naive_local().date();
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+                VALUES (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'door', 'Office Door', 'closed', ?),
+                       (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'door', 'Office Door', 'closed', ?)
+                "#,
+                params![
+                    format_timestamp(day_start(today) + Duration::hours(9)),
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(10)),
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": false})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(11)),
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": true})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(12)),
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": true})
+                        .to_string(),
+                ],
+            )
+            .expect("insert openings");
+
+        let openings = read_openings(&db_path, 1).expect("openings");
+        let door = openings[0]["door"].as_array().expect("door openings");
+
+        assert_eq!(door.len(), 1);
+        assert_eq!(door[0]["open"], "11:00:00");
+        assert_eq!(door[0]["close"], "12:00:00");
     }
 }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -266,8 +266,9 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
 }
 
 fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<Router> {
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
@@ -533,8 +534,9 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         .await
         .with_context(|| format!("failed to bind HTTP listener at {bind_address}"))?;
     let qingping = QingpingState::default();
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
@@ -642,6 +644,10 @@ fn start_door_grace_policy_poll(
 }
 
 fn door_grace_policy_delay(state: &AppState) -> Option<Duration> {
+    if !state.config.room_mode.contact_sensors_enabled {
+        return None;
+    }
+
     let now = unix_timestamp_now();
     let state_status = {
         let machine = state
@@ -3521,6 +3527,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn door_grace_policy_delay_stays_idle_when_contact_sensors_are_disabled() {
+        let mut config = test_config();
+        configure_fake_erv(&mut config);
+        config.room_mode.contact_sensors_enabled = false;
+        config.mitsubishi.active_control_enabled = true;
+        let opened_at = unix_timestamp_now() - 30.0;
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            opened_at - 1.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state lock");
+            machine.sensors.door_open = true;
+            machine.sensors.door_opened_at = opened_at;
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let (_router, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            erv_writer.clone(),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app");
+        state
+            .erv
+            .set_speed_with(
+                &state.config.erv,
+                erv_writer.as_ref(),
+                ErvFanSpeed::Turbo,
+                "test",
+                None,
+            )
+            .await
+            .expect("set ERV active");
+        state
+            .hvac
+            .record_status(hvac_status(HvacControlMode::Heat, 22.0));
+
+        assert!(door_grace_policy_delay(&state).is_none());
+    }
+
+    #[tokio::test]
     async fn door_grace_policy_delay_schedules_closed_away_restart_deadline() {
         let mut config = test_config();
         configure_fake_erv(&mut config);
@@ -3619,6 +3678,59 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn startup_restore_skips_contacts_when_contact_sensors_are_disabled() {
+        let mut config = test_config();
+        config.room_mode.contact_sensors_enabled = false;
+        db::migrate_database(&config.runtime.database_path).expect("migration");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log door");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "window",
+            "open",
+            Some("Office Window"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log window");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "motion",
+            "detected",
+            Some("Office Motion"),
+            None,
+        )
+        .expect("log motion");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["is_present"], true);
+        assert_eq!(value["sensors"]["motion_detected"], true);
+        assert_eq!(value["sensors"]["door_open"], false);
+        assert_eq!(value["sensors"]["window_open"], false);
+        assert_eq!(value["sensors"]["contact_sensors_enabled"], false);
+        assert_eq!(value["sensors"]["contact_sensors_ignored"], true);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::config::ThresholdsConfig;
+use crate::config::{RoomModeConfig, ThresholdsConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -26,10 +26,18 @@ pub struct StateConfig {
     pub door_open_away_timeout_minutes: f64,
     pub co2_critical_ppm: i64,
     pub co2_refresh_target_ppm: i64,
+    pub contact_sensors_enabled: bool,
 }
 
 impl StateConfig {
     pub fn from_thresholds(thresholds: &ThresholdsConfig) -> Self {
+        Self::from_thresholds_and_room_mode(thresholds, &RoomModeConfig::default())
+    }
+
+    pub fn from_thresholds_and_room_mode(
+        thresholds: &ThresholdsConfig,
+        room_mode: &RoomModeConfig,
+    ) -> Self {
         Self {
             motion_timeout_seconds: thresholds.motion_timeout_seconds as f64,
             departure_verification_seconds: thresholds.departure_verification_seconds as f64,
@@ -37,6 +45,7 @@ impl StateConfig {
             door_open_away_timeout_minutes: thresholds.door_open_away_timeout_minutes as f64,
             co2_critical_ppm: thresholds.co2_critical_ppm,
             co2_refresh_target_ppm: thresholds.co2_refresh_target_ppm,
+            contact_sensors_enabled: room_mode.contact_sensors_enabled,
         }
     }
 }
@@ -50,6 +59,7 @@ impl Default for StateConfig {
             door_open_away_timeout_minutes: 5.0,
             co2_critical_ppm: 2000,
             co2_refresh_target_ppm: 500,
+            contact_sensors_enabled: true,
         }
     }
 }
@@ -130,6 +140,7 @@ pub struct StateMachine {
     door_open_away_deadline: Option<f64>,
     suppress_next_door_close_departure: bool,
     last_activity_time: f64,
+    last_manual_away_at: Option<f64>,
 }
 
 impl StateMachine {
@@ -146,6 +157,7 @@ impl StateMachine {
             door_open_away_deadline: None,
             suppress_next_door_close_departure: false,
             last_activity_time: now,
+            last_manual_away_at: None,
         }
     }
 
@@ -153,13 +165,38 @@ impl StateMachine {
         Self::new(StateConfig::from_thresholds(thresholds), now)
     }
 
+    pub fn from_thresholds_and_room_mode(
+        thresholds: &ThresholdsConfig,
+        room_mode: &RoomModeConfig,
+        now: f64,
+    ) -> Self {
+        Self::new(
+            StateConfig::from_thresholds_and_room_mode(thresholds, room_mode),
+            now,
+        )
+    }
+
     pub fn in_door_open_mode_at(&self, now: f64) -> bool {
+        if !self.config.contact_sensors_enabled {
+            return false;
+        }
         self.sensors.door_open
             && (now - self.sensors.door_last_changed) / 60.0
                 >= self.config.door_open_threshold_minutes
     }
 
     pub fn presence_signal_active_at(&self, now: f64) -> bool {
+        if !self.config.contact_sensors_enabled {
+            let motion_age = now - self.sensors.motion_last_seen;
+            let motion_recent = self.sensors.motion_detected
+                || (self.sensors.motion_last_seen > 0.0
+                    && motion_age < self.config.motion_timeout_seconds);
+            let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
+            let mac_recent =
+                self.sensors.external_monitor && self.sensors.mac_last_active > freshness_anchor;
+            return mac_recent || motion_recent;
+        }
+
         if self.in_door_open_mode_at(now) {
             let motion_age = now - self.sensors.motion_last_seen;
             let motion_recent =
@@ -181,6 +218,9 @@ impl StateMachine {
     }
 
     pub fn safety_interlock_active(&self) -> bool {
+        if !self.config.contact_sensors_enabled {
+            return false;
+        }
         self.sensors.window_open || self.sensors.door_open
     }
 
@@ -200,6 +240,13 @@ impl StateMachine {
     }
 
     pub fn advance_timers(&mut self, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.departure_verification_deadline = None;
+            self.door_open_away_deadline = None;
+            self.suppress_next_door_close_departure = false;
+            return None;
+        }
+
         if self
             .departure_verification_deadline
             .is_some_and(|deadline| now >= deadline)
@@ -291,6 +338,11 @@ impl StateMachine {
     }
 
     pub fn update_door(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return self.advance_timers(now);
+        }
+
         let timer_transition = self.advance_timers(now);
         let was_open = self.last_door_state;
         let previous_open = was_open.unwrap_or(self.sensors.door_open);
@@ -322,6 +374,11 @@ impl StateMachine {
     }
 
     pub fn restore_door_state(&mut self, is_open: bool, changed_at: f64, now: f64) {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return;
+        }
+
         let changed_at = changed_at.min(now).max(0.0);
         self.sensors.door_open = is_open;
         self.sensors.door_last_changed = changed_at;
@@ -335,6 +392,11 @@ impl StateMachine {
     }
 
     pub fn update_window(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return self.advance_timers(now);
+        }
+
         let timer_transition = self.advance_timers(now);
 
         self.sensors.window_open = is_open;
@@ -353,13 +415,13 @@ impl StateMachine {
             if self.verifying_departure() {
                 self.cancel_departure_verification();
             }
-            if self.sensors.door_open {
+            if self.config.contact_sensors_enabled && self.sensors.door_open {
                 self.suppress_next_door_close_departure = true;
             }
             self.sensors.last_updated = now;
             self.state = OccupancyState::Present;
             self.last_door_state = Some(self.sensors.door_open);
-            if self.sensors.door_open {
+            if self.config.contact_sensors_enabled && self.sensors.door_open {
                 self.start_door_open_away_timer(now);
             }
             return (old_state != self.state).then_some(StateTransition {
@@ -377,6 +439,7 @@ impl StateMachine {
         self.sensors.last_updated = now;
         self.state = OccupancyState::Away;
         self.last_door_state = Some(self.sensors.door_open);
+        self.last_manual_away_at = Some(now);
 
         (old_state != self.state).then_some(StateTransition {
             old_state,
@@ -425,7 +488,7 @@ impl StateMachine {
     }
 
     fn start_departure_verification(&mut self, now: f64) {
-        if self.state == OccupancyState::Present {
+        if self.config.contact_sensors_enabled && self.state == OccupancyState::Present {
             self.departure_verification_deadline =
                 Some(now + self.config.departure_verification_seconds);
         }
@@ -436,7 +499,7 @@ impl StateMachine {
     }
 
     fn start_door_open_away_timer(&mut self, now: f64) {
-        if self.state == OccupancyState::Present {
+        if self.config.contact_sensors_enabled && self.state == OccupancyState::Present {
             self.door_open_away_deadline =
                 Some(now + self.config.door_open_away_timeout_minutes * 60.0);
         }
@@ -454,6 +517,13 @@ mod tests {
     fn fast_departure_config() -> StateConfig {
         StateConfig {
             departure_verification_seconds: 10.0,
+            ..StateConfig::default()
+        }
+    }
+
+    fn contact_disabled_config() -> StateConfig {
+        StateConfig {
+            contact_sensors_enabled: false,
             ..StateConfig::default()
         }
     }
@@ -726,6 +796,64 @@ mod tests {
         assert!(!machine.sensors.door_open);
         assert_eq!(machine.sensors.door_last_changed, 1_040.0);
         assert_eq!(machine.sensors.door_closed_at, 1_030.0);
+    }
+
+    #[test]
+    fn disabled_contact_sensors_do_not_update_logical_contact_state() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+
+        assert_eq!(machine.update_door(true, 1_010.0), None);
+        assert_eq!(machine.update_window(true, 1_011.0), None);
+
+        assert!(!machine.sensors.door_open);
+        assert_eq!(machine.sensors.door_opened_at, 0.0);
+        assert!(!machine.sensors.window_open);
+        assert!(!machine.safety_interlock_active());
+        assert!(!machine.in_door_open_mode_at(1_400.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_allow_motion_presence_without_door_boundary() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        machine.sensors.door_open = true;
+        machine.sensors.door_last_changed = 2_000.0;
+
+        let transition = machine.update_motion(true, 1_010.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(!machine.in_door_open_mode_at(2_400.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_do_not_reassert_stale_mac_after_manual_away() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_mac_occupancy(1_010.0, true, 1_010.0)
+                .is_some()
+        );
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        machine.set_manual_presence(false, 1_020.0);
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert_eq!(machine.update_mac_occupancy(1_010.0, true, 1_021.0), None);
+        assert_eq!(machine.state, OccupancyState::Away);
+
+        let transition = machine.update_mac_occupancy(1_022.0, true, 1_022.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1504,8 +1504,9 @@ async fn validate_live_devices(
     if !config.yolink.is_configured() {
         bail!("shadow validation requires configured YoLink API credentials");
     }
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         current_timestamp_seconds(),
     )));
     let yolink_state = YoLinkState::new(state_machine, config.runtime.database_path.clone());

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -230,16 +230,26 @@ impl YoLinkState {
             return Ok(None);
         };
         self.record_device_event(device_id, &validated.details);
+        let contact_sensors_enabled = self.contact_sensors_enabled();
+        let is_contact_event = matches!(validated.role, DeviceRole::Door | DeviceRole::Window);
+        let details = if is_contact_event {
+            contact_event_details(validated.details.clone(), contact_sensors_enabled)
+        } else {
+            validated.details.clone()
+        };
 
         let (device_type, event, transition) = match validated.role {
             DeviceRole::Door => match validated.state {
                 ValidatedYoLinkState::Open | ValidatedYoLinkState::Closed => {
                     let is_open = validated.state == ValidatedYoLinkState::Open;
-                    let transition = self
-                        .state_machine
-                        .write()
-                        .expect("state machine lock poisoned")
-                        .update_door(is_open, now);
+                    let transition = contact_sensors_enabled
+                        .then(|| {
+                            self.state_machine
+                                .write()
+                                .expect("state machine lock poisoned")
+                                .update_door(is_open, now)
+                        })
+                        .flatten();
                     ("door", if is_open { "open" } else { "closed" }, transition)
                 }
                 ValidatedYoLinkState::Error => ("door", "error", None),
@@ -250,11 +260,14 @@ impl YoLinkState {
             DeviceRole::Window => match validated.state {
                 ValidatedYoLinkState::Open | ValidatedYoLinkState::Closed => {
                     let is_open = validated.state == ValidatedYoLinkState::Open;
-                    let transition = self
-                        .state_machine
-                        .write()
-                        .expect("state machine lock poisoned")
-                        .update_window(is_open, now);
+                    let transition = contact_sensors_enabled
+                        .then(|| {
+                            self.state_machine
+                                .write()
+                                .expect("state machine lock poisoned")
+                                .update_window(is_open, now)
+                        })
+                        .flatten();
                     (
                         "window",
                         if is_open { "open" } else { "closed" },
@@ -292,13 +305,17 @@ impl YoLinkState {
             device_type,
             event,
             Some(&validated.device_name),
-            Some(&validated.details),
+            Some(&details),
         ) {
             tracing::warn!(
                 "failed to persist YoLink {device_type} event after state update: {error:#}"
             );
         }
         self.notify_status();
+
+        if is_contact_event && !contact_sensors_enabled {
+            return Ok(None);
+        }
 
         Ok(Some(YoLinkAppliedEvent {
             device_type: device_type.to_string(),
@@ -362,20 +379,31 @@ impl YoLinkState {
         }
     }
 
+    fn contact_sensors_enabled(&self) -> bool {
+        self.state_machine
+            .read()
+            .expect("state machine lock poisoned")
+            .config
+            .contact_sensors_enabled
+    }
+
     pub fn restore_from_database(&self, now: f64) -> Result<()> {
-        if let Some((state, changed_at)) =
-            db::get_latest_contact_device_state_with_timestamp(&self.database_path, "door")?
-        {
-            self.state_machine
-                .write()
-                .expect("state machine lock poisoned")
-                .restore_door_state(state == "open", changed_at.unwrap_or(now), now);
-        }
-        if let Some(state) = db::get_latest_contact_device_state(&self.database_path, "window")? {
-            self.state_machine
-                .write()
-                .expect("state machine lock poisoned")
-                .update_window(state == "open", now);
+        if self.contact_sensors_enabled() {
+            if let Some((state, changed_at)) =
+                db::get_latest_contact_device_state_with_timestamp(&self.database_path, "door")?
+            {
+                self.state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .restore_door_state(state == "open", changed_at.unwrap_or(now), now);
+            }
+            if let Some(state) = db::get_latest_contact_device_state(&self.database_path, "window")?
+            {
+                self.state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .update_window(state == "open", now);
+            }
         }
         if let Some(state) = db::get_latest_device_state(&self.database_path, "motion")? {
             self.state_machine
@@ -673,6 +701,19 @@ fn sanitize_yolink_event_details(event_data: &Value) -> Result<Value> {
     Ok(Value::Object(sanitized))
 }
 
+fn contact_event_details(mut details: Value, trusted: bool) -> Value {
+    if let Value::Object(object) = &mut details {
+        object.insert("contact_sensor_trusted".to_string(), json!(trusted));
+        if !trusted {
+            object.insert(
+                "ignored_reason".to_string(),
+                json!("renovation_contact_sensors_disabled"),
+            );
+        }
+    }
+    details
+}
+
 fn sanitize_yolink_detail_value(value: &Value) -> Option<Value> {
     match value {
         Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.clone()),
@@ -935,11 +976,15 @@ mod tests {
     }
 
     fn test_state(database_path: PathBuf) -> YoLinkState {
+        test_state_with_config(
+            database_path,
+            StateConfig::from_thresholds(&ThresholdsConfig::default()),
+        )
+    }
+
+    fn test_state_with_config(database_path: PathBuf, state_config: StateConfig) -> YoLinkState {
         YoLinkState::new(
-            Arc::new(RwLock::new(StateMachine::new(
-                StateConfig::from_thresholds(&ThresholdsConfig::default()),
-                1_000.0,
-            ))),
+            Arc::new(RwLock::new(StateMachine::new(state_config, 1_000.0))),
             database_path,
         )
     }
@@ -1367,6 +1412,74 @@ mod tests {
     }
 
     #[test]
+    fn disabled_contact_sensors_log_raw_events_without_updating_contact_state() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let yolink = test_state_with_config(
+            db_path.clone(),
+            StateConfig {
+                contact_sensors_enabled: false,
+                ..StateConfig::from_thresholds(&ThresholdsConfig::default())
+            },
+        );
+        yolink.apply_devices(sample_devices());
+
+        let door = yolink
+            .apply_event("door-1", json!({"state": "open"}), 1_010.0)
+            .expect("door event");
+        let window = yolink
+            .apply_event("window-1", json!({"state": "open"}), 1_011.0)
+            .expect("window event");
+        let motion = yolink
+            .apply_event("motion-1", json!({"state": "alert"}), 1_012.0)
+            .expect("motion event")
+            .expect("applied");
+
+        assert!(door.is_none());
+        assert!(window.is_none());
+        assert_eq!(
+            motion.transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(!machine.sensors.door_open);
+        assert!(!machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        assert_eq!(machine.state, OccupancyState::Present);
+        drop(machine);
+
+        assert_eq!(
+            db::get_latest_device_state(&db_path, "door").expect("raw door state"),
+            Some("open".to_string())
+        );
+        assert_eq!(
+            db::get_latest_contact_device_state(&db_path, "door").expect("trusted door state"),
+            None
+        );
+        let history = db::read_history(&db_path, 24, 10).expect("history");
+        let door_event = history
+            .device_events
+            .iter()
+            .find(|event| event["device_type"] == "door")
+            .expect("door event");
+        let door_details = door_event["details"].as_str().expect("details string");
+        let door_details: Value = serde_json::from_str(door_details).expect("details json");
+        assert_eq!(door_details["contact_sensor_trusted"], false);
+        assert_eq!(
+            door_details["ignored_reason"],
+            "renovation_contact_sensors_disabled"
+        );
+    }
+
+    #[test]
     fn persists_yolink_occupancy_transitions() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");
@@ -1514,6 +1627,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ignored_contact_events_do_not_trigger_policy_or_hook_but_motion_does() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let mut config = test_config(db_path.clone());
+        config.room_mode.contact_sensors_enabled = false;
+        let state_machine = Arc::new(RwLock::new(StateMachine::new(
+            StateConfig::from_thresholds_and_room_mode(&config.thresholds, &config.room_mode),
+            1_000.0,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
+        yolink.apply_devices(sample_devices());
+        let qingping = QingpingState::default();
+        let erv = ErvState::new(db_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(
+            ErvFanSpeed::Medium,
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = tokio::sync::broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+        let hook_observations = Arc::new(Mutex::new(Vec::new()));
+        let hook: DeviceIngressHook = Arc::new({
+            let hook_observations = hook_observations.clone();
+            move |transition| {
+                hook_observations
+                    .lock()
+                    .expect("hook observations lock")
+                    .push(transition);
+            }
+        });
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "door-1".to_string(),
+                data: json!({"state": "open"}),
+            },
+            1_002.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("ignored contact report applies");
+
+        assert!(writer.write_speeds().is_empty());
+        assert!(
+            hook_observations
+                .lock()
+                .expect("hook observations lock")
+                .is_empty()
+        );
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "motion-1".to_string(),
+                data: json!({"state": "alert"}),
+            },
+            1_003.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("motion report applies");
+
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Off]);
+        assert_eq!(
+            *hook_observations.lock().expect("hook observations lock"),
+            vec![Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })]
+        );
+    }
+
+    #[tokio::test]
     async fn device_hook_runs_when_erv_policy_write_fails_after_report_applies() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");
@@ -1623,6 +1820,49 @@ mod tests {
             .expect("state machine lock poisoned");
         assert!(machine.sensors.door_open);
         assert!((machine.sensors.door_opened_at - opened_at).abs() < 1.0);
+        assert!(!machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        assert_eq!(machine.state, OccupancyState::Present);
+    }
+
+    #[test]
+    fn restore_skips_contacts_when_contact_sensors_are_disabled_but_restores_motion() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        db::log_device_event(
+            &db_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log door");
+        db::log_device_event(
+            &db_path,
+            "window",
+            "open",
+            Some("Office Window"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log window");
+        db::log_device_event(&db_path, "motion", "detected", Some("Office Motion"), None)
+            .expect("log motion");
+
+        let yolink = test_state_with_config(
+            db_path,
+            StateConfig {
+                contact_sensors_enabled: false,
+                ..StateConfig::from_thresholds(&ThresholdsConfig::default())
+            },
+        );
+        yolink.restore_from_database(1_050.0).expect("restore");
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(!machine.sensors.door_open);
         assert!(!machine.sensors.window_open);
         assert!(machine.sensors.motion_detected);
         assert_eq!(machine.state, OccupancyState::Present);


### PR DESCRIPTION
## Summary
- Wire state-machine construction through `room_mode.contact_sensors_enabled` for HTTP startup and validation paths.
- Keep disabled door/window contact events as raw YoLink telemetry while preventing them from updating logical door/window state or contact safety interlocks.
- Make startup restore skip contact state when contacts are disabled while still restoring motion.
- Mark contact events with `contact_sensor_trusted` metadata and exclude ignored contacts from trusted restore, `/history/daily-stats`, and `/history/openings`.
- Disable door-grace scheduling when contact sensors are untrusted.

## Spec Reference
- `docs/working/147_renovation_mode.md`

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `git diff --check`

Refs #147
