### PR TITLE
Implement air quality trust mode

### DIFF
--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -74,7 +74,7 @@ impl ErvPolicyCoordinator {
                 .expect("state machine lock poisoned");
             machine.status_at(now)
         };
-        let qingping_reading = self.qingping.latest();
+        let qingping_reading = self.trusted_qingping_reading();
         let manual_override = self
             .erv
             .active_manual_override_speed(now)
@@ -120,10 +120,14 @@ impl ErvPolicyCoordinator {
                         && state_status.sensors.door_closed_at > 0.0)
                         .then_some((now - state_status.sensors.door_closed_at).max(0.0)),
                     window_open: state_status.sensors.window_open,
-                    co2_ppm: qingping_reading
-                        .as_ref()
-                        .and_then(|reading| reading.co2_ppm)
-                        .or(Some(state_status.sensors.co2_ppm)),
+                    co2_ppm: if self.config.room_mode.air_quality_sensors_enabled {
+                        qingping_reading
+                            .as_ref()
+                            .and_then(|reading| reading.co2_ppm)
+                            .or(Some(state_status.sensors.co2_ppm))
+                    } else {
+                        None
+                    },
                     tvoc: qingping_reading.as_ref().and_then(|reading| reading.tvoc),
                     current_running: erv_snapshot.running,
                     current_speed: ventilation_speed_from_erv(erv_snapshot.speed),
@@ -245,7 +249,16 @@ impl ErvPolicyCoordinator {
     }
 
     pub fn latest_co2_ppm(&self) -> Option<i64> {
-        self.qingping.latest().and_then(|reading| reading.co2_ppm)
+        self.trusted_qingping_reading()
+            .and_then(|reading| reading.co2_ppm)
+    }
+
+    fn trusted_qingping_reading(&self) -> Option<crate::qingping::QingpingReading> {
+        self.config
+            .room_mode
+            .air_quality_sensors_enabled
+            .then(|| self.qingping.latest())
+            .flatten()
     }
 
     pub fn broadcast_status(&self) {
@@ -276,9 +289,13 @@ impl ErvPolicyCoordinator {
             return false;
         }
 
-        let co2_ppm = qingping_reading
-            .and_then(|reading| reading.co2_ppm)
-            .or(Some(state_status.sensors.co2_ppm));
+        let co2_ppm = if self.config.room_mode.air_quality_sensors_enabled {
+            qingping_reading
+                .and_then(|reading| reading.co2_ppm)
+                .or(Some(state_status.sensors.co2_ppm))
+        } else {
+            None
+        };
         let tvoc = qingping_reading.and_then(|reading| reading.tvoc);
 
         if state_status.is_present {
@@ -572,6 +589,61 @@ mod tests {
             history.climate_actions[0]["reason"],
             "present_co2_critical_2100ppm"
         );
+    }
+
+    #[tokio::test]
+    async fn disabled_air_quality_sensors_do_not_drive_erv_policy_or_history() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let mut config = test_config(database_path.clone());
+        config.room_mode.air_quality_sensors_enabled = false;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Off))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy.clone(),
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy applies without trusted air-quality");
+
+        assert!(writer.writes().is_empty());
+        assert_eq!(
+            policy
+                .read()
+                .expect("policy lock poisoned")
+                .air_quality_sample_counts(),
+            (0, 0)
+        );
+        assert!(
+            db::read_history(&database_path, 1, 10)
+                .expect("history")
+                .climate_actions
+                .is_empty()
+        );
+        assert_eq!(coordinator.latest_co2_ppm(), None);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -68,7 +68,9 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
                 pm10 INTEGER,
                 tvoc INTEGER,
                 noise_db INTEGER,
-                source TEXT DEFAULT 'qingping'
+                source TEXT DEFAULT 'qingping',
+                office_trusted INTEGER NOT NULL DEFAULT 1,
+                ignored_reason TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_sensor_timestamp ON sensor_readings(timestamp);
 
@@ -197,6 +199,18 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
         "sensor_readings",
         "noise_db",
         "ALTER TABLE sensor_readings ADD COLUMN noise_db INTEGER",
