### PR TITLE
Add renovation mode for office automation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,15 @@ qingping:
   mqtt_password: "replace-with-random-device-password"
   device_mac: "AA:BB:CC:DD:EE:FF"
 
+# Room operating mode. Defaults preserve normal office behavior. During
+# renovation, keep raw telemetry flowing but mark moved sensors as untrusted and
+# disable automated climate writes.
+room_mode:
+  renovation: false
+  climate_automation_enabled: true
+  contact_sensors_enabled: true
+  air_quality_sensors_enabled: true
+
 # Android artifact upload hardening. Set this to the SHA-256 digest of the
 # office-climate release signing certificate. The deploy endpoint rejects APKs
 # signed by any other cert when this is configured.

--- a/docs/working/147_renovation_mode.md
+++ b/docs/working/147_renovation_mode.md
@@ -1,0 +1,469 @@
+# Renovation Mode for Climate and Presence Automation
+
+Issue: #147
+
+## Summary
+
+The office is under renovation. The ERV, HVAC-relevant equipment, Mac activity source, useful motion context, and Qingping air-quality monitor have moved to another room, while the door and window contact sensors remain in the physical office under construction. During this period, the automation should keep collecting productivity-relevant signals and raw sensor telemetry, but it must not use the renovated office's contact sensors or moved air-quality readings to infer presence or to drive climate behavior.
+
+This is a temporary operating mode, but it should be represented explicitly in config and status so future incidents are explainable from logs and dashboards.
+
+## Current Behavior
+
+The Rust controller currently treats the office as a two-state room model:
+
+- Mac activity with an external monitor can transition AWAY -> PRESENT.
+- Motion can count as presence, but normally only when it is inside the current door boundary.
+- Door and window contact sensors update the state machine and safety interlocks.
+- Qingping readings update status, CO2 state, ERV policy inputs, HVAC temperature policy inputs, and history charts as current office climate readings.
+- ERV and HVAC automation are gated independently by `erv.active_control_enabled` and `mitsubishi.active_control_enabled`.
+
+Relevant code paths:
+
+- `StateMachine::presence_signal_active_at()` uses door state to decide whether motion counts as inside-office presence.
+- `StateMachine::update_door()` starts departure verification and door-open timers.
+- `StateMachine::update_window()` sets window state used by safety interlocks.
+- `StateMachine::safety_interlock_active()` treats door/window open as an ERV safety interlock.
+- `evaluate_and_apply_hvac_policy()` treats window open and sustained door open as HVAC safety interlocks.
+- `QingpingState::overlay_status()` publishes CO2/temp/tVOC/etc. as `air_quality` and updates `status.sensors.co2_ppm`.
+- Qingping MQTT ingress triggers ERV/HVAC policy evaluation after readings are applied.
+- `YoLinkState::apply_event()` logs contact events and applies door/window updates to the state machine.
+- `apply_occupancy_signal()` and internal presence polling should continue to work for productivity monitoring.
+
+The key mismatch during renovation: door/window sensors still describe the under-renovation room, and Qingping readings describe the temporary equipment room, not the renovated office. These readings are raw telemetry only; they are not valid office presence or office climate-control inputs.
+
+## Goals
+
+1. Disable automated ERV and HVAC writes for the renovation period.
+2. Continue monitoring productivity signals.
+3. Treat Mac activity and motion as the only automatic presence signals.
+4. Continue logging door/window YoLink events as raw telemetry.
+5. Continue ingesting Qingping readings as raw telemetry while marking them as non-office/ignored for office climate behavior.
+6. Prevent door/window state from affecting:
+   - occupancy transitions,
+   - departure verification,
+   - door-open mode,
+   - ERV safety/interlock decisions,
+   - HVAC safety/interlock decisions,
+   - productivity summaries.
+7. Prevent moved Qingping readings from affecting:
+   - ERV air-quality policy inputs,
+   - HVAC temperature policy inputs,
+   - status fields presented as current office conditions,
+   - office climate history without source/trust context.
+8. Make the mode visible in status/logs so a future RCA does not misinterpret ignored contact sensors or moved air-quality readings as broken sensors or office conditions.
+
+## Non-Goals
+
+- Do not delete or disable YoLink device ingestion entirely.
+- Do not delete or disable Qingping ingestion entirely.
+- Do not stop productivity telemetry collection.
+- Do not change manual present/away behavior.
+- Do not permanently remove door/window semantics; this must be reversible when equipment returns.
+- Do not use door/window events from the renovated space to estimate productivity during the renovation window.
+
+## Proposed Configuration
+
+Add a top-level config block:
+
+```yaml
+room_mode:
+  renovation: false
+  climate_automation_enabled: true
+  contact_sensors_enabled: true
+  air_quality_sensors_enabled: true
+```
+
+For the current renovation:
+
+```yaml
+room_mode:
+  renovation: true
+  climate_automation_enabled: false
+  contact_sensors_enabled: false
+  air_quality_sensors_enabled: false
+
+erv:
+  active_control_enabled: false
+
+mitsubishi:
+  active_control_enabled: false
+```
+
+`erv.active_control_enabled` and `mitsubishi.active_control_enabled` remain the immediate kill switches and should still be honored. `room_mode.climate_automation_enabled=false` is an explanatory umbrella gate that prevents future automation paths from accidentally writing while the room is marked as under renovation.
+
+`room_mode.contact_sensors_enabled=false` means door/window events remain logged but are ignored by state and policy logic.
+
+`room_mode.air_quality_sensors_enabled=false` means Qingping readings remain ingested and stored as raw telemetry but are not trusted as current office air-quality, temperature, humidity, noise, CO2, or tVOC readings.
+
+`room_mode.renovation` is descriptive and observability-facing. The behavioral gates are `room_mode.climate_automation_enabled`, `room_mode.contact_sensors_enabled`, and `room_mode.air_quality_sensors_enabled`. Mixed states are valid:
+
+- `renovation=false`, `climate_automation_enabled=false`: non-renovation climate kill switch.
+- `renovation=false`, `contact_sensors_enabled=false`: contact sensor maintenance or replacement.
+- `renovation=false`, `air_quality_sensors_enabled=false`: Qingping maintenance, relocation, or calibration.
+- `renovation=true` with all behavioral gates enabled: allowed but should emit a validation warning, because the mode is visible but not protective.
+
+## Runtime Semantics
+
+### Presence
+
+When `contact_sensors_enabled=true`, preserve the current room-boundary model.
+
+When `contact_sensors_enabled=false`:
+
+- `in_door_open_mode_at()` returns false.
+- Contact-sensor driven departure verification is disabled.
+- Door-open away timers are disabled.
+- `safety_interlock_active()` ignores door/window state.
+- Motion presence is direct:
+
+```text
+motion_detected || now - motion_last_seen < motion_timeout_seconds
+```
+
+- Mac presence remains:
+
+```text
+external_monitor
+&& mac_last_active > 0
+&& mac_last_active is newer than the last manual-away timestamp, if any
+```
+
+The important differences:
+
+- Motion should no longer require `!door_open` or `motion_last_seen > door_last_changed`, because the door/window boundary no longer describes the active workspace.
+- Mac presence must not reassert stale presence after manual-away. Track a freshness anchor such as `last_manual_away_at`, and require Mac activity to be newer than that anchor when contact sensors are disabled. Add an explicit test where manual-away is set while an external monitor remains connected; the next unchanged Mac poll must not immediately transition AWAY -> PRESENT.
+
+Manual present/away should keep working and should continue logging to `occupancy_log`.
+
+### YoLink Contact Events
+
+Door/window events should still be persisted to `device_events`. This preserves raw sensor history and makes it obvious construction activity occurred.
+
+When `contact_sensors_enabled=false`, YoLink contact events must not call:
+
+- `StateMachine::update_door()`
+- `StateMachine::restore_door_state()`
+- `StateMachine::update_window()`
+
+The existing status fields `sensors.door_open` and `sensors.window_open` must remain trusted logical state-machine fields. When contact sensors are disabled, raw YoLink door/window events must not update those fields. Add explicit mode/status fields such as `contact_sensors_enabled=false` and `contact_sensors_ignored=true`. A separate raw contact telemetry section can be added later, but do not overload existing logical sensor booleans with ignored construction telemetry.
+
+### Startup Restore
+
+Startup restore must honor contact sensor trust mode. `build_app_state()` currently calls `yolink.restore_from_database(...)` before serving, and the restore path reads latest door/window rows from `device_events`. When `contact_sensors_enabled=false`:
+
+- Do not restore latest door/window state into `StateMachine`.
+- Do restore motion state if it is still useful and trustworthy.
+- Do not start door-open timers, departure verification, or safety interlocks from restored contact rows.
+- Add tests that a database with latest `door=open` and `window=open` still starts with contact-sensor logical state ignored when renovation/contact-disabled mode is configured.
+
+### Trusted vs Ignored Contact Events
+
+Ignored renovation contact events must be distinguishable from trusted contact events before contact sensors are re-enabled. Otherwise a later normal-mode restart could restore construction noise as trusted room-boundary state.
+
+Implement one of these contracts:
+
+1. Mark contact events in `device_events.details` with a trust field, for example:
+
+```json
+{
+  "contact_sensor_trusted": false,
+  "ignored_reason": "renovation_contact_sensors_disabled"
+}
+```
+
+Then update restore/history queries to include only trusted contact events where trusted state is required.
+
+2. Or require a fresh trusted contact snapshot/event after `contact_sensors_enabled=true` before restoring or relying on contact state.
+
+Preferred contract: mark ignored events in `details` and filter trusted-state restore from those details. Raw history can still show all events.
+
+### Qingping Air Quality Events
+
+Qingping ingestion should continue during renovation. The moved monitor can still be useful for temporary-room telemetry and device health, but it is not an office climate sensor while `air_quality_sensors_enabled=false`.
+
+When `air_quality_sensors_enabled=false`:
+
+- Continue accepting MQTT readings.
+- Continue storing raw rows in `sensor_readings`.
+- Mark readings as non-office or ignored in persisted metadata where possible. If the current schema cannot store trust metadata directly, add enough source/trust context through a schema change or parallel details field before relying on these rows for office climate history.
+- Do not update state-machine office CO2 from the reading.
+- Do not update `status.sensors.co2_ppm` as if it were trusted office CO2.
+- Do not feed CO2/tVOC into ERV policy decisions.
+- Do not feed temperature into HVAC policy decisions, including critical heat logic.
+- Do not present `air_quality` as current office conditions without an explicit ignored/non-office marker.
+
+Preferred status contract:
+
+```json
+{
+  "air_quality": {
+    "trusted_office_reading": false,
+    "ignored_reason": "renovation_air_quality_sensor_moved",
+    "co2_ppm": 640,
+    "temp_c": 22.5
+  },
+  "sensors": {
+    "co2_ppm": 400,
+    "air_quality_sensors_enabled": false,
+    "air_quality_sensors_ignored": true
+  }
+}
+```
+
+In this contract, `air_quality.*` may expose the latest raw Qingping reading as long as the trust marker is adjacent and unambiguous. `sensors.co2_ppm` remains trusted logical office CO2 and should not be overwritten by ignored readings.
+
+### ERV
+
+Automated ERV policy evaluation should be a no-op when either:
+
+- `erv.active_control_enabled=false`, or
+- `room_mode.climate_automation_enabled=false`.
+
+Manual ERV writes should continue to require the existing active-control gate. During renovation, keeping `erv.active_control_enabled=false` should reject manual writes unless the user deliberately re-enables it.
+
+Read-only ERV status polling can continue if configured. It does not drive climate control and is useful for diagnosing stale local connectivity.
+
+This umbrella gate must cover every automated ERV trigger path, including:
+
+- Qingping sensor update hooks,
+- YoLink device update hooks,
+- internal Mac presence polling,
+- `/occupancy` updates,
+- manual present/away follow-up policy evaluation,
+- door-grace background timers.
+
+If `room_mode.air_quality_sensors_enabled=false`, ERV policy input should treat office CO2 and tVOC as unavailable even if `room_mode.climate_automation_enabled=true`. This prevents accidental future reuse of moved Qingping data if climate automation is temporarily re-enabled before the sensor returns.
+
+### HVAC
+
+Automated HVAC policy evaluation should be a no-op when either:
+
+- `mitsubishi.active_control_enabled=false`, or
+- `room_mode.climate_automation_enabled=false`.
+
+HVAC safety interlocks should ignore door/window while `contact_sensors_enabled=false`, but this should be mostly redundant while climate automation is disabled. Implement both so the behavior is correct if climate automation is temporarily re-enabled while contact sensors are still untrusted.
+
+Manual HVAC writes should continue to require the existing active-control gate.
+
+This umbrella gate must cover every automated HVAC trigger path, including:
+
+- Qingping sensor update hooks,
+- YoLink device update hooks,
+- internal Mac presence polling,
+- `/occupancy` updates,
+- manual present/away follow-up policy evaluation,
+- door-grace background timers.
+
+If `room_mode.air_quality_sensors_enabled=false`, HVAC policy input should treat office temperature and humidity as unavailable even if `room_mode.climate_automation_enabled=true`. In particular, critical heat/cool and temperature-band decisions must not use moved Qingping readings as office temperature.
+
+### Door-Grace Scheduler
+
+When `contact_sensors_enabled=false`, `door_grace_policy_delay()` should return `None`. Door-grace scheduling is based entirely on door timestamps, so it should be inert while contact sensors are untrusted even if climate writer gates would also prevent writes. This avoids stale restored door timestamps causing repeated background evaluation and misleading logs.
+
+### Productivity and History
+
+Productivity monitoring should continue to ingest:
+
+- Mac/internal presence snapshots,
+- motion-driven presence,
+- session/tool telemetry,
+- raw climate and air-quality readings, clearly marked as non-office/ignored when `air_quality_sensors_enabled=false`.
+
+Door/window event handling should be endpoint-specific:
+
+- Raw `/history` should still include all door/window `device_events`, including ignored renovation events, because this is operational telemetry.
+- Raw `/history` should still include Qingping `sensor_readings`, including renovation-period readings, because this is operational telemetry.
+- `/history/daily-stats` should exclude ignored contact events from `door_events`, or add a separate `ignored_contact_events` count and keep trusted `door_events` separate.
+- `/history/openings` should exclude ignored contact events from trusted door/window open intervals, or label ignored intervals separately.
+- CO2 and temperature history endpoints should either exclude non-office Qingping readings by default or label them explicitly with source/trust context so charts cannot be mistaken for renovated-office conditions.
+- Leverage/session productivity endpoints that do not consume contact events do not need changes beyond avoiding broad claims that contact events affect leverage.
+
+The current physical office contact events are construction/context noise, not actual office entry/exit behavior.
+
+## Status and Observability
+
+Expose the active mode in `/status`:
+
+```json
+{
+  "room_mode": {
+      "renovation": true,
+      "climate_automation_enabled": false,
+      "contact_sensors_enabled": false,
+      "air_quality_sensors_enabled": false
+  }
+}
+```
+
+Also expose whether contact sensors are ignored in the existing sensor status area, for example:
+
+```json
+{
+  "sensors": {
+    "door_open": false,
+    "window_open": false,
+    "contact_sensors_enabled": false,
+    "contact_sensors_ignored": true,
+    "air_quality_sensors_enabled": false,
+    "air_quality_sensors_ignored": true
+  }
+}
+```
+
+Status source of truth:
+
+- `sensors.door_open` and `sensors.window_open` are trusted logical state-machine values.
+- When `contact_sensors_enabled=false`, raw ignored YoLink contact events do not update those fields.
+- `contact_sensors_enabled=false` and `contact_sensors_ignored=true` explain why raw contact telemetry may differ from logical sensor state.
+- `air_quality.trusted_office_reading=false` explains why raw Qingping values may differ from logical office climate state.
+- `sensors.co2_ppm` remains trusted logical office CO2 and is not overwritten by ignored Qingping readings.
+
+Add log details when skipping contact-sensor state application:
+
+- device type,
+- raw event state,
+- timestamp,
+- reason: `renovation_contact_sensors_disabled`.
+
+Add log details when skipping climate automation:
+
+- subsystem: `erv` or `hvac`,
+- reason: `renovation_climate_automation_disabled`.
+
+Add log details when applying a raw-but-ignored Qingping reading:
+
+- source: `qingping`,
+- reading timestamp,
+- reason: `renovation_air_quality_sensor_moved`.
+
+## Implementation Plan
+
+1. Add `RoomModeConfig` in `src/config.rs`.
+   - Defaults should preserve current behavior:
+     - `renovation=false`
+     - `climate_automation_enabled=true`
+     - `contact_sensors_enabled=true`
+     - `air_quality_sensors_enabled=true`
+   - Add environment overrides only if consistent with nearby config patterns.
+   - Add config parser tests.
+
+2. Thread room mode into app status.
+   - Add fields to `Status` and serialization tests.
+   - Update dashboard consumers only if they require explicit model changes.
+   - Preserve `sensors.door_open` and `sensors.window_open` as trusted logical state fields; do not repurpose them as raw ignored telemetry.
+   - Preserve `sensors.co2_ppm` as trusted logical office CO2; do not overwrite it with ignored Qingping readings.
+   - Add explicit air-quality trust fields to status serialization.
+
+3. Update `StateMachine` to support contact-sensor-disabled semantics.
+   - Prefer adding `contact_sensors_enabled` to `StateConfig`, sourced from `AppConfig`.
+   - Update `presence_signal_active_at()`, `in_door_open_mode_at()`, `safety_interlock_active()`, and relevant timer paths.
+   - Add a manual-away freshness anchor for Mac presence when contact sensors are disabled.
+   - Add state-machine tests for direct motion, Mac presence, and manual-away with external monitor still connected.
+
+4. Update YoLink event application.
+   - Continue logging door/window `device_events`.
+   - Mark ignored contact events in `details`, including `contact_sensor_trusted=false` and an ignored reason.
+   - Skip state-machine door/window updates when contact sensors are disabled.
+   - Make startup restore skip untrusted/ignored contact rows and skip all contact restore when contact sensors are disabled.
+   - Add tests that door/window events are logged but do not mutate state or trigger occupancy transitions.
+
+5. Update Qingping ingestion and trust handling.
+   - Continue applying/storing raw Qingping readings.
+   - Mark readings as non-office/ignored when `air_quality_sensors_enabled=false`.
+   - Prevent ignored readings from updating state-machine office CO2 and trusted status sensor CO2.
+   - Add tests that ignored readings appear in raw history/status with trust markers but are not presented as trusted office conditions.
+
+6. Gate ERV automation with room mode.
+   - Keep existing `erv.active_control_enabled` behavior.
+   - Add an umbrella no-op when `room_mode.climate_automation_enabled=false`.
+   - Treat CO2/tVOC as unavailable when `room_mode.air_quality_sensors_enabled=false`, even if climate automation is enabled.
+   - Add tests that policy updates produce no automated ERV writes from Qingping, YoLink, Mac/presence, manual present/away follow-up, and door-grace triggers in renovation mode.
+   - Add tests that ERV policy does not consume Qingping CO2/tVOC when air-quality sensors are disabled.
+
+7. Gate HVAC automation with room mode.
+   - Keep existing `mitsubishi.active_control_enabled` behavior.
+   - Add an umbrella no-op when `room_mode.climate_automation_enabled=false`.
+   - Update `hvac_safety_interlock_active()` or its caller so contact sensors are ignored when disabled.
+   - Treat temperature/humidity as unavailable when `room_mode.air_quality_sensors_enabled=false`, even if climate automation is enabled.
+   - Make `door_grace_policy_delay()` inert when contact sensors are disabled.
+   - Add tests for sustained door-open and window-open not driving HVAC behavior in renovation mode.
+   - Add tests that HVAC policy does not consume Qingping temperature/humidity when air-quality sensors are disabled.
+
+8. Adjust productivity/history summaries.
+   - Keep raw `/history` door/window events.
+   - Keep raw `/history` Qingping sensor readings.
+   - Exclude or label ignored door/window events in `/history/daily-stats`.
+   - Exclude or label ignored door/window intervals in `/history/openings`.
+   - Exclude or label non-office Qingping readings in CO2 and temperature history endpoints.
+   - Add tests around those concrete endpoint payloads.
+
+9. Update `config.example.yaml` and deployment notes.
+   - Document the renovation configuration.
+   - Include the restore checklist:
+     - set `room_mode.renovation=false`,
+     - set `room_mode.contact_sensors_enabled=true`,
+     - set `room_mode.climate_automation_enabled=true`,
+     - set `room_mode.air_quality_sensors_enabled=true`,
+     - re-enable `erv.active_control_enabled` and `mitsubishi.active_control_enabled` when equipment is back.
+     - require a fresh trusted door/window event or snapshot before relying on contact-sensor state.
+     - require a fresh trusted Qingping reading from the office before relying on air-quality history/status or climate automation.
+
+## Acceptance Criteria
+
+1. With renovation mode enabled and contact sensors disabled, a door-open YoLink event is logged but does not set state-machine `door_open`, does not start door-open mode, and does not start departure verification.
+2. With renovation mode enabled and contact sensors disabled, a window-open YoLink event is logged but does not trip ERV or HVAC safety interlocks.
+3. With contact sensors disabled, startup/database restore does not apply latest trusted-looking or ignored door/window rows into the state machine; motion restore can still work.
+4. Ignored contact events are marked in `device_events.details`, and trusted contact restore/history queries do not treat ignored rows as trusted room-boundary state.
+5. Motion alone transitions AWAY -> PRESENT when contact sensors are disabled.
+6. Fresh Mac activity with external monitor transitions AWAY -> PRESENT when contact sensors are disabled.
+7. Manual away while an external monitor remains connected is not immediately undone by stale Mac activity on the next poll.
+8. Manual present/away continues to work.
+9. Automated ERV writes are not emitted from Qingping, YoLink, Mac/presence, manual present/away follow-up, or door-grace triggers when `room_mode.climate_automation_enabled=false`.
+10. Automated HVAC writes are not emitted from Qingping, YoLink, Mac/presence, manual present/away follow-up, or door-grace triggers when `room_mode.climate_automation_enabled=false`.
+11. If `air_quality_sensors_enabled=false`, ERV policy does not consume Qingping CO2/tVOC as office air-quality input, even if climate automation is enabled.
+12. If `air_quality_sensors_enabled=false`, HVAC policy does not consume Qingping temperature/humidity as office climate input, even if climate automation is enabled.
+13. `door_grace_policy_delay()` returns no scheduled work when contact sensors are disabled.
+14. `/status` clearly reports renovation mode and contact sensors ignored, while `sensors.door_open/window_open` remain trusted logical state fields.
+15. `/status` clearly reports air-quality readings as ignored/non-office when air-quality sensors are disabled, and `sensors.co2_ppm` is not overwritten by ignored Qingping readings.
+16. Raw `/history` includes ignored door/window events and non-office Qingping readings, while `/history/daily-stats`, `/history/openings`, CO2 history, and temperature history exclude or explicitly label ignored/non-office data.
+17. When defaults are used, all existing contact-sensor, air-quality, ERV, and HVAC behaviors are preserved.
+
+## Rollout
+
+1. Merge the code with defaults preserving current behavior.
+2. Deploy with only:
+
+```yaml
+room_mode:
+  renovation: true
+  climate_automation_enabled: false
+  contact_sensors_enabled: false
+  air_quality_sensors_enabled: false
+
+erv:
+  active_control_enabled: false
+
+mitsubishi:
+  active_control_enabled: false
+```
+
+3. Verify:
+   - `/status` shows renovation/contact-sensors-ignored.
+   - `/status` shows Qingping readings ignored/non-office.
+   - Motion or Mac activity can still mark present.
+   - Door/window events appear in history but do not change occupancy.
+   - Qingping readings appear in raw history but do not update trusted office CO2/temp.
+   - ERV/HVAC writes are not emitted by automation.
+
+4. When equipment returns:
+   - Re-enable `contact_sensors_enabled`.
+   - Move Qingping back into the office, then re-enable `air_quality_sensors_enabled`.
+   - Require a fresh trusted door/window event or explicit contact-state refresh.
+   - Require a fresh trusted Qingping reading from the office.
+   - Only after trusted contact and air-quality state are fresh, re-enable `climate_automation_enabled`, `erv.active_control_enabled`, and `mitsubishi.active_control_enabled`.
+   - Verify `/status` shows trusted logical door/window and air-quality state before relying on automation.
+
+## Classification
+
+Single ticket. The implementation touches several modules, but the behavioral surface is cohesive and bounded: add renovation/contact-sensor trust mode, gate climate automation, and preserve productivity monitoring.

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -68,19 +68,31 @@ function statusToOccupancy(api: ApiStatus): OccupancyState {
   return api.is_present ? OccupancyState.PRESENT : OccupancyState.AWAY;
 }
 
+function hasTrustedAirQuality(api: ApiStatus): boolean {
+  return api.air_quality.trusted_office_reading !== false;
+}
+
+function trustedCo2(api: ApiStatus): number {
+  if (hasTrustedAirQuality(api)) {
+    return api.air_quality.co2_ppm ?? api.sensors.co2_ppm ?? 0;
+  }
+  return api.sensors.co2_ppm ?? 0;
+}
+
 // Convert API response to OfficeState
 function apiToState(api: ApiStatus): OfficeState {
   const occupancy = statusToOccupancy(api);
+  const trustedAirQuality = hasTrustedAirQuality(api);
 
   return {
-    co2: api.air_quality.co2_ppm ?? api.sensors.co2_ppm ?? 0,
-    temperature: api.air_quality.temp_c ? toFahrenheit(api.air_quality.temp_c) : 0,
+    co2: trustedCo2(api),
+    temperature: trustedAirQuality && api.air_quality.temp_c ? toFahrenheit(api.air_quality.temp_c) : 0,
     tempTrend: 'stable',
-    humidity: api.air_quality.humidity ? Math.round(api.air_quality.humidity * 10) / 10 : 0,
-    tvoc: api.air_quality.tvoc ?? 0,
-    noise: api.air_quality.noise_db ?? 0,
-    pm25: api.air_quality.pm25 ?? 0,
-    pm10: api.air_quality.pm10 ?? 0,
+    humidity: trustedAirQuality && api.air_quality.humidity ? Math.round(api.air_quality.humidity * 10) / 10 : 0,
+    tvoc: trustedAirQuality ? api.air_quality.tvoc ?? 0 : 0,
+    noise: trustedAirQuality ? api.air_quality.noise_db ?? 0 : 0,
+    pm25: trustedAirQuality ? api.air_quality.pm25 ?? 0 : 0,
+    pm10: trustedAirQuality ? api.air_quality.pm10 ?? 0 : 0,
     door: api.sensors.door_open ? DeviceStatus.OPEN : DeviceStatus.CLOSED,
     window: api.sensors.window_open ? DeviceStatus.OPEN : DeviceStatus.CLOSED,
     hvacMode: api.hvac?.mode === 'heat' ? DeviceStatus.HEAT :
@@ -219,7 +231,7 @@ const App: React.FC = () => {
 
           // Add to history every update
           addHistoryPoint(
-            status.air_quality.co2_ppm ?? status.sensors.co2_ppm ?? 0,
+            trustedCo2(status),
             statusToOccupancy(status),
             status.erv.running
           );
@@ -285,7 +297,7 @@ const App: React.FC = () => {
       setApiConnected(true);
 
       addHistoryPoint(
-        status.air_quality.co2_ppm ?? status.sensors.co2_ppm ?? 0,
+        trustedCo2(status),
         statusToOccupancy(status),
         status.erv.running
       );

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -120,6 +120,8 @@ export interface ApiStatus {
     tvoc: number | null;
     noise_db: number | null;
     last_update: string | null;
+    trusted_office_reading?: boolean;
+    ignored_reason?: string | null;
   };
   erv: {
     running: boolean;

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -457,6 +457,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -66,6 +66,10 @@ impl ErvPolicyCoordinator {
     }
 
     async fn evaluate_erv_policy_locked(&self, bypass_dwell: bool) -> Result<()> {
+        if !self.config.room_mode.climate_automation_enabled {
+            return Ok(());
+        }
+
         let now = unix_timestamp_now();
         let state_status = {
             let machine = self
@@ -644,6 +648,53 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(coordinator.latest_co2_ppm(), None);
+    }
+
+    #[tokio::test]
+    async fn disabled_climate_automation_skips_erv_policy_writes() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let mut config = test_config(database_path.clone());
+        config.room_mode.climate_automation_enabled = false;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Off))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy gate returns ok");
+
+        assert!(writer.writes().is_empty());
+        assert!(
+            db::read_history(&database_path, 1, 10)
+                .expect("history")
+                .climate_actions
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -74,7 +74,7 @@ impl ErvPolicyCoordinator {
                 .expect("state machine lock poisoned");
             machine.status_at(now)
         };
-        let qingping_reading = self.qingping.latest();
+        let qingping_reading = self.trusted_qingping_reading();
         let manual_override = self
             .erv
             .active_manual_override_speed(now)
@@ -120,10 +120,14 @@ impl ErvPolicyCoordinator {
                         && state_status.sensors.door_closed_at > 0.0)
                         .then_some((now - state_status.sensors.door_closed_at).max(0.0)),
                     window_open: state_status.sensors.window_open,
-                    co2_ppm: qingping_reading
-                        .as_ref()
-                        .and_then(|reading| reading.co2_ppm)
-                        .or(Some(state_status.sensors.co2_ppm)),
+                    co2_ppm: if self.config.room_mode.air_quality_sensors_enabled {
+                        qingping_reading
+                            .as_ref()
+                            .and_then(|reading| reading.co2_ppm)
+                            .or(Some(state_status.sensors.co2_ppm))
+                    } else {
+                        None
+                    },
                     tvoc: qingping_reading.as_ref().and_then(|reading| reading.tvoc),
                     current_running: erv_snapshot.running,
                     current_speed: ventilation_speed_from_erv(erv_snapshot.speed),
@@ -245,7 +249,16 @@ impl ErvPolicyCoordinator {
     }
 
     pub fn latest_co2_ppm(&self) -> Option<i64> {
-        self.qingping.latest().and_then(|reading| reading.co2_ppm)
+        self.trusted_qingping_reading()
+            .and_then(|reading| reading.co2_ppm)
+    }
+
+    fn trusted_qingping_reading(&self) -> Option<crate::qingping::QingpingReading> {
+        self.config
+            .room_mode
+            .air_quality_sensors_enabled
+            .then(|| self.qingping.latest())
+            .flatten()
     }
 
     pub fn broadcast_status(&self) {
@@ -276,9 +289,13 @@ impl ErvPolicyCoordinator {
             return false;
         }
 
-        let co2_ppm = qingping_reading
-            .and_then(|reading| reading.co2_ppm)
-            .or(Some(state_status.sensors.co2_ppm));
+        let co2_ppm = if self.config.room_mode.air_quality_sensors_enabled {
+            qingping_reading
+                .and_then(|reading| reading.co2_ppm)
+                .or(Some(state_status.sensors.co2_ppm))
+        } else {
+            None
+        };
         let tvoc = qingping_reading.and_then(|reading| reading.tvoc);
 
         if state_status.is_present {
@@ -572,6 +589,61 @@ mod tests {
             history.climate_actions[0]["reason"],
             "present_co2_critical_2100ppm"
         );
+    }
+
+    #[tokio::test]
+    async fn disabled_air_quality_sensors_do_not_drive_erv_policy_or_history() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let mut config = test_config(database_path.clone());
+        config.room_mode.air_quality_sensors_enabled = false;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(2100));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Off))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy.clone(),
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy applies without trusted air-quality");
+
+        assert!(writer.writes().is_empty());
+        assert_eq!(
+            policy
+                .read()
+                .expect("policy lock poisoned")
+                .air_quality_sample_counts(),
+            (0, 0)
+        );
+        assert!(
+            db::read_history(&database_path, 1, 10)
+                .expect("history")
+                .climate_actions
+                .is_empty()
+        );
+        assert_eq!(coordinator.latest_co2_ppm(), None);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -651,6 +651,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_air_quality_sensors_do_not_turn_running_erv_off_as_clean_air() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let mut config = test_config(database_path.clone());
+        config.room_mode.air_quality_sensors_enabled = false;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 2.0,
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, now - 1.0);
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(450));
+        let erv = ErvState::new(database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(ErvFanSpeed::Turbo))]));
+        erv.smoke_status_with(&config.erv, writer.as_ref())
+            .await
+            .expect("initial ERV status");
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+
+        coordinator
+            .evaluate_erv_policy(false)
+            .await
+            .expect("policy preserves current speed without trusted air-quality");
+
+        assert!(writer.writes().is_empty());
+        assert!(
+            db::read_history(&database_path, 1, 10)
+                .expect("history")
+                .climate_actions
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn disabled_climate_automation_skips_erv_policy_writes() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub orchestrator: OrchestratorConfig,
+    pub room_mode: RoomModeConfig,
     pub presence: PresenceConfig,
     pub qingping: QingpingConfig,
     pub yolink: YoLinkConfig,
@@ -19,6 +20,26 @@ pub struct AppConfig {
     pub thresholds: ThresholdsConfig,
     pub telemetry: TelemetryConfig,
     pub runtime: RuntimeConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RoomModeConfig {
+    pub renovation: bool,
+    pub climate_automation_enabled: bool,
+    pub contact_sensors_enabled: bool,
+    pub air_quality_sensors_enabled: bool,
+}
+
+impl Default for RoomModeConfig {
+    fn default() -> Self {
+        Self {
+            renovation: false,
+            climate_automation_enabled: true,
+            contact_sensors_enabled: true,
+            air_quality_sensors_enabled: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -430,6 +451,7 @@ pub struct RuntimeConfig {
 #[serde(default)]
 struct FileConfig {
     orchestrator: OrchestratorConfig,
+    room_mode: RoomModeConfig,
     presence: PresenceConfig,
     qingping: QingpingConfig,
     yolink: YoLinkConfig,
@@ -604,6 +626,26 @@ impl AppConfig {
             file_config.cloudflare_access.api_base_url = api_base_url;
         }
 
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_RENOVATION_MODE") {
+            file_config.room_mode.renovation =
+                parse_bool_env("OFFICE_AUTOMATE_RENOVATION_MODE", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED") {
+            file_config.room_mode.climate_automation_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED") {
+            file_config.room_mode.contact_sensors_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED") {
+            file_config.room_mode.air_quality_sensors_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED", &enabled)?;
+        }
+
         if let Some(admin_emails) = env_lookup("OFFICE_AUTOMATE_ADMIN_EMAILS") {
             file_config.orchestrator.admin_emails = admin_emails
                 .split(',')
@@ -732,6 +774,7 @@ impl AppConfig {
 
         Ok(Self {
             orchestrator: file_config.orchestrator,
+            room_mode: file_config.room_mode,
             presence: file_config.presence,
             qingping: file_config.qingping,
             yolink: file_config.yolink,
@@ -795,6 +838,11 @@ orchestrator:
   port: 9001
 presence:
   poll_interval_seconds: 7
+room_mode:
+  renovation: false
+  climate_automation_enabled: true
+  contact_sensors_enabled: true
+  air_quality_sensors_enabled: true
 telemetry:
   repos:
     - "/yaml/repo"
@@ -843,6 +891,10 @@ thresholds:
             "OFFICE_AUTOMATE_ERV_DEVICE_ID" => Some("env-erv-device".to_string()),
             "OFFICE_AUTOMATE_ERV_LOCAL_KEY" => Some("env-erv-key".to_string()),
             "OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_RENOVATION_MODE" => Some("true".to_string()),
+            "OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED" => Some("false".to_string()),
+            "OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED" => Some("false".to_string()),
+            "OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED" => Some("false".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_ENABLED" => Some("true".to_string()),
             "OFFICE_AUTOMATE_PRESENCE_COMMAND_TIMEOUT_SECONDS" => Some("3".to_string()),
             "OFFICE_AUTOMATE_TELEMETRY_REPOS" => Some("/env/repo-a,/env/repo-b".to_string()),
@@ -896,6 +948,10 @@ thresholds:
 
         assert_eq!(config.orchestrator.host, "127.0.0.1");
         assert_eq!(config.orchestrator.port, 9001);
+        assert!(config.room_mode.renovation);
+        assert!(!config.room_mode.climate_automation_enabled);
+        assert!(!config.room_mode.contact_sensors_enabled);
+        assert!(!config.room_mode.air_quality_sensors_enabled);
         assert!(config.presence.enabled);
         assert_eq!(config.presence.poll_interval_seconds, 7);
         assert_eq!(config.presence.command_timeout_seconds, 3);

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -2047,19 +2047,30 @@ pub fn get_latest_contact_device_state_with_timestamp(
     let row = connection
         .query_row(
             r#"
-            SELECT event, timestamp FROM device_events
+            SELECT
+                event,
+                timestamp,
+                COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0 AS trusted
+            FROM device_events
             WHERE device_type = ?
               AND event IN ('open', 'closed')
-              AND (details IS NULL OR COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0)
             ORDER BY timestamp DESC, id DESC
             LIMIT 1
             "#,
             params![device_type],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, bool>(2)?,
+                ))
+            },
         )
         .optional()
         .with_context(|| format!("failed to read latest {device_type} contact state"))?;
-    Ok(row.map(|(event, timestamp)| (event, timestamp_to_unix_seconds(&timestamp))))
+    Ok(row.and_then(|(event, timestamp, trusted)| {
+        trusted.then(|| (event, timestamp_to_unix_seconds(&timestamp)))
+    }))
 }
 
 fn parse_timestamp(value: &str) -> Option<NaiveDateTime> {
@@ -3286,7 +3297,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_contact_state_ignores_untrusted_contact_events() {
+    fn latest_contact_state_stops_at_newer_untrusted_contact_events() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");
         migrate_database(&db_path).expect("migration");
@@ -3335,7 +3346,7 @@ mod tests {
         );
         assert_eq!(
             get_latest_contact_device_state(&db_path, "door").expect("latest trusted contact"),
-            Some("closed".to_string())
+            None
         );
     }
 

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -68,7 +68,9 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
                 pm10 INTEGER,
                 tvoc INTEGER,
                 noise_db INTEGER,
-                source TEXT DEFAULT 'qingping'
+                source TEXT DEFAULT 'qingping',
+                office_trusted INTEGER NOT NULL DEFAULT 1,
+                ignored_reason TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_sensor_timestamp ON sensor_readings(timestamp);
 
@@ -197,6 +199,18 @@ pub fn migrate_database(database_path: &Path) -> Result<()> {
         "sensor_readings",
         "noise_db",
         "ALTER TABLE sensor_readings ADD COLUMN noise_db INTEGER",
+    )?;
+    ensure_column(
+        &connection,
+        "sensor_readings",
+        "office_trusted",
+        "ALTER TABLE sensor_readings ADD COLUMN office_trusted INTEGER NOT NULL DEFAULT 1",
+    )?;
+    ensure_column(
+        &connection,
+        "sensor_readings",
+        "ignored_reason",
+        "ALTER TABLE sensor_readings ADD COLUMN ignored_reason TEXT",
     )?;
     ensure_column(
         &connection,
@@ -883,6 +897,15 @@ fn random_url_token(byte_len: usize) -> String {
 }
 
 pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) -> Result<()> {
+    insert_sensor_reading_with_trust(database_path, reading, true, None)
+}
+
+pub fn insert_sensor_reading_with_trust(
+    database_path: &Path,
+    reading: &QingpingReading,
+    office_trusted: bool,
+    ignored_reason: Option<&str>,
+) -> Result<()> {
     if let Some(parent) = database_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create data directory {}", parent.display()))?;
@@ -894,8 +917,8 @@ pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) ->
         .execute(
             r#"
             INSERT INTO sensor_readings
-                (timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (timestamp, co2_ppm, temp_c, humidity, pm25, pm10, tvoc, noise_db, source, office_trusted, ignored_reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             params![
                 reading.database_timestamp(),
@@ -907,6 +930,8 @@ pub fn insert_sensor_reading(database_path: &Path, reading: &QingpingReading) ->
                 reading.tvoc,
                 reading.noise_db,
                 "qingping",
+                office_trusted,
+                ignored_reason,
             ],
         )
         .context("failed to insert Qingping sensor reading")?;
@@ -2145,7 +2170,7 @@ fn query_sensor_points(
         .with_context(|| format!("failed to open SQLite database {}", database_path.display()))?;
     let cutoff = format_timestamp(Local::now().naive_local() - Duration::hours(hours));
     let mut statement = connection.prepare(&format!(
-        "SELECT timestamp, {column} FROM sensor_readings WHERE timestamp > ? AND {column} IS NOT NULL ORDER BY timestamp ASC"
+        "SELECT timestamp, {column} FROM sensor_readings WHERE timestamp > ? AND {column} IS NOT NULL AND (office_trusted IS NULL OR office_trusted != 0) ORDER BY timestamp ASC"
     ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((
@@ -3147,6 +3172,55 @@ mod tests {
                 37,
                 "qingping".to_string()
             )
+        );
+    }
+
+    #[test]
+    fn untrusted_sensor_readings_keep_raw_history_metadata_and_leave_trusted_charts() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        let reading = QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(23.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(900),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+            raw_data: "{}".to_string(),
+        };
+
+        insert_sensor_reading_with_trust(
+            &db_path,
+            &reading,
+            false,
+            Some("renovation_air_quality_sensor_moved"),
+        )
+        .expect("insert untrusted reading");
+
+        let history = read_history(&db_path, 1, 10).expect("history");
+        assert_eq!(history.sensor_readings.len(), 1);
+        assert_eq!(history.sensor_readings[0]["co2_ppm"], 900);
+        assert_eq!(history.sensor_readings[0]["office_trusted"], 0);
+        assert_eq!(
+            history.sensor_readings[0]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
+
+        let co2 = read_co2_ohlc(&db_path, 1, 5).expect("co2 history");
+        assert_eq!(co2["candles"].as_array().expect("candles").len(), 0);
+        let temperature = read_temperature_history(&db_path, 1, 5).expect("temperature history");
+        assert_eq!(
+            temperature["points"]
+                .as_array()
+                .expect("temperature points")
+                .len(),
+            0
         );
     }
 

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -1512,30 +1512,45 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
         .collect::<BTreeMap<_, _>>();
 
     for device_type in ["door", "window"] {
-        let last_before: Option<String> = connection
+        let last_before: Option<(String, bool)> = connection
             .query_row(
-                &format!(
-                    "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp DESC, id DESC LIMIT 1"
-                ),
+                "SELECT event, COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0 AS trusted \
+                 FROM device_events \
+                 WHERE timestamp < ? AND device_type = ? AND event IN ('open', 'closed') \
+                 ORDER BY timestamp DESC, id DESC LIMIT 1",
                 params![cutoff, device_type],
-                |row| row.get(0),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?)),
             )
             .optional()?;
-        let mut open_start = (last_before.as_deref() == Some("open")).then_some(start);
+        let mut open_start = last_before
+            .as_ref()
+            .is_some_and(|(event, trusted)| *trusted && event == "open")
+            .then_some(start);
 
         let mut statement = connection.prepare(
-            &format!(
-                "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp ASC, id ASC"
-            ),
+            "SELECT timestamp, event, COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0 AS trusted \
+             FROM device_events \
+             WHERE timestamp >= ? AND device_type = ? AND event IN ('open', 'closed') \
+             ORDER BY timestamp ASC, id ASC",
         )?;
         let rows = statement.query_map(params![cutoff, device_type], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, bool>(2)?,
+            ))
         })?;
         for row in rows {
-            let (timestamp, event) = row?;
+            let (timestamp, event, trusted) = row?;
             let Some(parsed) = parse_timestamp(&timestamp) else {
                 continue;
             };
+            if !trusted {
+                if let Some(started) = open_start.take() {
+                    push_open_intervals(&mut grouped, device_type, started, parsed);
+                }
+                continue;
+            }
             if event == "open" && open_start.is_none() {
                 open_start = Some(parsed);
             } else if event == "closed" {
@@ -3427,5 +3442,42 @@ mod tests {
         assert_eq!(door.len(), 1);
         assert_eq!(door[0]["open"], "11:00:00");
         assert_eq!(door[0]["close"], "12:00:00");
+    }
+
+    #[test]
+    fn openings_stop_carried_trusted_interval_at_ignored_contact_event() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let today = Local::now().naive_local().date();
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+                VALUES (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'door', 'Office Door', 'open', ?)
+                "#,
+                params![
+                    format_timestamp(day_start(today) - Duration::hours(1)),
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": true})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(10)),
+                    serde_json::json!({
+                        "state": "open",
+                        "contact_sensor_trusted": false,
+                        "ignored_reason": "renovation_contact_sensors_disabled"
+                    })
+                    .to_string(),
+                ],
+            )
+            .expect("insert openings");
+
+        let openings = read_openings(&db_path, 1).expect("openings");
+        let door = openings[0]["door"].as_array().expect("door openings");
+
+        assert_eq!(door.len(), 1);
+        assert_eq!(door[0]["open"], "00:00:00");
+        assert_eq!(door[0]["close"], "10:00:00");
     }
 }

--- a/rust/office-automate-server/src/db.rs
+++ b/rust/office-automate-server/src/db.rs
@@ -16,6 +16,8 @@ use sha2::{Digest, Sha256};
 use crate::{config::AppConfig, qingping::QingpingReading};
 
 pub const DEVICE_PAIRING_MAX_FAILED_ATTEMPTS: i64 = 5;
+const TRUSTED_CONTACT_EVENT_FILTER: &str =
+    "(details IS NULL OR COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0)";
 
 const SESSION_OUTPUT_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS session_output (
@@ -1263,15 +1265,26 @@ pub fn read_daily_stats(database_path: &Path, days: i64) -> Result<Vec<Value>> {
     let labels = day_labels(now.date(), days);
 
     let mut door_counts = HashMap::new();
-    let mut statement = connection.prepare(
-        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type = 'door' GROUP BY date(timestamp)",
-    )?;
+    let mut statement = connection.prepare(&format!(
+        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type = 'door' AND {TRUSTED_CONTACT_EVENT_FILTER} GROUP BY date(timestamp)",
+    ))?;
     let rows = statement.query_map(params![cutoff], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
     })?;
     for row in rows {
         let (date, count) = row?;
         door_counts.insert(date, count);
+    }
+    let mut ignored_contact_counts = HashMap::new();
+    let mut statement = connection.prepare(
+        "SELECT date(timestamp) AS date, COUNT(*) AS count FROM device_events WHERE timestamp >= ? AND device_type IN ('door', 'window') AND json_extract(details, '$.contact_sensor_trusted') = 0 GROUP BY date(timestamp)",
+    )?;
+    let rows = statement.query_map(params![cutoff], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (date, count) = row?;
+        ignored_contact_counts.insert(date, count);
     }
 
     let presence = durations_from_state_table(
@@ -1314,6 +1327,7 @@ pub fn read_daily_stats(database_path: &Path, days: i64) -> Result<Vec<Value>> {
             json!({
                 "date": date,
                 "door_events": door_counts.get(&date).copied().unwrap_or_default(),
+                "ignored_contact_events": ignored_contact_counts.get(&date).copied().unwrap_or_default(),
                 "erv_runtime_min": erv.get(&date).copied().unwrap_or_default().round() as i64,
                 "hvac_runtime_min": hvac.get(&date).copied().unwrap_or_default().round() as i64,
                 "presence_hours": round1(presence.get(&date).copied().unwrap_or_default()),
@@ -1475,7 +1489,9 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
     for device_type in ["door", "window"] {
         let last_before: Option<String> = connection
             .query_row(
-                "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? ORDER BY timestamp DESC LIMIT 1",
+                &format!(
+                    "SELECT event FROM device_events WHERE timestamp < ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp DESC, id DESC LIMIT 1"
+                ),
                 params![cutoff, device_type],
                 |row| row.get(0),
             )
@@ -1483,7 +1499,9 @@ pub fn read_openings(database_path: &Path, days: i64) -> Result<Vec<Value>> {
         let mut open_start = (last_before.as_deref() == Some("open")).then_some(start);
 
         let mut statement = connection.prepare(
-            "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? ORDER BY timestamp ASC",
+            &format!(
+                "SELECT timestamp, event FROM device_events WHERE timestamp >= ? AND device_type = ? AND event IN ('open', 'closed') AND {TRUSTED_CONTACT_EVENT_FILTER} ORDER BY timestamp ASC, id ASC"
+            ),
         )?;
         let rows = statement.query_map(params![cutoff, device_type], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -2007,6 +2025,7 @@ pub fn get_latest_contact_device_state_with_timestamp(
             SELECT event, timestamp FROM device_events
             WHERE device_type = ?
               AND event IN ('open', 'closed')
+              AND (details IS NULL OR COALESCE(json_extract(details, '$.contact_sensor_trusted'), 1) != 0)
             ORDER BY timestamp DESC, id DESC
             LIMIT 1
             "#,
@@ -3190,5 +3209,138 @@ mod tests {
             )
             .expect("read details");
         assert_eq!(details, Some(r#"{"state":"open"}"#.to_string()));
+    }
+
+    #[test]
+    fn latest_contact_state_ignores_untrusted_contact_events() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+
+        log_device_event(
+            &db_path,
+            "door",
+            "closed",
+            Some("Office Door"),
+            Some(&serde_json::json!({
+                "state": "closed",
+                "contact_sensor_trusted": true,
+            })),
+        )
+        .expect("log trusted closed");
+        log_device_event(
+            &db_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&serde_json::json!({
+                "state": "open",
+                "contact_sensor_trusted": false,
+                "ignored_reason": "renovation_contact_sensors_disabled",
+            })),
+        )
+        .expect("log ignored open");
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                UPDATE device_events
+                SET timestamp = CASE event
+                    WHEN 'closed' THEN '2026-06-01 12:00:00'
+                    WHEN 'open' THEN '2026-06-01 13:00:00'
+                END
+                WHERE device_type = 'door'
+                "#,
+                [],
+            )
+            .expect("update timestamps");
+
+        assert_eq!(
+            get_latest_device_state(&db_path, "door").expect("latest raw"),
+            Some("open".to_string())
+        );
+        assert_eq!(
+            get_latest_contact_device_state(&db_path, "door").expect("latest trusted contact"),
+            Some("closed".to_string())
+        );
+    }
+
+    #[test]
+    fn daily_stats_separates_ignored_contact_events() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let today = Local::now().naive_local().date();
+        let trusted_timestamp = format_timestamp(day_start(today) + Duration::hours(9));
+        let ignored_timestamp = format_timestamp(day_start(today) + Duration::hours(10));
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+                VALUES (?, 'door', 'Office Door', 'closed', ?),
+                       (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'window', 'Office Window', 'open', ?)
+                "#,
+                params![
+                    trusted_timestamp,
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": true})
+                        .to_string(),
+                    ignored_timestamp,
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                    ignored_timestamp,
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                ],
+            )
+            .expect("insert contact events");
+
+        let stats = read_daily_stats(&db_path, 1).expect("daily stats");
+
+        assert_eq!(stats[0]["date"], today.to_string());
+        assert_eq!(stats[0]["door_events"], 1);
+        assert_eq!(stats[0]["ignored_contact_events"], 2);
+    }
+
+    #[test]
+    fn openings_exclude_ignored_contact_intervals() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let today = Local::now().naive_local().date();
+        let connection = Connection::open(&db_path).expect("open database");
+        connection
+            .execute(
+                r#"
+                INSERT INTO device_events (timestamp, device_type, device_name, event, details)
+                VALUES (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'door', 'Office Door', 'closed', ?),
+                       (?, 'door', 'Office Door', 'open', ?),
+                       (?, 'door', 'Office Door', 'closed', ?)
+                "#,
+                params![
+                    format_timestamp(day_start(today) + Duration::hours(9)),
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": false})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(10)),
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": false})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(11)),
+                    serde_json::json!({"state": "open", "contact_sensor_trusted": true})
+                        .to_string(),
+                    format_timestamp(day_start(today) + Duration::hours(12)),
+                    serde_json::json!({"state": "closed", "contact_sensor_trusted": true})
+                        .to_string(),
+                ],
+            )
+            .expect("insert openings");
+
+        let openings = read_openings(&db_path, 1).expect("openings");
+        let door = openings[0]["door"].as_array().expect("door openings");
+
+        assert_eq!(door.len(), 1);
+        assert_eq!(door[0]["open"], "11:00:00");
+        assert_eq!(door[0]["close"], "12:00:00");
     }
 }

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1391,6 +1391,7 @@ mod tests {
     fn app_config(erv: ErvConfig) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1489,6 +1489,10 @@ async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> 
 }
 
 async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
+    if !state.config.room_mode.climate_automation_enabled {
+        return Ok(());
+    }
+
     if !state.config.mitsubishi.active_control_enabled {
         return Ok(());
     }
@@ -4991,6 +4995,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_climate_automation_skips_internal_and_manual_presence_policy_writes() {
+        let mut config = configured_erv_config(true);
+        config.mitsubishi = configured_hvac_config(true).mitsubishi;
+        config.room_mode.climate_automation_enabled = false;
+        let qingping = qingping_with_temp(28.0);
+        qingping.apply_reading(qingping_reading(2100));
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 10.0,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Quiet))],
+        ));
+        let hvac_writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            erv_writer.clone(),
+            hvac_writer.clone(),
+        )
+        .expect("app state");
+
+        apply_presence_snapshot(
+            &state,
+            PresenceSnapshot {
+                last_active_timestamp: now,
+                external_monitor: true,
+                idle_seconds: 0.1,
+                display_count: 2,
+                external_displays: vec!["Studio Display".to_string()],
+            },
+        )
+        .await
+        .expect("presence update");
+        let response = service
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/presence")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"away"}"#))
+                    .expect("request"),
+            )
+            .await
+            .expect("manual presence response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(erv_writer.smoke_calls(), 0);
+        assert!(erv_writer.write_speeds().is_empty());
+        assert_eq!(hvac_writer.smoke_calls(), 0);
+        assert!(hvac_writer.write_modes().is_empty());
+    }
+
+    #[tokio::test]
     async fn websocket_broadcasts_manual_presence_updates() {
         let service = app(test_config());
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
@@ -5788,6 +5860,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_climate_automation_skips_yolink_hvac_policy_write() {
+        let mut config = configured_hvac_config(true);
+        config.room_mode.climate_automation_enabled = false;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        yolink.apply_devices(vec![office_motion_device()]);
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping_with_temp(28.0),
+            state_machine,
+            yolink.clone(),
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        let applied = yolink
+            .apply_event("motion-1", json!({"state": "alert"}), now + 1.0)
+            .expect("event applies")
+            .expect("motion report applies");
+        assert!(applied.transition.is_some());
+
+        evaluate_yolink_hvac_update(state, applied.transition).await;
+
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
+    }
+
+    #[tokio::test]
     async fn yolink_transition_broadcasts_when_only_hvac_override_clears() {
         let config = configured_hvac_config(true);
         let now = unix_timestamp_now();
@@ -6522,6 +6637,61 @@ mod tests {
             writer.write_modes(),
             vec![(HvacControlMode::Cool, Some(25.5))]
         );
+    }
+
+    #[tokio::test]
+    async fn disabled_climate_automation_skips_sensor_and_door_grace_policy_writes() {
+        let mut config = configured_erv_config(true);
+        config.mitsubishi = configured_hvac_config(true).mitsubishi;
+        config.room_mode.climate_automation_enabled = false;
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Quiet))],
+        ));
+        let hvac_writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        qingping.apply_reading(qingping_reading(2100));
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            unix_timestamp_now(),
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, unix_timestamp_now());
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            erv_writer.clone(),
+            hvac_writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_sensor_policies(
+            state.erv_automation.clone(),
+            state.clone(),
+            false,
+            "Qingping",
+        )
+        .await;
+        evaluate_sensor_policies(state.erv_automation.clone(), state, true, "door grace").await;
+
+        assert_eq!(erv_writer.smoke_calls(), 0);
+        assert!(erv_writer.write_speeds().is_empty());
+        assert_eq!(hvac_writer.smoke_calls(), 0);
+        assert!(hvac_writer.write_modes().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -1503,10 +1503,17 @@ async fn evaluate_and_apply_hvac_policy(state: &AppState) -> Result<()> {
     };
     let hvac_snapshot = state.hvac.snapshot();
     let temp_f = state
-        .qingping
-        .latest()
-        .and_then(|reading| reading.temp_c)
-        .map(celsius_to_fahrenheit);
+        .config
+        .room_mode
+        .air_quality_sensors_enabled
+        .then(|| {
+            state
+                .qingping
+                .latest()
+                .and_then(|reading| reading.temp_c)
+                .map(celsius_to_fahrenheit)
+        })
+        .flatten();
     let bands = active_temperature_bands(state);
     let hvac_mode = hvac_mode_from_str(&hvac_snapshot.mode).unwrap_or(HvacMode::Off);
     let critical_heat_needed = !state_status.is_present
@@ -3824,6 +3831,42 @@ mod tests {
         assert_eq!(value["air_quality"]["tvoc"], 25);
         assert_eq!(value["air_quality"]["noise_db"], 37.0);
         assert_eq!(value["air_quality"]["last_update"], "2026-06-05T12:30:00");
+    }
+
+    #[tokio::test]
+    async fn status_route_marks_moved_qingping_reading_as_untrusted() {
+        let qingping = QingpingState::default();
+        qingping.apply_reading(qingping_reading(900));
+        let mut config = test_config();
+        config.room_mode.renovation = true;
+        config.room_mode.air_quality_sensors_enabled = false;
+
+        let response = try_app_with_qingping(config, qingping)
+            .expect("app")
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(value["sensors"]["co2_ppm"], 400);
+        assert_eq!(value["sensors"]["air_quality_sensors_enabled"], false);
+        assert_eq!(value["sensors"]["air_quality_sensors_ignored"], true);
+        assert_eq!(value["air_quality"]["co2_ppm"], 900);
+        assert_eq!(value["air_quality"]["trusted_office_reading"], false);
+        assert_eq!(
+            value["air_quality"]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
     }
 
     #[tokio::test]
@@ -6387,6 +6430,48 @@ mod tests {
         assert_eq!(value["climate_actions"][0]["system"], "hvac");
         assert_eq!(value["climate_actions"][0]["action"], "cool");
         assert_eq!(value["climate_actions"][0]["reason"], "cool_band_start_82F");
+    }
+
+    #[tokio::test]
+    async fn disabled_air_quality_sensors_do_not_drive_hvac_temperature_policy() {
+        let mut config = configured_hvac_config(true);
+        config.room_mode.air_quality_sensors_enabled = false;
+        let writer = Arc::new(FakeHvacWriter::new(
+            vec![Ok(hvac_status(HvacControlMode::Off, 22.0))],
+            vec![Ok(hvac_status(HvacControlMode::Cool, 25.5))],
+        ));
+        let qingping = qingping_with_temp(28.0);
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            unix_timestamp_now(),
+        )));
+        state_machine
+            .write()
+            .expect("state machine lock poisoned")
+            .set_manual_presence(true, unix_timestamp_now());
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        hvac_state.record_status(hvac_status(HvacControlMode::Off, 22.0));
+        let (_service, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            qingping,
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            Arc::new(FakeErvWriter::default()),
+            writer.clone(),
+        )
+        .expect("app");
+
+        evaluate_and_apply_hvac_policy(&state)
+            .await
+            .expect("HVAC policy applies without trusted air-quality");
+
+        assert_eq!(writer.smoke_calls(), 0);
+        assert!(writer.write_modes().is_empty());
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -3007,6 +3007,7 @@ mod tests {
         let root = temp_dir.keep();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -266,8 +266,9 @@ pub fn try_app(config: AppConfig) -> Result<Router> {
 }
 
 fn try_app_with_qingping(config: AppConfig, qingping: QingpingState) -> Result<Router> {
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
@@ -533,8 +534,9 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         .await
         .with_context(|| format!("failed to bind HTTP listener at {bind_address}"))?;
     let qingping = QingpingState::default();
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         unix_timestamp_now(),
     )));
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
@@ -642,6 +644,10 @@ fn start_door_grace_policy_poll(
 }
 
 fn door_grace_policy_delay(state: &AppState) -> Option<Duration> {
+    if !state.config.room_mode.contact_sensors_enabled {
+        return None;
+    }
+
     let now = unix_timestamp_now();
     let state_status = {
         let machine = state
@@ -3521,6 +3527,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn door_grace_policy_delay_stays_idle_when_contact_sensors_are_disabled() {
+        let mut config = test_config();
+        configure_fake_erv(&mut config);
+        config.room_mode.contact_sensors_enabled = false;
+        config.mitsubishi.active_control_enabled = true;
+        let opened_at = unix_timestamp_now() - 30.0;
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            opened_at - 1.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state lock");
+            machine.sensors.door_open = true;
+            machine.sensors.door_opened_at = opened_at;
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let erv_state = ErvState::new(config.runtime.database_path.clone());
+        let hvac_state = HvacState::new(config.runtime.database_path.clone());
+        let erv_writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let (_router, state) = try_app_with_erv_writer_and_coordinator(
+            config,
+            QingpingState::default(),
+            state_machine,
+            yolink,
+            erv_state,
+            hvac_state,
+            erv_writer.clone(),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app");
+        state
+            .erv
+            .set_speed_with(
+                &state.config.erv,
+                erv_writer.as_ref(),
+                ErvFanSpeed::Turbo,
+                "test",
+                None,
+            )
+            .await
+            .expect("set ERV active");
+        state
+            .hvac
+            .record_status(hvac_status(HvacControlMode::Heat, 22.0));
+
+        assert!(door_grace_policy_delay(&state).is_none());
+    }
+
+    #[tokio::test]
     async fn door_grace_policy_delay_schedules_closed_away_restart_deadline() {
         let mut config = test_config();
         configure_fake_erv(&mut config);
@@ -3619,6 +3678,59 @@ mod tests {
         assert!(value.get("erv").is_some());
         assert!(value.get("hvac").is_some());
         assert!(value["erv"]["control"].get("last_local_ok_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn startup_restore_skips_contacts_when_contact_sensors_are_disabled() {
+        let mut config = test_config();
+        config.room_mode.contact_sensors_enabled = false;
+        db::migrate_database(&config.runtime.database_path).expect("migration");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log door");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "window",
+            "open",
+            Some("Office Window"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log window");
+        db::log_device_event(
+            &config.runtime.database_path,
+            "motion",
+            "detected",
+            Some("Office Motion"),
+            None,
+        )
+        .expect("log motion");
+
+        let response = app(config)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["is_present"], true);
+        assert_eq!(value["sensors"]["motion_detected"], true);
+        assert_eq!(value["sensors"]["door_open"], false);
+        assert_eq!(value["sensors"]["window_open"], false);
+        assert_eq!(value["sensors"]["contact_sensors_enabled"], false);
+        assert_eq!(value["sensors"]["contact_sensors_ignored"], true);
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -2069,6 +2069,7 @@ fn status_for_state(state: &AppState) -> Status {
     if let Err(error) = log_state_transition(state, timer_transition, "internal_presence") {
         tracing::warn!("failed to persist timer-driven status transition: {error:#}");
     }
+    schedule_timer_transition_policy_evaluation(state, timer_transition);
 
     status.state = state_status.state;
     status.is_present = state_status.is_present;
@@ -2090,6 +2091,36 @@ fn status_for_state(state: &AppState) -> Status {
     state.erv.overlay_status(&mut status);
     state.hvac.overlay_status(&mut status);
     status
+}
+
+fn schedule_timer_transition_policy_evaluation(
+    state: &AppState,
+    transition: Option<StateTransition>,
+) {
+    if transition.is_none() {
+        return;
+    }
+
+    clear_hvac_manual_override_on_transition(state, transition);
+    let state = state.clone();
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        tracing::warn!("skipping timer-driven policy evaluation: no Tokio runtime is active");
+        return;
+    };
+
+    handle.spawn(async move {
+        if let Err(error) = state.erv_automation.evaluate_erv_policy(true).await {
+            tracing::warn!(
+                "ERV automated policy apply failed after timer-driven transition: {error:#}"
+            );
+        }
+        if let Err(error) = evaluate_and_apply_hvac_policy(&state).await {
+            tracing::warn!(
+                "HVAC automated policy apply failed after timer-driven transition: {error:#}"
+            );
+        }
+        broadcast_status(&state);
+    });
 }
 
 fn validate_temperature_bands(bands: TemperatureBands) -> Result<(), &'static str> {
@@ -3791,6 +3822,71 @@ mod tests {
         assert_eq!(history.occupancy_history.len(), 1);
         assert_eq!(history.occupancy_history[0]["state"], "away");
         assert_eq!(history.occupancy_history[0]["trigger"], "internal_presence");
+    }
+
+    #[tokio::test]
+    async fn status_route_timer_transition_runs_policy_evaluation() {
+        let mut config = configured_erv_config(true);
+        config.room_mode.contact_sensors_enabled = false;
+        config.thresholds.motion_timeout_seconds = 1;
+        config.thresholds.min_away_seconds_before_erv = 0;
+        config.thresholds.erv_min_dwell_seconds = 0;
+        let now = unix_timestamp_now();
+        let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
+            &config.thresholds,
+            &config.room_mode,
+            now - 10.0,
+        )));
+        {
+            let mut machine = state_machine.write().expect("state lock");
+            machine.set_manual_presence(true, now - 5.0);
+            assert_eq!(machine.state, OccupancyState::Present);
+        }
+        let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
+        let writer = Arc::new(FakeErvWriter::new(
+            vec![Ok(erv_status(ErvFanSpeed::Off))],
+            vec![Ok(erv_status(ErvFanSpeed::Turbo))],
+        ));
+        let (router, _state) = try_app_with_erv_writer_and_coordinator(
+            config.clone(),
+            qingping_with_co2(2100),
+            state_machine,
+            yolink,
+            ErvState::new(config.runtime.database_path.clone()),
+            HvacState::new(config.runtime.database_path.clone()),
+            writer.clone(),
+            Arc::new(FakeHvacWriter::default()),
+        )
+        .expect("app");
+
+        let response = router
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let value: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(value["is_present"], false);
+
+        for _ in 0..50 {
+            if !writer.write_speeds().is_empty() {
+                break;
+            }
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
+        let history = db::read_history(&config.runtime.database_path, 1, 10).expect("history");
+        assert_eq!(history.occupancy_history[0]["state"], "away");
+        assert_eq!(history.climate_actions[0]["action"], "turbo");
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -907,6 +907,7 @@ mod tests {
 
         let mut status = Status::read_only_default(&crate::config::AppConfig {
             orchestrator: crate::config::OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: crate::config::QingpingConfig::default(),
             yolink: crate::config::YoLinkConfig::default(),

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -534,6 +534,27 @@ fn write_restore_env(
 
     write_literal_env(
         &mut contents,
+        "OFFICE_AUTOMATE_RENOVATION_MODE",
+        bool_env(config.room_mode.renovation),
+    )?;
+    write_literal_env(
+        &mut contents,
+        "OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED",
+        bool_env(config.room_mode.climate_automation_enabled),
+    )?;
+    write_literal_env(
+        &mut contents,
+        "OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED",
+        bool_env(config.room_mode.contact_sensors_enabled),
+    )?;
+    write_literal_env(
+        &mut contents,
+        "OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED",
+        bool_env(config.room_mode.air_quality_sensors_enabled),
+    )?;
+
+    write_literal_env(
+        &mut contents,
         "OFFICE_AUTOMATE_PRESENCE_ENABLED",
         bool_env(config.presence.enabled),
     )?;
@@ -1103,6 +1124,10 @@ mod tests {
         config.mitsubishi.device_serial = Some("serial-1".to_string());
         config.yolink.uaid = "uaid".to_string();
         config.yolink.secret_key = "secret-key".to_string();
+        config.room_mode.renovation = true;
+        config.room_mode.climate_automation_enabled = false;
+        config.room_mode.contact_sensors_enabled = false;
+        config.room_mode.air_quality_sensors_enabled = false;
         config.presence.enabled = true;
 
         let report =
@@ -1123,6 +1148,10 @@ mod tests {
         assert!(contents.contains("export OFFICE_AUTOMATE_ERV_LOCAL_KEY='local'\"'\"'key'"));
         assert!(contents.contains("export OFFICE_AUTOMATE_KUMO_PASSWORD='kumo-password'"));
         assert!(contents.contains("export OFFICE_AUTOMATE_YOLINK_SECRET_KEY='secret-key'"));
+        assert!(contents.contains("export OFFICE_AUTOMATE_RENOVATION_MODE='true'"));
+        assert!(contents.contains("export OFFICE_AUTOMATE_CLIMATE_AUTOMATION_ENABLED='false'"));
+        assert!(contents.contains("export OFFICE_AUTOMATE_CONTACT_SENSORS_ENABLED='false'"));
+        assert!(contents.contains("export OFFICE_AUTOMATE_AIR_QUALITY_SENSORS_ENABLED='false'"));
         assert!(report.validations.iter().any(
             |validation| validation == "effective restore environment written: restore-env.sh"
         ));

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -880,6 +880,7 @@ mod tests {
     fn test_config(root: &Path, config_path: PathBuf, database_path: PathBuf) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/mqtt.rs
+++ b/rust/office-automate-server/src/mqtt.rs
@@ -118,6 +118,7 @@ pub fn start_qingping_ingress(
     )?;
     let database_path = config.runtime.database_path.clone();
     let configured_mac = device_mac.to_string();
+    let office_trusted = config.room_mode.air_quality_sensors_enabled;
     let guard = Arc::new(Mutex::new(QingpingIngressGuard::default()));
 
     let mut broker = Broker::new(broker_config);
@@ -140,6 +141,7 @@ pub fn start_qingping_ingress(
                 qingping,
                 guard,
                 reading_hook,
+                office_trusted,
             );
         })
         .context("failed to spawn Qingping MQTT ingest thread")?;
@@ -167,6 +169,7 @@ fn ingest_loop(
     qingping: QingpingState,
     guard: Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<SensorIngressHook>,
+    office_trusted: bool,
 ) {
     loop {
         match link_rx.recv() {
@@ -181,6 +184,7 @@ fn ingest_loop(
                     &qingping,
                     &guard,
                     reading_hook.as_ref(),
+                    office_trusted,
                 );
             }
             Ok(Some(_)) | Ok(None) => {}
@@ -199,6 +203,7 @@ fn handle_qingping_publish(
     qingping: &QingpingState,
     guard: &Arc<Mutex<QingpingIngressGuard>>,
     reading_hook: Option<&SensorIngressHook>,
+    office_trusted: bool,
 ) {
     match parse_qingping_payload(payload, configured_mac) {
         Ok(Some(reading)) => {
@@ -210,7 +215,13 @@ fn handle_qingping_publish(
                 tracing::warn!("rejected Qingping MQTT reading: {error}");
                 return;
             }
-            if let Err(error) = db::insert_sensor_reading(database_path, &reading) {
+            let ignored_reason = (!office_trusted).then_some("renovation_air_quality_sensor_moved");
+            if let Err(error) = db::insert_sensor_reading_with_trust(
+                database_path,
+                &reading,
+                office_trusted,
+                ignored_reason,
+            ) {
                 tracing::warn!("failed to store Qingping reading: {error:#}");
             }
             qingping.apply_reading(reading);
@@ -460,10 +471,38 @@ mod tests {
             &qingping,
             &Arc::new(Mutex::new(QingpingIngressGuard::default())),
             Some(&hook),
+            true,
         );
 
         assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
         assert_eq!(qingping.latest().expect("reading").co2_ppm, Some(2100));
+    }
+
+    #[test]
+    fn qingping_publish_marks_untrusted_air_quality_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&database_path).expect("migration");
+        let qingping = QingpingState::default();
+
+        handle_qingping_publish(
+            br#"{"sensorData":[{"co2":{"value":900},"temperature":{"value":23.5},"tvoc":{"value":30}}]}"#,
+            "aa:bb:cc:dd:ee:ff",
+            &database_path,
+            &qingping,
+            &Arc::new(Mutex::new(QingpingIngressGuard::default())),
+            None,
+            false,
+        );
+
+        let history = db::read_history(&database_path, 1, 10).expect("history");
+        assert_eq!(history.sensor_readings.len(), 1);
+        assert_eq!(history.sensor_readings[0]["co2_ppm"], 900);
+        assert_eq!(history.sensor_readings[0]["office_trusted"], 0);
+        assert_eq!(
+            history.sensor_readings[0]["ignored_reason"],
+            "renovation_air_quality_sensor_moved"
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -287,6 +287,7 @@ impl ErvPolicyState {
         let tvoc_at_target = input
             .tvoc
             .is_some_and(|tvoc| tvoc <= thresholds.tvoc_away_target);
+        let air_quality_available = input.co2_ppm.is_some() || input.tvoc.is_some();
 
         match input.occupancy {
             OccupancyState::Present => {
@@ -321,7 +322,7 @@ impl ErvPolicyState {
                     return ErvDecision::NoChange;
                 }
 
-                if input.current_running {
+                if input.current_running && air_quality_available {
                     return target_decision(
                         thresholds,
                         &input,
@@ -433,6 +434,7 @@ impl ErvPolicyState {
                     && !self.tvoc_away_ventilation_active
                     && stale_speed.is_none()
                     && input.current_running
+                    && air_quality_available
                 {
                     return target_decision(
                         thresholds,

--- a/rust/office-automate-server/src/qingping.rs
+++ b/rust/office-automate-server/src/qingping.rs
@@ -70,7 +70,9 @@ impl QingpingState {
         status.air_quality.noise_db = reading.noise_db.map(|value| value as f64);
         status.air_quality.last_update = Some(reading.timestamp);
 
-        if let Some(co2_ppm) = status.air_quality.co2_ppm {
+        if status.air_quality.trusted_office_reading
+            && let Some(co2_ppm) = status.air_quality.co2_ppm
+        {
             status.sensors.co2_ppm = co2_ppm;
         }
     }
@@ -390,6 +392,7 @@ mod tests {
             erv_should_run: false,
             verifying_departure: false,
             in_door_open_mode: false,
+            room_mode: crate::status::RoomModeStatus::default(),
             sensors: crate::status::SensorsStatus::default(),
             air_quality: crate::status::AirQualityStatus::default(),
             erv: crate::status::ErvStatus::default(),
@@ -404,6 +407,61 @@ mod tests {
         state.mark_interval_configured();
         state.overlay_status(&mut status);
         assert!(status.air_quality.interval_configured);
+    }
+
+    #[test]
+    fn ignored_air_quality_does_not_overwrite_trusted_sensor_co2() {
+        let state = QingpingState::default();
+        state.apply_reading(QingpingReading {
+            device_name: "Qingping Air Monitor".to_string(),
+            mac_hint: "AABBCCDDEEFF".to_string(),
+            temp_c: Some(22.5),
+            humidity: Some(45.0),
+            co2_ppm: Some(900),
+            pm25: Some(3),
+            pm10: Some(4),
+            tvoc: Some(25),
+            noise_db: Some(37),
+            timestamp: "2026-06-22T07:30:00".to_string(),
+            raw_data: "{}".to_string(),
+        });
+        let mut status = Status {
+            state: "away".to_string(),
+            is_present: false,
+            presence_signal_active: false,
+            safety_interlock: false,
+            erv_should_run: false,
+            verifying_departure: false,
+            in_door_open_mode: false,
+            room_mode: crate::status::RoomModeStatus {
+                renovation: true,
+                climate_automation_enabled: false,
+                contact_sensors_enabled: false,
+                air_quality_sensors_enabled: false,
+            },
+            sensors: crate::status::SensorsStatus {
+                co2_ppm: 400,
+                air_quality_sensors_enabled: false,
+                air_quality_sensors_ignored: true,
+                ..crate::status::SensorsStatus::default()
+            },
+            air_quality: crate::status::AirQualityStatus {
+                trusted_office_reading: false,
+                ignored_reason: Some("renovation_air_quality_sensor_moved".to_string()),
+                ..crate::status::AirQualityStatus::default()
+            },
+            erv: crate::status::ErvStatus::default(),
+            hvac: crate::status::HvacStatus::default(),
+            manual_override: crate::status::ManualOverrideStatus::default(),
+            notifications: Vec::new(),
+        };
+
+        state.overlay_status(&mut status);
+
+        assert_eq!(status.air_quality.co2_ppm, Some(900));
+        assert_eq!(status.air_quality.temp_c, Some(22.5));
+        assert!(!status.air_quality.trusted_office_reading);
+        assert_eq!(status.sensors.co2_ppm, 400);
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -187,13 +187,11 @@ impl StateMachine {
 
     pub fn presence_signal_active_at(&self, now: f64) -> bool {
         if !self.config.contact_sensors_enabled {
-            let motion_age = now - self.sensors.motion_last_seen;
-            let motion_recent = self.sensors.motion_detected
-                || (self.sensors.motion_last_seen > 0.0
-                    && motion_age < self.config.motion_timeout_seconds);
+            let motion_recent = self.signal_recent_at(self.sensors.motion_last_seen, now);
             let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
-            let mac_recent =
-                self.sensors.external_monitor && self.sensors.mac_last_active > freshness_anchor;
+            let mac_recent = self.sensors.external_monitor
+                && self.sensors.mac_last_active > freshness_anchor
+                && self.signal_recent_at(self.sensors.mac_last_active, now);
             return mac_recent || motion_recent;
         }
 
@@ -215,6 +213,10 @@ impl StateMachine {
             && self.sensors.motion_last_seen > self.sensors.door_last_changed;
 
         mac_presence || motion_inside
+    }
+
+    fn signal_recent_at(&self, timestamp: f64, now: f64) -> bool {
+        timestamp > 0.0 && now - timestamp < self.config.motion_timeout_seconds
     }
 
     pub fn safety_interlock_active(&self) -> bool {
@@ -291,10 +293,19 @@ impl StateMachine {
                 }
                 None
             }
-        } else if self.state == OccupancyState::Away && self.presence_signal_active_at(now) {
-            self.transition_to(OccupancyState::Present)
         } else {
-            None
+            let presence_signal_active = self.presence_signal_active_at(now);
+            if self.state == OccupancyState::Away && presence_signal_active {
+                self.transition_to(OccupancyState::Present)
+            } else if !self.config.contact_sensors_enabled
+                && self.state == OccupancyState::Present
+                && !presence_signal_active
+            {
+                self.sensors.motion_detected = false;
+                self.transition_to(OccupancyState::Away)
+            } else {
+                None
+            }
         };
 
         self.last_door_state = Some(self.sensors.door_open);
@@ -854,6 +865,73 @@ mod tests {
                 new_state: OccupancyState::Present,
             })
         );
+    }
+
+    #[test]
+    fn disabled_contact_sensors_transition_away_after_motion_timeout() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_motion(true, 1_010.0)
+                .is_some_and(|transition| transition.new_state == OccupancyState::Present)
+        );
+
+        let transition = machine.evaluate_at(1_071.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.sensors.motion_detected);
+        assert!(!machine.presence_signal_active_at(1_071.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_transition_away_when_mac_activity_is_stale() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_mac_occupancy(1_010.0, true, 1_010.0)
+                .is_some_and(|transition| transition.new_state == OccupancyState::Present)
+        );
+
+        let transition = machine.evaluate_at(1_071.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.presence_signal_active_at(1_071.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_transition_away_when_external_monitor_disconnects() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_mac_occupancy(1_010.0, true, 1_010.0)
+                .is_some_and(|transition| transition.new_state == OccupancyState::Present)
+        );
+
+        let transition = machine.update_mac_occupancy(1_010.0, false, 1_020.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.presence_signal_active_at(1_020.0));
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::config::ThresholdsConfig;
+use crate::config::{RoomModeConfig, ThresholdsConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -26,10 +26,18 @@ pub struct StateConfig {
     pub door_open_away_timeout_minutes: f64,
     pub co2_critical_ppm: i64,
     pub co2_refresh_target_ppm: i64,
+    pub contact_sensors_enabled: bool,
 }
 
 impl StateConfig {
     pub fn from_thresholds(thresholds: &ThresholdsConfig) -> Self {
+        Self::from_thresholds_and_room_mode(thresholds, &RoomModeConfig::default())
+    }
+
+    pub fn from_thresholds_and_room_mode(
+        thresholds: &ThresholdsConfig,
+        room_mode: &RoomModeConfig,
+    ) -> Self {
         Self {
             motion_timeout_seconds: thresholds.motion_timeout_seconds as f64,
             departure_verification_seconds: thresholds.departure_verification_seconds as f64,
@@ -37,6 +45,7 @@ impl StateConfig {
             door_open_away_timeout_minutes: thresholds.door_open_away_timeout_minutes as f64,
             co2_critical_ppm: thresholds.co2_critical_ppm,
             co2_refresh_target_ppm: thresholds.co2_refresh_target_ppm,
+            contact_sensors_enabled: room_mode.contact_sensors_enabled,
         }
     }
 }
@@ -50,6 +59,7 @@ impl Default for StateConfig {
             door_open_away_timeout_minutes: 5.0,
             co2_critical_ppm: 2000,
             co2_refresh_target_ppm: 500,
+            contact_sensors_enabled: true,
         }
     }
 }
@@ -130,6 +140,7 @@ pub struct StateMachine {
     door_open_away_deadline: Option<f64>,
     suppress_next_door_close_departure: bool,
     last_activity_time: f64,
+    last_manual_away_at: Option<f64>,
 }
 
 impl StateMachine {
@@ -146,6 +157,7 @@ impl StateMachine {
             door_open_away_deadline: None,
             suppress_next_door_close_departure: false,
             last_activity_time: now,
+            last_manual_away_at: None,
         }
     }
 
@@ -153,13 +165,38 @@ impl StateMachine {
         Self::new(StateConfig::from_thresholds(thresholds), now)
     }
 
+    pub fn from_thresholds_and_room_mode(
+        thresholds: &ThresholdsConfig,
+        room_mode: &RoomModeConfig,
+        now: f64,
+    ) -> Self {
+        Self::new(
+            StateConfig::from_thresholds_and_room_mode(thresholds, room_mode),
+            now,
+        )
+    }
+
     pub fn in_door_open_mode_at(&self, now: f64) -> bool {
+        if !self.config.contact_sensors_enabled {
+            return false;
+        }
         self.sensors.door_open
             && (now - self.sensors.door_last_changed) / 60.0
                 >= self.config.door_open_threshold_minutes
     }
 
     pub fn presence_signal_active_at(&self, now: f64) -> bool {
+        if !self.config.contact_sensors_enabled {
+            let motion_age = now - self.sensors.motion_last_seen;
+            let motion_recent = self.sensors.motion_detected
+                || (self.sensors.motion_last_seen > 0.0
+                    && motion_age < self.config.motion_timeout_seconds);
+            let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
+            let mac_recent =
+                self.sensors.external_monitor && self.sensors.mac_last_active > freshness_anchor;
+            return mac_recent || motion_recent;
+        }
+
         if self.in_door_open_mode_at(now) {
             let motion_age = now - self.sensors.motion_last_seen;
             let motion_recent =
@@ -181,6 +218,9 @@ impl StateMachine {
     }
 
     pub fn safety_interlock_active(&self) -> bool {
+        if !self.config.contact_sensors_enabled {
+            return false;
+        }
         self.sensors.window_open || self.sensors.door_open
     }
 
@@ -200,6 +240,13 @@ impl StateMachine {
     }
 
     pub fn advance_timers(&mut self, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.departure_verification_deadline = None;
+            self.door_open_away_deadline = None;
+            self.suppress_next_door_close_departure = false;
+            return None;
+        }
+
         if self
             .departure_verification_deadline
             .is_some_and(|deadline| now >= deadline)
@@ -291,6 +338,11 @@ impl StateMachine {
     }
 
     pub fn update_door(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return self.advance_timers(now);
+        }
+
         let timer_transition = self.advance_timers(now);
         let was_open = self.last_door_state;
         let previous_open = was_open.unwrap_or(self.sensors.door_open);
@@ -322,6 +374,11 @@ impl StateMachine {
     }
 
     pub fn restore_door_state(&mut self, is_open: bool, changed_at: f64, now: f64) {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return;
+        }
+
         let changed_at = changed_at.min(now).max(0.0);
         self.sensors.door_open = is_open;
         self.sensors.door_last_changed = changed_at;
@@ -335,6 +392,11 @@ impl StateMachine {
     }
 
     pub fn update_window(&mut self, is_open: bool, now: f64) -> Option<StateTransition> {
+        if !self.config.contact_sensors_enabled {
+            self.sensors.last_updated = now;
+            return self.advance_timers(now);
+        }
+
         let timer_transition = self.advance_timers(now);
 
         self.sensors.window_open = is_open;
@@ -353,13 +415,13 @@ impl StateMachine {
             if self.verifying_departure() {
                 self.cancel_departure_verification();
             }
-            if self.sensors.door_open {
+            if self.config.contact_sensors_enabled && self.sensors.door_open {
                 self.suppress_next_door_close_departure = true;
             }
             self.sensors.last_updated = now;
             self.state = OccupancyState::Present;
             self.last_door_state = Some(self.sensors.door_open);
-            if self.sensors.door_open {
+            if self.config.contact_sensors_enabled && self.sensors.door_open {
                 self.start_door_open_away_timer(now);
             }
             return (old_state != self.state).then_some(StateTransition {
@@ -377,6 +439,7 @@ impl StateMachine {
         self.sensors.last_updated = now;
         self.state = OccupancyState::Away;
         self.last_door_state = Some(self.sensors.door_open);
+        self.last_manual_away_at = Some(now);
 
         (old_state != self.state).then_some(StateTransition {
             old_state,
@@ -425,7 +488,7 @@ impl StateMachine {
     }
 
     fn start_departure_verification(&mut self, now: f64) {
-        if self.state == OccupancyState::Present {
+        if self.config.contact_sensors_enabled && self.state == OccupancyState::Present {
             self.departure_verification_deadline =
                 Some(now + self.config.departure_verification_seconds);
         }
@@ -436,7 +499,7 @@ impl StateMachine {
     }
 
     fn start_door_open_away_timer(&mut self, now: f64) {
-        if self.state == OccupancyState::Present {
+        if self.config.contact_sensors_enabled && self.state == OccupancyState::Present {
             self.door_open_away_deadline =
                 Some(now + self.config.door_open_away_timeout_minutes * 60.0);
         }
@@ -454,6 +517,13 @@ mod tests {
     fn fast_departure_config() -> StateConfig {
         StateConfig {
             departure_verification_seconds: 10.0,
+            ..StateConfig::default()
+        }
+    }
+
+    fn contact_disabled_config() -> StateConfig {
+        StateConfig {
+            contact_sensors_enabled: false,
             ..StateConfig::default()
         }
     }
@@ -726,6 +796,64 @@ mod tests {
         assert!(!machine.sensors.door_open);
         assert_eq!(machine.sensors.door_last_changed, 1_040.0);
         assert_eq!(machine.sensors.door_closed_at, 1_030.0);
+    }
+
+    #[test]
+    fn disabled_contact_sensors_do_not_update_logical_contact_state() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+
+        assert_eq!(machine.update_door(true, 1_010.0), None);
+        assert_eq!(machine.update_window(true, 1_011.0), None);
+
+        assert!(!machine.sensors.door_open);
+        assert_eq!(machine.sensors.door_opened_at, 0.0);
+        assert!(!machine.sensors.window_open);
+        assert!(!machine.safety_interlock_active());
+        assert!(!machine.in_door_open_mode_at(1_400.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_allow_motion_presence_without_door_boundary() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        machine.sensors.door_open = true;
+        machine.sensors.door_last_changed = 2_000.0;
+
+        let transition = machine.update_motion(true, 1_010.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(!machine.in_door_open_mode_at(2_400.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_do_not_reassert_stale_mac_after_manual_away() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_mac_occupancy(1_010.0, true, 1_010.0)
+                .is_some()
+        );
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        machine.set_manual_presence(false, 1_020.0);
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert_eq!(machine.update_mac_occupancy(1_010.0, true, 1_021.0), None);
+        assert_eq!(machine.state, OccupancyState::Away);
+
+        let transition = machine.update_mac_occupancy(1_022.0, true, 1_022.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -189,9 +189,8 @@ impl StateMachine {
         if !self.config.contact_sensors_enabled {
             let motion_recent = self.signal_recent_at(self.sensors.motion_last_seen, now);
             let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
-            let mac_recent = self.sensors.external_monitor
-                && self.sensors.mac_last_active > freshness_anchor
-                && self.signal_recent_at(self.sensors.mac_last_active, now);
+            let mac_recent =
+                self.sensors.external_monitor && self.sensors.mac_last_active > freshness_anchor;
             return mac_recent || motion_recent;
         }
 
@@ -246,7 +245,7 @@ impl StateMachine {
             self.departure_verification_deadline = None;
             self.door_open_away_deadline = None;
             self.suppress_next_door_close_departure = false;
-            return None;
+            return self.advance_contact_disabled_absence(now);
         }
 
         if self
@@ -282,13 +281,6 @@ impl StateMachine {
             return Some(transition);
         }
 
-        if !self.config.contact_sensors_enabled
-            && self.sensors.motion_detected
-            && !self.signal_recent_at(self.sensors.motion_last_seen, now)
-        {
-            self.sensors.motion_detected = false;
-        }
-
         let transition = if self.in_door_open_mode_at(now) {
             if self.state == OccupancyState::Away && self.presence_signal_active_at(now) {
                 let transition = self.transition_to(OccupancyState::Present);
@@ -317,6 +309,20 @@ impl StateMachine {
 
         self.last_door_state = Some(self.sensors.door_open);
         transition
+    }
+
+    fn advance_contact_disabled_absence(&mut self, now: f64) -> Option<StateTransition> {
+        if self.sensors.motion_detected
+            && !self.signal_recent_at(self.sensors.motion_last_seen, now)
+        {
+            self.sensors.motion_detected = false;
+        }
+
+        if self.state == OccupancyState::Present && !self.presence_signal_active_at(now) {
+            return self.transition_to(OccupancyState::Away);
+        }
+
+        None
     }
 
     pub fn update_mac_occupancy(
@@ -898,6 +904,29 @@ mod tests {
     }
 
     #[test]
+    fn disabled_contact_sensors_advance_timers_transitions_away_after_motion_timeout() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_motion(true, 1_010.0)
+                .is_some_and(|transition| transition.new_state == OccupancyState::Present)
+        );
+
+        let transition = machine.advance_timers(1_071.0);
+
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert_eq!(machine.state, OccupancyState::Away);
+        assert!(!machine.sensors.motion_detected);
+        assert!(!machine.presence_signal_active_at(1_071.0));
+    }
+
+    #[test]
     fn disabled_contact_sensors_keep_present_while_motion_flag_is_recent() {
         let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
         assert!(
@@ -923,7 +952,7 @@ mod tests {
     }
 
     #[test]
-    fn disabled_contact_sensors_transition_away_when_mac_activity_is_stale() {
+    fn disabled_contact_sensors_keep_present_while_external_monitor_remains_connected() {
         let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
         assert!(
             machine
@@ -933,15 +962,9 @@ mod tests {
 
         let transition = machine.evaluate_at(1_071.0);
 
-        assert_eq!(
-            transition,
-            Some(StateTransition {
-                old_state: OccupancyState::Present,
-                new_state: OccupancyState::Away,
-            })
-        );
-        assert_eq!(machine.state, OccupancyState::Away);
-        assert!(!machine.presence_signal_active_at(1_071.0));
+        assert_eq!(transition, None);
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(machine.presence_signal_active_at(1_071.0));
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -187,7 +187,8 @@ impl StateMachine {
 
     pub fn presence_signal_active_at(&self, now: f64) -> bool {
         if !self.config.contact_sensors_enabled {
-            let motion_recent = self.signal_recent_at(self.sensors.motion_last_seen, now);
+            let motion_recent = self.sensors.motion_detected
+                || self.signal_recent_at(self.sensors.motion_last_seen, now);
             let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
             let mac_recent = self.sensors.external_monitor
                 && self.sensors.mac_last_active > freshness_anchor
@@ -280,6 +281,13 @@ impl StateMachine {
     pub fn evaluate_at(&mut self, now: f64) -> Option<StateTransition> {
         if let Some(transition) = self.advance_timers(now) {
             return Some(transition);
+        }
+
+        if !self.config.contact_sensors_enabled
+            && self.sensors.motion_detected
+            && !self.signal_recent_at(self.sensors.motion_last_seen, now)
+        {
+            self.sensors.motion_detected = false;
         }
 
         let transition = if self.in_door_open_mode_at(now) {
@@ -888,6 +896,22 @@ mod tests {
         assert_eq!(machine.state, OccupancyState::Away);
         assert!(!machine.sensors.motion_detected);
         assert!(!machine.presence_signal_active_at(1_071.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_keep_present_while_motion_flag_is_recent() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        assert!(
+            machine
+                .update_motion(true, 1_010.0)
+                .is_some_and(|transition| transition.new_state == OccupancyState::Present)
+        );
+
+        assert_eq!(machine.evaluate_at(1_040.0), None);
+
+        assert_eq!(machine.state, OccupancyState::Present);
+        assert!(machine.sensors.motion_detected);
+        assert!(machine.presence_signal_active_at(1_040.0));
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -187,8 +187,7 @@ impl StateMachine {
 
     pub fn presence_signal_active_at(&self, now: f64) -> bool {
         if !self.config.contact_sensors_enabled {
-            let motion_recent = self.sensors.motion_detected
-                || self.signal_recent_at(self.sensors.motion_last_seen, now);
+            let motion_recent = self.signal_recent_at(self.sensors.motion_last_seen, now);
             let freshness_anchor = self.last_manual_away_at.unwrap_or(0.0);
             let mac_recent = self.sensors.external_monitor
                 && self.sensors.mac_last_active > freshness_anchor
@@ -912,6 +911,15 @@ mod tests {
         assert_eq!(machine.state, OccupancyState::Present);
         assert!(machine.sensors.motion_detected);
         assert!(machine.presence_signal_active_at(1_040.0));
+    }
+
+    #[test]
+    fn disabled_contact_sensors_report_stale_motion_inactive_without_evaluation() {
+        let mut machine = StateMachine::new(contact_disabled_config(), 1_000.0);
+        machine.sensors.motion_detected = true;
+        machine.sensors.motion_last_seen = 1_010.0;
+
+        assert!(!machine.presence_signal_active_at(1_071.0));
     }
 
     #[test]

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -11,6 +11,7 @@ pub struct Status {
     pub erv_should_run: bool,
     pub verifying_departure: bool,
     pub in_door_open_mode: bool,
+    pub room_mode: RoomModeStatus,
     pub sensors: SensorsStatus,
     pub air_quality: AirQualityStatus,
     pub erv: ErvStatus,
@@ -28,7 +29,20 @@ impl Status {
         config: &AppConfig,
         temperature_bands: TemperatureBands,
     ) -> Self {
-        let sensors = SensorsStatus::default();
+        let sensors = SensorsStatus {
+            contact_sensors_enabled: config.room_mode.contact_sensors_enabled,
+            contact_sensors_ignored: !config.room_mode.contact_sensors_enabled,
+            air_quality_sensors_enabled: config.room_mode.air_quality_sensors_enabled,
+            air_quality_sensors_ignored: !config.room_mode.air_quality_sensors_enabled,
+            ..SensorsStatus::default()
+        };
+        let air_quality = AirQualityStatus {
+            report_interval: config.qingping.report_interval,
+            trusted_office_reading: config.room_mode.air_quality_sensors_enabled,
+            ignored_reason: (!config.room_mode.air_quality_sensors_enabled)
+                .then(|| "renovation_air_quality_sensor_moved".to_string()),
+            ..AirQualityStatus::default()
+        };
 
         Self {
             state: "away".to_string(),
@@ -38,11 +52,9 @@ impl Status {
             erv_should_run: sensors.co2_ppm > config.thresholds.co2_refresh_target_ppm,
             verifying_departure: false,
             in_door_open_mode: false,
+            room_mode: RoomModeStatus::from_config(config),
             sensors,
-            air_quality: AirQualityStatus {
-                report_interval: config.qingping.report_interval,
-                ..AirQualityStatus::default()
-            },
+            air_quality,
             erv: ErvStatus {
                 away_stale_flush_enabled: config.thresholds.away_stale_flush_enabled,
                 ..ErvStatus::default()
@@ -58,6 +70,36 @@ impl Status {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomModeStatus {
+    pub renovation: bool,
+    pub climate_automation_enabled: bool,
+    pub contact_sensors_enabled: bool,
+    pub air_quality_sensors_enabled: bool,
+}
+
+impl RoomModeStatus {
+    fn from_config(config: &AppConfig) -> Self {
+        Self {
+            renovation: config.room_mode.renovation,
+            climate_automation_enabled: config.room_mode.climate_automation_enabled,
+            contact_sensors_enabled: config.room_mode.contact_sensors_enabled,
+            air_quality_sensors_enabled: config.room_mode.air_quality_sensors_enabled,
+        }
+    }
+}
+
+impl Default for RoomModeStatus {
+    fn default() -> Self {
+        Self {
+            renovation: false,
+            climate_automation_enabled: true,
+            contact_sensors_enabled: true,
+            air_quality_sensors_enabled: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SensorsStatus {
     pub mac_last_active: f64,
@@ -68,6 +110,10 @@ pub struct SensorsStatus {
     pub door_last_changed: f64,
     pub window_open: bool,
     pub co2_ppm: i64,
+    pub contact_sensors_enabled: bool,
+    pub contact_sensors_ignored: bool,
+    pub air_quality_sensors_enabled: bool,
+    pub air_quality_sensors_ignored: bool,
 }
 
 impl Default for SensorsStatus {
@@ -81,6 +127,10 @@ impl Default for SensorsStatus {
             door_last_changed: 0.0,
             window_open: false,
             co2_ppm: 400,
+            contact_sensors_enabled: true,
+            contact_sensors_ignored: false,
+            air_quality_sensors_enabled: true,
+            air_quality_sensors_ignored: false,
         }
     }
 }
@@ -97,6 +147,8 @@ pub struct AirQualityStatus {
     pub last_update: Option<String>,
     pub report_interval: u64,
     pub interval_configured: bool,
+    pub trusted_office_reading: bool,
+    pub ignored_reason: Option<String>,
 }
 
 impl Default for AirQualityStatus {
@@ -112,6 +164,8 @@ impl Default for AirQualityStatus {
             last_update: None,
             report_interval: 60,
             interval_configured: false,
+            trusted_office_reading: true,
+            ignored_reason: None,
         }
     }
 }
@@ -243,12 +297,13 @@ mod tests {
     use super::*;
     use crate::config::{
         ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-        RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
+        RoomModeConfig, RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig {
                 report_interval: 45,
@@ -302,6 +357,7 @@ mod tests {
             "erv_should_run",
             "verifying_departure",
             "in_door_open_mode",
+            "room_mode",
             "sensors",
             "air_quality",
             "erv",
@@ -316,8 +372,16 @@ mod tests {
         assert_eq!(value["sensors"]["mac_last_active"], 0.0);
         assert_eq!(value["sensors"]["mac_active"], false);
         assert_eq!(value["sensors"]["co2_ppm"], 400);
+        assert_eq!(value["room_mode"]["renovation"], false);
+        assert_eq!(value["room_mode"]["climate_automation_enabled"], true);
+        assert_eq!(value["sensors"]["contact_sensors_enabled"], true);
+        assert_eq!(value["sensors"]["contact_sensors_ignored"], false);
+        assert_eq!(value["sensors"]["air_quality_sensors_enabled"], true);
+        assert_eq!(value["sensors"]["air_quality_sensors_ignored"], false);
         assert_eq!(value["air_quality"]["report_interval"], 45);
         assert_eq!(value["air_quality"]["interval_configured"], false);
+        assert_eq!(value["air_quality"]["trusted_office_reading"], true);
+        assert!(value["air_quality"]["ignored_reason"].is_null());
         assert_eq!(value["erv"]["speed"], "off");
         assert_eq!(value["erv"]["away_stale_flush_enabled"], false);
         assert!(value["erv"]["control"]["last_ok_at"].is_null());

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1504,8 +1504,9 @@ async fn validate_live_devices(
     if !config.yolink.is_configured() {
         bail!("shadow validation requires configured YoLink API credentials");
     }
-    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds(
+    let state_machine = Arc::new(RwLock::new(StateMachine::from_thresholds_and_room_mode(
         &config.thresholds,
+        &config.room_mode,
         current_timestamp_seconds(),
     )));
     let yolink_state = YoLinkState::new(state_machine, config.runtime.database_path.clone());

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -3404,6 +3404,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: crate::config::PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -951,6 +951,7 @@ mod tests {
             .to_path_buf();
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
+            room_mode: crate::config::RoomModeConfig::default(),
             presence: PresenceConfig::default(),
             qingping: QingpingConfig::default(),
             yolink: YoLinkConfig::default(),

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -1627,6 +1627,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_climate_automation_skips_yolink_erv_policy_write() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let mut config = test_config(db_path.clone());
+        config.room_mode.climate_automation_enabled = false;
+        let state_machine = Arc::new(RwLock::new(StateMachine::new(
+            StateConfig::from_thresholds_and_room_mode(&config.thresholds, &config.room_mode),
+            1_000.0,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
+        yolink.apply_devices(sample_devices());
+        let qingping = QingpingState::default();
+        let erv = ErvState::new(db_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(
+            ErvFanSpeed::Medium,
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = tokio::sync::broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+        let hook_observations = Arc::new(Mutex::new(Vec::new()));
+        let hook: DeviceIngressHook = Arc::new({
+            let hook_observations = hook_observations.clone();
+            move |transition| {
+                hook_observations
+                    .lock()
+                    .expect("hook observations lock")
+                    .push(transition);
+            }
+        });
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "motion-1".to_string(),
+                data: json!({"state": "alert"}),
+            },
+            1_002.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("report applies through climate gate");
+
+        assert!(writer.write_speeds().is_empty());
+        assert_eq!(
+            *hook_observations.lock().expect("hook observations lock"),
+            vec![Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })]
+        );
+    }
+
+    #[tokio::test]
     async fn ignored_contact_events_do_not_trigger_policy_or_hook_but_motion_does() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -230,16 +230,26 @@ impl YoLinkState {
             return Ok(None);
         };
         self.record_device_event(device_id, &validated.details);
+        let contact_sensors_enabled = self.contact_sensors_enabled();
+        let is_contact_event = matches!(validated.role, DeviceRole::Door | DeviceRole::Window);
+        let details = if is_contact_event {
+            contact_event_details(validated.details.clone(), contact_sensors_enabled)
+        } else {
+            validated.details.clone()
+        };
 
         let (device_type, event, transition) = match validated.role {
             DeviceRole::Door => match validated.state {
                 ValidatedYoLinkState::Open | ValidatedYoLinkState::Closed => {
                     let is_open = validated.state == ValidatedYoLinkState::Open;
-                    let transition = self
-                        .state_machine
-                        .write()
-                        .expect("state machine lock poisoned")
-                        .update_door(is_open, now);
+                    let transition = contact_sensors_enabled
+                        .then(|| {
+                            self.state_machine
+                                .write()
+                                .expect("state machine lock poisoned")
+                                .update_door(is_open, now)
+                        })
+                        .flatten();
                     ("door", if is_open { "open" } else { "closed" }, transition)
                 }
                 ValidatedYoLinkState::Error => ("door", "error", None),
@@ -250,11 +260,14 @@ impl YoLinkState {
             DeviceRole::Window => match validated.state {
                 ValidatedYoLinkState::Open | ValidatedYoLinkState::Closed => {
                     let is_open = validated.state == ValidatedYoLinkState::Open;
-                    let transition = self
-                        .state_machine
-                        .write()
-                        .expect("state machine lock poisoned")
-                        .update_window(is_open, now);
+                    let transition = contact_sensors_enabled
+                        .then(|| {
+                            self.state_machine
+                                .write()
+                                .expect("state machine lock poisoned")
+                                .update_window(is_open, now)
+                        })
+                        .flatten();
                     (
                         "window",
                         if is_open { "open" } else { "closed" },
@@ -292,13 +305,17 @@ impl YoLinkState {
             device_type,
             event,
             Some(&validated.device_name),
-            Some(&validated.details),
+            Some(&details),
         ) {
             tracing::warn!(
                 "failed to persist YoLink {device_type} event after state update: {error:#}"
             );
         }
         self.notify_status();
+
+        if is_contact_event && !contact_sensors_enabled {
+            return Ok(None);
+        }
 
         Ok(Some(YoLinkAppliedEvent {
             device_type: device_type.to_string(),
@@ -362,20 +379,31 @@ impl YoLinkState {
         }
     }
 
+    fn contact_sensors_enabled(&self) -> bool {
+        self.state_machine
+            .read()
+            .expect("state machine lock poisoned")
+            .config
+            .contact_sensors_enabled
+    }
+
     pub fn restore_from_database(&self, now: f64) -> Result<()> {
-        if let Some((state, changed_at)) =
-            db::get_latest_contact_device_state_with_timestamp(&self.database_path, "door")?
-        {
-            self.state_machine
-                .write()
-                .expect("state machine lock poisoned")
-                .restore_door_state(state == "open", changed_at.unwrap_or(now), now);
-        }
-        if let Some(state) = db::get_latest_contact_device_state(&self.database_path, "window")? {
-            self.state_machine
-                .write()
-                .expect("state machine lock poisoned")
-                .update_window(state == "open", now);
+        if self.contact_sensors_enabled() {
+            if let Some((state, changed_at)) =
+                db::get_latest_contact_device_state_with_timestamp(&self.database_path, "door")?
+            {
+                self.state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .restore_door_state(state == "open", changed_at.unwrap_or(now), now);
+            }
+            if let Some(state) = db::get_latest_contact_device_state(&self.database_path, "window")?
+            {
+                self.state_machine
+                    .write()
+                    .expect("state machine lock poisoned")
+                    .update_window(state == "open", now);
+            }
         }
         if let Some(state) = db::get_latest_device_state(&self.database_path, "motion")? {
             self.state_machine
@@ -673,6 +701,19 @@ fn sanitize_yolink_event_details(event_data: &Value) -> Result<Value> {
     Ok(Value::Object(sanitized))
 }
 
+fn contact_event_details(mut details: Value, trusted: bool) -> Value {
+    if let Value::Object(object) = &mut details {
+        object.insert("contact_sensor_trusted".to_string(), json!(trusted));
+        if !trusted {
+            object.insert(
+                "ignored_reason".to_string(),
+                json!("renovation_contact_sensors_disabled"),
+            );
+        }
+    }
+    details
+}
+
 fn sanitize_yolink_detail_value(value: &Value) -> Option<Value> {
     match value {
         Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.clone()),
@@ -935,11 +976,15 @@ mod tests {
     }
 
     fn test_state(database_path: PathBuf) -> YoLinkState {
+        test_state_with_config(
+            database_path,
+            StateConfig::from_thresholds(&ThresholdsConfig::default()),
+        )
+    }
+
+    fn test_state_with_config(database_path: PathBuf, state_config: StateConfig) -> YoLinkState {
         YoLinkState::new(
-            Arc::new(RwLock::new(StateMachine::new(
-                StateConfig::from_thresholds(&ThresholdsConfig::default()),
-                1_000.0,
-            ))),
+            Arc::new(RwLock::new(StateMachine::new(state_config, 1_000.0))),
             database_path,
         )
     }
@@ -1367,6 +1412,74 @@ mod tests {
     }
 
     #[test]
+    fn disabled_contact_sensors_log_raw_events_without_updating_contact_state() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let yolink = test_state_with_config(
+            db_path.clone(),
+            StateConfig {
+                contact_sensors_enabled: false,
+                ..StateConfig::from_thresholds(&ThresholdsConfig::default())
+            },
+        );
+        yolink.apply_devices(sample_devices());
+
+        let door = yolink
+            .apply_event("door-1", json!({"state": "open"}), 1_010.0)
+            .expect("door event");
+        let window = yolink
+            .apply_event("window-1", json!({"state": "open"}), 1_011.0)
+            .expect("window event");
+        let motion = yolink
+            .apply_event("motion-1", json!({"state": "alert"}), 1_012.0)
+            .expect("motion event")
+            .expect("applied");
+
+        assert!(door.is_none());
+        assert!(window.is_none());
+        assert_eq!(
+            motion.transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })
+        );
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(!machine.sensors.door_open);
+        assert!(!machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        assert_eq!(machine.state, OccupancyState::Present);
+        drop(machine);
+
+        assert_eq!(
+            db::get_latest_device_state(&db_path, "door").expect("raw door state"),
+            Some("open".to_string())
+        );
+        assert_eq!(
+            db::get_latest_contact_device_state(&db_path, "door").expect("trusted door state"),
+            None
+        );
+        let history = db::read_history(&db_path, 24, 10).expect("history");
+        let door_event = history
+            .device_events
+            .iter()
+            .find(|event| event["device_type"] == "door")
+            .expect("door event");
+        let door_details = door_event["details"].as_str().expect("details string");
+        let door_details: Value = serde_json::from_str(door_details).expect("details json");
+        assert_eq!(door_details["contact_sensor_trusted"], false);
+        assert_eq!(
+            door_details["ignored_reason"],
+            "renovation_contact_sensors_disabled"
+        );
+    }
+
+    #[test]
     fn persists_yolink_occupancy_transitions() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");
@@ -1514,6 +1627,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ignored_contact_events_do_not_trigger_policy_or_hook_but_motion_does() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        let mut config = test_config(db_path.clone());
+        config.room_mode.contact_sensors_enabled = false;
+        let state_machine = Arc::new(RwLock::new(StateMachine::new(
+            StateConfig::from_thresholds_and_room_mode(&config.thresholds, &config.room_mode),
+            1_000.0,
+        )));
+        let yolink = YoLinkState::new(state_machine.clone(), db_path.clone());
+        yolink.apply_devices(sample_devices());
+        let qingping = QingpingState::default();
+        let erv = ErvState::new(db_path);
+        let writer = Arc::new(FakeErvWriter::new(vec![Ok(erv_status(
+            ErvFanSpeed::Medium,
+        ))]));
+        let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
+        let (status_broadcast, _) = tokio::sync::broadcast::channel(4);
+        let coordinator = ErvPolicyCoordinator::new(
+            config,
+            state_machine,
+            qingping,
+            erv,
+            policy,
+            writer.clone(),
+            status_broadcast,
+        );
+        let hook_observations = Arc::new(Mutex::new(Vec::new()));
+        let hook: DeviceIngressHook = Arc::new({
+            let hook_observations = hook_observations.clone();
+            move |transition| {
+                hook_observations
+                    .lock()
+                    .expect("hook observations lock")
+                    .push(transition);
+            }
+        });
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "door-1".to_string(),
+                data: json!({"state": "open"}),
+            },
+            1_002.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("ignored contact report applies");
+
+        assert!(writer.write_speeds().is_empty());
+        assert!(
+            hook_observations
+                .lock()
+                .expect("hook observations lock")
+                .is_empty()
+        );
+
+        apply_yolink_report_with_policy(
+            &yolink,
+            YoLinkReport {
+                device_id: "motion-1".to_string(),
+                data: json!({"state": "alert"}),
+            },
+            1_003.0,
+            Some(&coordinator),
+            Some(&hook),
+        )
+        .await
+        .expect("motion report applies");
+
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Off]);
+        assert_eq!(
+            *hook_observations.lock().expect("hook observations lock"),
+            vec![Some(StateTransition {
+                old_state: OccupancyState::Away,
+                new_state: OccupancyState::Present,
+            })]
+        );
+    }
+
+    #[tokio::test]
     async fn device_hook_runs_when_erv_policy_write_fails_after_report_applies() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("office_climate.db");
@@ -1623,6 +1820,49 @@ mod tests {
             .expect("state machine lock poisoned");
         assert!(machine.sensors.door_open);
         assert!((machine.sensors.door_opened_at - opened_at).abs() < 1.0);
+        assert!(!machine.sensors.window_open);
+        assert!(machine.sensors.motion_detected);
+        assert_eq!(machine.state, OccupancyState::Present);
+    }
+
+    #[test]
+    fn restore_skips_contacts_when_contact_sensors_are_disabled_but_restores_motion() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("office_climate.db");
+        migrate_database(&db_path).expect("migration");
+        db::log_device_event(
+            &db_path,
+            "door",
+            "open",
+            Some("Office Door"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log door");
+        db::log_device_event(
+            &db_path,
+            "window",
+            "open",
+            Some("Office Window"),
+            Some(&json!({"state": "open", "contact_sensor_trusted": true})),
+        )
+        .expect("log window");
+        db::log_device_event(&db_path, "motion", "detected", Some("Office Motion"), None)
+            .expect("log motion");
+
+        let yolink = test_state_with_config(
+            db_path,
+            StateConfig {
+                contact_sensors_enabled: false,
+                ..StateConfig::from_thresholds(&ThresholdsConfig::default())
+            },
+        );
+        yolink.restore_from_database(1_050.0).expect("restore");
+
+        let machine = yolink
+            .state_machine
+            .read()
+            .expect("state machine lock poisoned");
+        assert!(!machine.sensors.door_open);
         assert!(!machine.sensors.window_open);
         assert!(machine.sensors.motion_detected);
         assert_eq!(machine.state, OccupancyState::Present);


### PR DESCRIPTION
## Summary
- Add `room_mode` config/status scaffolding for renovation, contact sensor trust, air-quality trust, and climate automation gating.
- Ignore door/window contacts as logical presence/safety inputs when contact sensors are disabled while preserving raw YoLink telemetry.
- Mark raw contact and Qingping readings with trust metadata and filter trusted history/restore consumers.
- Treat moved Qingping readings as unavailable to ERV/HVAC policies when air-quality sensors are disabled.
- Gate automated ERV/HVAC policy evaluation with `room_mode.climate_automation_enabled` across Qingping, YoLink, Mac/internal presence, manual presence follow-up, and door-grace triggers.

## Spec Reference
- `docs/working/147_renovation_mode.md`

## Component PRs
- #148: room mode/status scaffold
- #149: contact sensor trust mode
- #150: air-quality trust mode
- #151: climate automation umbrella gate

## Test Plan
- [x] `cargo test --manifest-path rust/office-automate-server/Cargo.toml` on `epic/147-renovation-mode` after all component PRs merged
- [x] `git diff --check`

Fixes #147