+    )?;
+    ensure_column(
+        &connection,
+        "sensor_readings",
+        "office_trusted",
+        "ALTER TABLE sensor_readings ADD COLUMN office_trusted INTEGER NOT NULL DEFAULT 1",
+    )?;
+    ensure_column(
+        &connection,
+        "sensor_readings",
+        "ignored_reason",
+        "ALTER TABLE sensor_readings ADD COLUMN ignored_reason TEXT",
     )?;
     ensure_column(
         &connection,
@@ -883,6 +897,15 @@ fn random_url_token(byte_len: usize) -> String {
 }
 
 pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) -> Result<()> {
+    insert_sensor_reading_with_trust(database_path, reading, true, None)
+}
+
+pub fn insert_sensor_reading_with_trust(
+    database_path: &Path,
+    reading: &QingpingReading,
+    office_trusted: bool,
+    ignored_reason: Option<&str>,
+) -> Result<()> {
     if let Some(parent) = database_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create data directory {}", parent.display()))?;
@@ -894,8 +917,8 @@ pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) ->
         .execute(
             r#"
             INSERT INTO sensor_readings
-                (timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source, office_trusted, ignored_reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             params![
                 reading.database_timestamp(),
@@ -907,6 +930,8 @@ pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) ->
                 reading.tvoc,
                 reading.noise_db,
                 "qingping",
+                office_trusted,
+                ignored_reason,
             ],
         )
         .context("failed to insert Qingping sensor reading")?;
@@ -2145,7 +2170,7 @@ fn query_sensor_points(
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
     let cutoff = format_timestamp(Local::now().naive_local() - Duration::hours(hours));
     let mut statement = connection.prepare(&format!(
-        "SELECT timestamp, {column} FROM sensor_readings WHERE timestamp > ? AND {column} IS NOT NULL ORDER BY timestamp ASC"
+        "SELECT timestamp, {column} FROM sensor_readings WHERE timestamp > ? AND {column} IS NOT NULL AND (office_trusted IS NULL OR office_trusted != 0) ORDER BY timestamp ASC"
     ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((
@@ -3147,6 +3172,55 @@ mod tests {
                 37,
                 "qingping".to_string()
             )
+        );
+    }
+
+    #[test]
+    fn untrusted_sensor_readings_keep_raw_history_metadata_and_leave_trusted_charts() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let reading = QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(23.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(900),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+            raw_data: "{}".to_string(),
+        };
+
+        insert_sensor_reading_with_trust(
+            &db_path,
+            &reading,
+            false,
+            Some("renovation_air_quality_sensor_moved"),
+        )
+        .expect("insert untrusted reading");
+
+        let history = read_history(&db_path, 1, 10).expect("history");
+        assert_eq!(history.sensor_readings.len(), 1);
+        assert_eq!(history.sensor_readings[0]["co2_ppm"], 900);
+        assert_eq!(history.sensor_readings[0]["office_trusted"], 0);
+        assert_eq!(
+            history.sensor_readings[0]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
+
+        let co2 = read_co2_ohlc(&db_path, 1, 5).expect("co2 history");
+        assert_eq!(co2["candles"].as_array().expect("candles").len(), 0);
+        let temperature = read_temperature_history(&db_path, 1, 5).expect("temperature history");
+        assert_eq!(
+            temperature["points"]
+                .as_array()
+                .expect("temperature points")
+                .len(),
+            0
         );
     }
 

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1503,10 +1503,17 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
     };
     let hvac_snapshot = state.hvac.snapshot();
     let temp_f = state
-        .qingping
-        .latest()
-        .and_then(|reading| reading.temp_c)
-        .map(celsius_to_fahrenheit);
+        .config
+        .room_mode
+        .air_quality_sensors_enabled
+        .then(|| {
+            state
+                .qingping
+                .latest()
+                .and_then(|reading| reading.temp_c)
+                .map(celsius_to_fahrenheit)
+        })
+        .flatten();
     let bands = active_temperature_bands(state);
     let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
     let critical_heat_needed = !state_status.is_present
@@ -3824,6 +3831,42 @@ mod tests {
         assert_eq!(value["air_quality"]["tvoc"], 25);
         assert_eq!(value["air_quality"]["noise_db"], 37.0);
         assert_eq!(value["air_quality"]["last_update"], "2026-06-05T12:30:00");
+    }
+
+    #[tokio::test]
+    async fn status_route_marks_moved_qingping_reading_as_untrusted() {
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(900));
+        let mut config = test_config();
+        config.room_mode.renovation = true;
+        config.room_mode.air_quality_sensors_enabled = false;
+
+        let response = try_app_with_qingping(config, qingping)
+            .expect("app")
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["sensors"]["co2_ppm"], 400);
+        assert_eq!(value["sensors"]["air_quality_sensors_enabled"], false);
+        assert_eq!(value["sensors"]["air_quality_sensors_ignored"], true);
+        assert_eq!(value["air_quality"]["co2_ppm"], 900);
+        assert_eq!(value["air_quality"]["trusted_office_reading"], false);
+        assert_eq!(
+            value["air_quality"]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
     }
 
     #[tokio::test]
@@ -6387,6 +6430,48 @@ mod tests {
         assert_eq!(value["climate_actions"][0]["system"], "hvac");
         assert_eq!(value["climate_actions"][0]["action"], "cool");
         assert_eq!(value["climate_actions"][0]["reason"], "cool_band_start_82F");
+    }
+
+    #[tokio::test]
+    async fn disabled_air_quality_sensors_do_not_drive_hvac_temperature_policy() {
+        let mut config = configured_hvac_config(true);
+        config.room_mode.air_quality_sensors_enabled = false;
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            unix_timestamp_now(),
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, unix_timestamp_now());
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies without trusted air-quality");
+
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -118,6 +118,7 @@ pub fn start_qingping_ingress(
     )?;
     let database_path = config.runtime.database_path.clone();
     let configured_mac = device_mac.to_string();
+    let office_trusted = config.room_mode.air_quality_sensors_enabled;
     let guard = Arc::new(Mutex::new(QingpingIngressGuard::default()));
 
     let mut broker = Broker::new(broker_config);
@@ -140,6 +141,7 @@ pub fn start_qingping_ingress(
                 qingping,
                 guard,
                 reading_hook,
+                office_trusted,
             );
         })
         .context("failed to spawn Qingping MQTT ingest thread")?;
@@ -167,6 +169,7 @@ fn ingest_loop(
     qingping: QingpingState,
     guard: Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<SensorIngressHook>,
+    office_trusted: bool,
 ) {
     loop {
         match link_rx.recv() {
@@ -181,6 +184,7 @@ fn ingest_loop(
                     &qingping,
                     &guard,
                     reading_hook.as_ref(),
+                    office_trusted,
                 );
             }
             Ok(Some(_)) | Ok(None) => {}
@@ -199,6 +203,7 @@ fn handle_qingping_publish(
     qingping: &QingpingState,
     guard: &Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<&SensorIngressHook>,
+    office_trusted: bool,
 ) {
     match parse_qingping_payload(payload, configured_mac) {
         Ok(Some(reading)) => {
@@ -210,7 +215,13 @@ fn handle_qingping_publish(
                 tracing::warn!("rejected Qingping MQTT reading: {error}");
                 return;
             }
-            if let Err(error) = db::insert_sensor_reading(database_path, &reading) {
+            let ignored_reason = (!office_trusted).then_some("renovation_air_quality_sensor_moved");
+            if let Err(error) = db::insert_sensor_reading_with_trust(
+                database_path,
+                &reading,
+                office_trusted,
+                ignored_reason,
+            ) {
                 tracing::warn!("failed to store Qingping reading: {error:#}");
             }
             qingping.apply_reading(reading);
@@ -460,10 +471,38 @@ mod tests {
             &qingping,
             &Arc::new(Mutex::new(QingpingIngressGuard::default())),
             Some(&hook),
+            true,
         );
 
         assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
         assert_eq!(qingping.latest().expect("reading").co2_ppm, Some(2100));
+    }
+
+    #[test]
+    fn qingping_publish_marks_untrusted_air_quality_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&database_path).expect("migration");
+        let qingping = QingpingState::default();
+
+        handle_qingping_publish(
+            br#"{"sensorData":[{"co2":{"value":900},"temperature":{"value":23.5},"tvoc":{"value":30}}]}"#,
+            "aa:bb:cc:dd:ee:ff",
+            &database_path,
+            &qingping,
+            &Arc::new(Mutex::new(QingpingIngressGuard::default())),
+            None,
+            false,
+        );
+
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.sensor_readings.len(), 1);
+        assert_eq!(history.sensor_readings[0]["co2_ppm"], 900);
+        assert_eq!(history.sensor_readings[0]["office_trusted"], 0);
+        assert_eq!(
+            history.sensor_readings[0]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Persist Qingping `sensor_readings` with `office_trusted` and `ignored_reason` metadata, preserving raw telemetry while marking moved readings as non-office.
- Exclude untrusted Qingping rows from trusted CO2 and temperature aggregate history.
- Treat Qingping CO2/tVOC/temp as unavailable to ERV/HVAC policy inputs when `room_mode.air_quality_sensors_enabled=false`.
- Preserve `/status` raw `air_quality.*` values with an ignored marker while keeping trusted logical `sensors.co2_ppm` unchanged.

## Spec Reference
- `docs/working/147_renovation_mode.md`

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- [x] `git diff --check`

Refs #147
