### PR TITLE
[codex] add smart blinds controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,33 @@ version = 4
 
 [[package]]
 name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aead"
 version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -18,9 +39,23 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
 ]
 
 [[package]]
@@ -29,11 +64,11 @@ version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.6.0-rc.10",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -438,13 +473,23 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -636,6 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -652,11 +698,20 @@ dependencies = [
 
 [[package]]
 name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -691,6 +746,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -731,7 +787,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -943,11 +999,21 @@ dependencies = [
 
 [[package]]
 name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval",
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -1004,6 +1070,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -1326,6 +1401,15 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
@@ -1482,6 +1566,12 @@ dependencies = [
  "cfg-if",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1658,6 +1748,7 @@ dependencies = [
 name = "office-automate-server"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm 0.10.3",
  "anyhow",
  "axum 0.8.9",
  "base64 0.22.1",
@@ -1665,8 +1756,10 @@ dependencies = [
  "chrono-tz",
  "clap",
  "futures-util",
+ "hmac 0.12.1",
  "ipnet",
  "jsonwebtoken",
+ "md5",
  "rand 0.8.6",
  "reqwest",
  "rumqttc-v4-next",
@@ -1685,6 +1778,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -1698,6 +1792,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1835,13 +1935,25 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2328,17 +2440,17 @@ version = "0.3.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914d825bd2465f37554a2ac624a16ac15f5668ff7ae500b1fe726444788645b9"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.9.1",
+ "aes-gcm 0.11.0-rc.4",
  "async-stream",
  "base64 0.22.1",
  "byteorder",
- "cipher",
+ "cipher 0.5.2",
  "crc",
  "ecb",
  "futures-core",
  "futures-util",
- "hmac",
+ "hmac 0.13.0",
  "log",
  "md-5",
  "parking_lot",
@@ -3094,6 +3206,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "universal-hash"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,8 +41,8 @@ android {
         applicationId = "com.rajesh.officeclimate"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2
-        versionName = "1.1"
+        versionCode = 5
+        versionName = "1.4"
         buildConfigField("String", "APK_HASH", "\"$officeClimateBuildHash\"")
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/ApiService.kt
@@ -47,6 +47,9 @@ interface ApiService {
     @POST("presence")
     suspend fun setPresence(@Body body: Map<String, String>): JsonObject
 
+    @POST("blinds")
+    suspend fun setBlinds(@Body body: Map<String, String>): JsonObject
+
     @POST("hvac/temperature-bands")
     suspend fun setTemperatureBands(@Body body: JsonObject): TemperatureBandsResponse
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/remote/HttpClientFactory.kt
@@ -14,6 +14,7 @@ import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedKeyManager
@@ -69,9 +70,6 @@ class HttpClientFactory(
                 .onSuccess { sslConfig ->
                     sslConfig?.let { (sslSocketFactory, trustManager) ->
                         builder.sslSocketFactory(sslSocketFactory, trustManager)
-                        if (legacyPrivateKeyPkcs8.isNotBlank()) {
-                            settingsRepository.clearDevicePrivateKeyPkcs8()
-                        }
                     }
                 }
                 .onFailure { error ->
@@ -93,7 +91,7 @@ class HttpClientFactory(
         }
         val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
         val privateKey = loadPrivateKeyFromStore(keyStore, alias)
-            ?: importLegacyPrivateKey(keyStore, alias, certificateChain, legacyPrivateKeyPkcs8)
+            ?: decodePrivateKey(legacyPrivateKeyPkcs8)
             ?: return null
 
         val keyManager = SingleAliasKeyManager(
@@ -127,34 +125,22 @@ class HttpClientFactory(
             .filterIsInstance<X509Certificate>()
     }
 
-    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey? =
-        runCatching {
-            val keyBytes = Base64.decode(privateKeyPkcs8, Base64.DEFAULT)
-            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
-        }.getOrNull()
+    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey? {
+        if (privateKeyPkcs8.isBlank()) return null
+        val keyBytes = runCatching { Base64.decode(privateKeyPkcs8, Base64.DEFAULT) }.getOrNull()
+            ?: return null
+        val spec = PKCS8EncodedKeySpec(keyBytes)
+        for (algorithm in listOf("EC", "RSA")) {
+            try {
+                return KeyFactory.getInstance(algorithm).generatePrivate(spec)
+            } catch (_: InvalidKeySpecException) {
+            }
+        }
+        return null
+    }
 
     private fun loadPrivateKeyFromStore(keyStore: KeyStore, alias: String): PrivateKey? =
         runCatching { keyStore.getKey(alias, null) as? PrivateKey }.getOrNull()
-
-    private fun importLegacyPrivateKey(
-        keyStore: KeyStore,
-        alias: String,
-        certificateChain: List<X509Certificate>,
-        privateKeyPkcs8: String,
-    ): PrivateKey? {
-        if (privateKeyPkcs8.isBlank()) {
-            return null
-        }
-        val privateKey = decodePrivateKey(privateKeyPkcs8) ?: return null
-        return runCatching {
-            keyStore.setEntry(
-                alias,
-                KeyStore.PrivateKeyEntry(privateKey, certificateChain.toTypedArray()),
-                null,
-            )
-            loadPrivateKeyFromStore(keyStore, alias)
-        }.getOrNull()
-    }
 
     private companion object {
         const val TAG = "HttpClientFactory"

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/ClimateRepository.kt
@@ -176,6 +176,10 @@ class ClimateRepository(
         apiService.setPresence(mapOf("state" to state))
     }
 
+    suspend fun setBlinds(command: String): Result<Unit> = runCatching {
+        apiService.setBlinds(mapOf("command" to command))
+    }
+
     suspend fun setTemperatureBands(bands: TemperatureBands): Result<Unit> = runCatching {
         val body = buildJsonObject {
             put("temperature_bands", buildJsonObject {

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -2,6 +2,7 @@ package com.rajesh.officeclimate.data.repository
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import android.util.Base64
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,6 +24,7 @@ import java.net.URI
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
+import java.security.spec.ECGenParameterSpec
 import java.util.UUID
 
 @Serializable
@@ -98,7 +100,9 @@ class DeviceEnrollmentRepository(
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
                 settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
                 settingsRepository.saveDeviceCertificateAlias(alias)
-                settingsRepository.clearDevicePrivateKeyPkcs8()
+                settingsRepository.saveDevicePrivateKeyPkcs8(
+                    Base64.encodeToString(keyPair.private.encoded, Base64.NO_WRAP),
+                )
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -115,35 +119,15 @@ class DeviceEnrollmentRepository(
 
     private fun generateKeyPair(alias: String): KeyPair {
         deleteDeviceKey(alias)
-        val keyPairGenerator = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_RSA,
-            ANDROID_KEYSTORE,
-        )
-        keyPairGenerator.initialize(
-            KeyGenParameterSpec.Builder(
-                alias,
-                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
-            )
-                .setKeySize(2048)
-                .setDigests(
-                    KeyProperties.DIGEST_SHA256,
-                    KeyProperties.DIGEST_SHA384,
-                    KeyProperties.DIGEST_SHA512,
-                )
-                .setSignaturePaddings(
-                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
-                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
-                )
-                .setUserAuthenticationRequired(false)
-                .build(),
-        )
+        val keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC)
+        keyPairGenerator.initialize(ECGenParameterSpec("secp256r1"))
         return keyPairGenerator.generateKeyPair()
     }
 
     private fun buildCsrPem(keyPair: KeyPair, deviceName: String): String {
         val subject = X500Name("CN=${deviceName.ifBlank { "Office Automate Device" }}")
         val builder = JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
-        val signer = JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private)
+        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.private)
         val csr: PKCS10CertificationRequest = builder.build(signer)
         val writer = StringWriter()
         JcaPEMWriter(writer).use { pemWriter ->

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/DeviceEnrollmentRepository.kt
@@ -2,7 +2,6 @@ package com.rajesh.officeclimate.data.repository
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
-import android.util.Base64
 import com.rajesh.officeclimate.data.remote.HttpClientFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -100,9 +99,7 @@ class DeviceEnrollmentRepository(
                 val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
                 settingsRepository.saveDeviceCertificateChainPem(payload.certificateChainPem)
                 settingsRepository.saveDeviceCertificateAlias(alias)
-                settingsRepository.saveDevicePrivateKeyPkcs8(
-                    Base64.encodeToString(keyPair.private.encoded, Base64.NO_WRAP),
-                )
+                settingsRepository.clearDevicePrivateKeyPkcs8()
                 return@withContext DeviceEnrollmentResult(
                     alias = alias,
                     deviceId = payload.deviceId,
@@ -119,8 +116,20 @@ class DeviceEnrollmentRepository(
 
     private fun generateKeyPair(alias: String): KeyPair {
         deleteDeviceKey(alias)
-        val keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC)
-        keyPairGenerator.initialize(ECGenParameterSpec("secp256r1"))
+        val keyPairGenerator = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_EC,
+            ANDROID_KEYSTORE,
+        )
+        keyPairGenerator.initialize(
+            KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_SIGN)
+                .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+                .setDigests(
+                    KeyProperties.DIGEST_SHA256,
+                    KeyProperties.DIGEST_SHA384,
+                    KeyProperties.DIGEST_SHA512,
+                )
+                .build(),
+        )
         return keyPairGenerator.generateKeyPair()
     }
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/data/repository/SettingsRepository.kt
@@ -180,7 +180,8 @@ class SettingsRepository(private val context: Context) {
             val certificates = CertificateFactory.getInstance("X.509")
                 .generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
                 .filterIsInstance<X509Certificate>()
-            certificates.firstOrNull()?.publicKey?.algorithm.equals("RSA", ignoreCase = true)
+            val algorithm = certificates.firstOrNull()?.publicKey?.algorithm.orEmpty()
+            algorithm.equals("RSA", ignoreCase = true) || algorithm.equals("EC", ignoreCase = true)
         }.getOrDefault(false)
 
     private fun deviceKeyExists(alias: String): Boolean =

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardScreen.kt
@@ -273,6 +273,7 @@ fun DashboardScreen(
                 onPresenceState = viewModel::setPresence,
                 onErvSpeed = viewModel::setErvSpeed,
                 onHvacMode = viewModel::setHvacMode,
+                onBlindsCommand = viewModel::setBlinds,
                 onTemperatureBandAction = viewModel::updateTemperatureBand,
                 onTemperatureBandReset = viewModel::resetTemperatureBands,
             )

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/DashboardViewModel.kt
@@ -99,6 +99,18 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
         }
     }
 
+    fun setBlinds(command: String) {
+        _controlLoading.value = "blinds_$command"
+        viewModelScope.launch {
+            climateRepo.setBlinds(command)
+                .onFailure { e ->
+                    Log.e("DashboardVM", "Blinds control failed", e)
+                    _controlError.value = "Blinds command failed: ${e.message}"
+                }
+            _controlLoading.value = null
+        }
+    }
+
     fun updateTemperatureBand(band: String, action: String, delta: Int) {
         if (_bandUpdateInFlight.value) return
 

--- a/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
+++ b/android/app/src/main/java/com/rajesh/officeclimate/ui/dashboard/QuickControls.kt
@@ -40,6 +40,7 @@ fun QuickControls(
     onPresenceState: (String) -> Unit,
     onErvSpeed: (String) -> Unit,
     onHvacMode: (String, Int?) -> Unit,
+    onBlindsCommand: (String) -> Unit,
     onTemperatureBandAction: (String, String, Int) -> Unit,
     onTemperatureBandReset: () -> Unit,
     modifier: Modifier = Modifier,
@@ -141,6 +142,31 @@ fun QuickControls(
                     isActive = currentMode == "cool",
                     isLoading = controlLoading == "hvac_cool",
                     onClick = { onHvacMode("cool", 76) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+
+        // Blinds Controls
+        Column {
+            Text("Blinds", style = MaterialTheme.typography.labelLarge, color = TextPrimary)
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                ControlButton(
+                    label = "OPEN",
+                    isActive = false,
+                    isLoading = controlLoading == "blinds_open",
+                    onClick = { onBlindsCommand("open") },
+                    modifier = Modifier.weight(1f),
+                )
+                ControlButton(
+                    label = "CLOSE",
+                    isActive = false,
+                    isLoading = controlLoading == "blinds_close",
+                    onClick = { onBlindsCommand("close") },
                     modifier = Modifier.weight(1f),
                 )
             }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,6 +51,26 @@ erv:
   poll_interval_seconds: 60       # Poll while ERV state is unknown/running
   idle_poll_interval_seconds: 300  # Back off status polling when ERV is known off
 
+# Tuya smart blinds over the office window. This is independent of the
+# window open/closed contact sensor.
+blinds:
+  type: "tuya"
+  device_id: "your_blinds_tuya_device_id"
+  local_key: "your_blinds_tuya_local_key"
+  ip: "192.168.1.xxx"   # Leave empty for RF subdevices behind a Tuya bridge
+  active_control_enabled: false
+  # For direct Wi-Fi blinds, local Tuya can use control_dp/open_value/close_value.
+  control_dp: "1"
+  open_value: "open"
+  close_value: "close"
+  # For RF blinds behind a Smart Life Wi-Fi bridge, create Smart Life tap-to-run
+  # scenes and configure these IDs. Scene control is preferred when configured.
+  smart_life_home_id: "your_smart_life_home_id"
+  open_scene_id: "your_open_blinds_scene_id"
+  close_scene_id: "your_close_blinds_scene_id"
+  # Optional; defaults to ~/.office-automate/tuya-sharing-auth.json.
+  # smart_life_auth_file: "~/.office-automate/tuya-sharing-auth.json"
+
 # Option 2: Shelly relay (if using relay instead of Tuya)
 # erv:
 #   type: "shelly"
@@ -84,6 +104,14 @@ thresholds:
   away_stale_flush_interval_hours: 8    # Flush every 8 hours if room stays closed
   away_stale_flush_duration_minutes: 30 # Run each stale flush for 30 minutes
   away_stale_flush_speed: "medium"      # 3/2 airflow (quiet|medium|turbo)
+  post_renovation_enabled: false        # Temporary paint-fume clearing policy
+  post_renovation_expires_at: null      # RFC3339 timestamp, e.g. "2026-07-11T23:59:59-07:00"
+  post_renovation_tvoc_threshold: 150   # Start clearing above this tVOC value
+  post_renovation_present_tvoc_target: 120 # Present-room target before falling back to quiet
+  post_renovation_away_tvoc_target: 40  # Away target near outdoor/baseline air
+  post_renovation_min_speed: "quiet"    # Keep at least this ERV speed while active
+  post_renovation_negative_pressure: false # Use exhaust-biased SA/EA presets while active
+  post_renovation_departure_verification_seconds: 30 # Detect away quickly after door close while active
 
 # Orchestrator network settings (for Mac occupancy detector to report to)
 orchestrator:

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -12,7 +12,7 @@ import {
 import { STATUS_CONFIG } from './constants';
 import VitalTile from './components/VitalTile';
 import CO2Chart from './components/CO2Chart';
-import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, setPresence, setHVACTemperatureBands, ERVSpeed as ApiERVSpeed, HVACMode, HVACTemperatureBands, logout, checkTrustedNetwork } from './api';
+import { fetchStatus, ApiStatus, toFahrenheit, StatusWebSocket, setERVSpeed, setHVACMode, setPresence, setHVACTemperatureBands, setBlindsCommand, ERVSpeed as ApiERVSpeed, HVACMode, HVACTemperatureBands, BlindsCommand, logout, checkTrustedNetwork } from './api';
 import Login from './Login';
 import HistoricalCharts from './HistoricalCharts';
 import OfficeReplay from './OfficeReplay';
@@ -389,6 +389,22 @@ const App: React.FC = () => {
     }
   }, [addEvent, state.co2, state.occupancy]);
 
+  const handleBlindsControl = useCallback(async (command: BlindsCommand) => {
+    setControlLoading(`blinds-${command}`);
+    try {
+      const result = await setBlindsCommand(command);
+      if (!result.ok) {
+        console.error('Blinds control failed:', result.error);
+      } else {
+        addEvent('blinds', `Manual: Blinds ${command === 'open' ? 'opened' : 'closed'}`);
+      }
+    } catch (e) {
+      console.error('Blinds control error:', e);
+    } finally {
+      setControlLoading(null);
+    }
+  }, [addEvent]);
+
   const clampTemperatureBand = useCallback((key: keyof HVACTemperatureBands, value: number) => {
     const limit = TEMPERATURE_BAND_LIMITS[key];
     return Math.max(limit.min, Math.min(limit.max, value));
@@ -685,6 +701,33 @@ const App: React.FC = () => {
                 ? '...'
                 : state.occupancy === OccupancyState.PRESENT ? "I'm away" : "I'm here"}
             </button>
+          </div>
+
+          {/* Blinds Controls */}
+          <div className="rounded-2xl border border-zinc-800/70 bg-black/20 p-4 space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+              <div>
+                <div className="text-sm font-bold text-zinc-400 uppercase tracking-wide">🪟 Blinds</div>
+                <div className="text-xs font-semibold text-zinc-500 mt-1">
+                  Window shade position
+                </div>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {(['open', 'close'] as const).map((command) => (
+                <button
+                  key={command}
+                  onClick={() => handleBlindsControl(command)}
+                  disabled={controlLoading !== null}
+                  className={`px-3 py-2 text-xs font-bold uppercase rounded-lg transition-all bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200
+                    ${controlLoading === `blinds-${command}` ? 'opacity-50 cursor-wait' : ''}
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                  `}
+                >
+                  {controlLoading === `blinds-${command}` ? '...' : command}
+                </button>
+              ))}
+            </div>
           </div>
 
           {/* ERV Controls */}

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -237,6 +237,7 @@ export async function setERVSpeed(speed: ERVSpeed): Promise<{ ok: boolean; error
 
 export type HVACMode = 'off' | 'heat' | 'cool';
 export type PresenceState = 'present' | 'away';
+export type BlindsCommand = 'open' | 'close';
 
 /**
  * Set HVAC mode manually
@@ -248,6 +249,26 @@ export async function setHVACMode(mode: HVACMode, setpoint_f: number = 70): Prom
     method: 'POST',
     headers,
     body: JSON.stringify({ mode, setpoint_f }),
+  });
+
+  if (response.status === 401) {
+    clearAuthToken();
+    throw new Error('Authentication required');
+  }
+
+  return response.json();
+}
+
+/**
+ * Open or close the Tuya smart blinds.
+ */
+export async function setBlindsCommand(command: BlindsCommand): Promise<{ ok: boolean; error?: string }> {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+
+  const response = await authFetch(`${API_BASE}/blinds`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ command }),
   });
 
   if (response.status === 401) {

--- a/rust/office-automate-server/Cargo.toml
+++ b/rust/office-automate-server/Cargo.toml
@@ -6,14 +6,17 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"
+aes-gcm = "0.10"
 axum = { version = "0.8", features = ["multipart", "ws"] }
 base64 = "0.22"
 chrono = "0.4"
 chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive", "env"] }
 futures-util = "0.3"
+hmac = "0.12"
 ipnet = "2"
 jsonwebtoken = "9"
+md5 = "0.7"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rumqttd = { version = "0.20", default-features = false }
@@ -31,6 +34,7 @@ tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 urlencoding = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -133,6 +133,7 @@ impl ErvPolicyCoordinator {
                         None
                     },
                     tvoc: qingping_reading.as_ref().and_then(|reading| reading.tvoc),
+                    current_status_known: erv_snapshot.status_known,
                     current_running: erv_snapshot.running,
                     current_speed: ventilation_speed_from_erv(erv_snapshot.speed),
                     manual_override,
@@ -223,6 +224,7 @@ impl ErvPolicyCoordinator {
                 &self.config.erv,
                 self.writer.as_ref(),
                 speed,
+                self.post_renovation_negative_pressure_active(),
                 reason,
                 co2_ppm,
             )
@@ -243,6 +245,7 @@ impl ErvPolicyCoordinator {
                     &self.config.erv,
                     self.writer.as_ref(),
                     speed,
+                    self.post_renovation_negative_pressure_active(),
                     reason,
                     co2_ppm,
                 )
@@ -250,6 +253,12 @@ impl ErvPolicyCoordinator {
         }
 
         self.apply_erv_speed(speed, reason, co2_ppm).await
+    }
+
+    fn post_renovation_negative_pressure_active(&self) -> bool {
+        let now = unix_timestamp_now();
+        self.config.thresholds.post_renovation_negative_pressure
+            && self.config.thresholds.post_renovation_active_at(now)
     }
 
     pub fn latest_co2_ppm(&self) -> Option<i64> {
@@ -459,6 +468,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
             speed: ErvFanSpeed,
+            _negative_pressure: bool,
         ) -> BoxFutureResult<'a, ErvDeviceStatus> {
             self.writes.lock().expect("writes lock").push(speed);
             let set_delay = self.set_delay;
@@ -494,6 +504,7 @@ mod tests {
                 ..ErvConfig::default()
             },
             mitsubishi: MitsubishiConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: TelemetryConfig::default(),
             runtime: RuntimeConfig {
@@ -964,6 +975,7 @@ mod tests {
                 &config.erv,
                 writer.as_ref(),
                 ErvFanSpeed::Turbo,
+                false,
                 &format!("away_refresh_{index}"),
                 Some(900),
             )
@@ -974,6 +986,7 @@ mod tests {
             &config.erv,
             writer.as_ref(),
             ErvFanSpeed::Turbo,
+            false,
             "away_refresh_suppressed",
             Some(900),
         )

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -99,6 +99,7 @@ impl ErvPolicyCoordinator {
             fresh_status_checked = true;
         }
 
+        let negative_pressure_active = self.post_renovation_negative_pressure_active();
         let decision = {
             let mut policy = self.policy.write().expect("ERV policy lock poisoned");
             if let Some(reading) = &qingping_reading {
@@ -136,6 +137,8 @@ impl ErvPolicyCoordinator {
                     current_status_known: erv_snapshot.status_known,
                     current_running: erv_snapshot.running,
                     current_speed: ventilation_speed_from_erv(erv_snapshot.speed),
+                    current_negative_pressure: erv_snapshot.negative_pressure,
+                    target_negative_pressure: negative_pressure_active,
                     manual_override,
                     last_speed_changed_at: erv_snapshot.last_speed_changed_at,
                     bypass_dwell,

--- a/rust/office-automate-server/src/blinds.rs
+++ b/rust/office-automate-server/src/blinds.rs
@@ -1,0 +1,499 @@
+use std::{env, fs, path::PathBuf, str::FromStr, time::Duration};
+
+use aes_gcm::{
+    Aes128Gcm, Nonce,
+    aead::{Aead, KeyInit},
+};
+use anyhow::{Context, Result, anyhow, bail};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use hmac::{Hmac, Mac};
+use rand::Rng;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use uuid::Uuid;
+
+use crate::config::BlindsConfig;
+
+const SMART_LIFE_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
+const DEFAULT_SMART_LIFE_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlindsCommand {
+    Open,
+    Close,
+}
+
+impl BlindsCommand {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Close => "close",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "open" => Some(Self::Open),
+            "close" => Some(Self::Close),
+            _ => None,
+        }
+    }
+
+    fn tuya_value<'a>(self, config: &'a BlindsConfig) -> &'a str {
+        match self {
+            Self::Open => &config.open_value,
+            Self::Close => &config.close_value,
+        }
+    }
+
+    fn scene_id<'a>(self, config: &'a BlindsConfig) -> Option<&'a str> {
+        match self {
+            Self::Open => config.open_scene_id.as_deref(),
+            Self::Close => config.close_scene_id.as_deref(),
+        }
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    }
+}
+
+pub async fn set_blinds(config: &BlindsConfig, command: BlindsCommand) -> Result<()> {
+    if !config.active_control_enabled {
+        bail!("Blinds active control is disabled");
+    }
+    if !config.is_configured() {
+        bail!("Blinds config is incomplete");
+    }
+
+    if config.smart_life_scene_configured() {
+        trigger_smart_life_scene(config, command).await
+    } else {
+        set_local_tuya_blinds(config, command).await
+    }
+}
+
+async fn set_local_tuya_blinds(config: &BlindsConfig, command: BlindsCommand) -> Result<()> {
+    if !config.local_tuya_configured() {
+        bail!("Blinds local Tuya config is incomplete");
+    }
+
+    let device = build_rustuya_device(config)?;
+    let result = device
+        .set_value(&config.control_dp, command.tuya_value(config))
+        .await
+        .with_context(|| format!("failed to send blinds {} command", command.as_str()));
+    device.close().await;
+
+    let payload = result?;
+    ensure_tuya_command_ok("Local blinds command failed", payload.as_deref())
+}
+
+async fn trigger_smart_life_scene(config: &BlindsConfig, command: BlindsCommand) -> Result<()> {
+    let home_id = config
+        .smart_life_home_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("Blinds Smart Life home id is missing"))?;
+    let scene_id = command
+        .scene_id(config)
+        .ok_or_else(|| anyhow!("Blinds Smart Life {} scene id is missing", command.as_str()))?;
+
+    let auth_file = smart_life_auth_file(config);
+    let mut auth_cache = SmartLifeAuthCache::load(&auth_file)?;
+    let client = SmartLifeClient::new();
+    client.refresh_auth_if_needed(&mut auth_cache).await?;
+    auth_cache.save(&auth_file)?;
+    client
+        .post(
+            &mut auth_cache,
+            "/v1.0/m/scene/ha/trigger",
+            None,
+            Some(json!({"homeId": home_id, "sceneId": scene_id})),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to trigger Smart Life {} blinds scene",
+                command.as_str()
+            )
+        })?;
+    auth_cache.save(&auth_file)?;
+    Ok(())
+}
+
+fn smart_life_auth_file(config: &BlindsConfig) -> PathBuf {
+    config.smart_life_auth_file.clone().unwrap_or_else(|| {
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(DEFAULT_SMART_LIFE_AUTH_FILE)
+    })
+}
+
+fn build_rustuya_device(config: &BlindsConfig) -> Result<rustuya::Device> {
+    let version = rustuya::Version::from_str(&config.version)
+        .map_err(|error| anyhow!("invalid blinds Tuya protocol version: {error}"))?;
+    Ok(rustuya::Device::builder(
+        config.device_id.clone(),
+        config.local_key.as_bytes().to_vec(),
+    )
+    .address(config.ip.clone())
+    .version(version)
+    .port(config.port)
+    .persist(false)
+    .timeout(Duration::from_secs(config.status_timeout_seconds.max(1)))
+    .build())
+}
+
+fn ensure_tuya_command_ok(context: &str, payload: Option<&str>) -> Result<()> {
+    match payload {
+        Some(raw) if raw.contains("\"Err\"") || raw.contains("\"Error\"") => {
+            bail!("{context}: {raw}")
+        }
+        _ => Ok(()),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct SmartLifeAuthCache {
+    user_code: String,
+    terminal_id: String,
+    endpoint: String,
+    token_info: SmartLifeTokenInfo,
+}
+
+impl SmartLifeAuthCache {
+    fn load(path: &PathBuf) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read Smart Life auth cache {}", path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse Smart Life auth cache {}", path.display()))
+    }
+
+    fn save(&self, path: &PathBuf) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)
+            .context("failed to serialize Smart Life auth cache")?;
+        fs::write(path, format!("{content}\n"))
+            .with_context(|| format!("failed to write Smart Life auth cache {}", path.display()))
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct SmartLifeTokenInfo {
+    t: i64,
+    expire_time: i64,
+    uid: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SmartLifeApiEnvelope {
+    success: bool,
+    result: Option<Value>,
+    code: Option<Value>,
+    msg: Option<Value>,
+}
+
+struct SmartLifeClient {
+    http: Client,
+}
+
+impl SmartLifeClient {
+    fn new() -> Self {
+        Self {
+            http: Client::new(),
+        }
+    }
+
+    async fn refresh_auth_if_needed(&self, auth: &mut SmartLifeAuthCache) -> Result<()> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let expires_at = auth.token_info.t + auth.token_info.expire_time * 1_000;
+        if expires_at - 60_000 > now_ms {
+            return Ok(());
+        }
+
+        let path = format!("/v1.0/m/token/{}", auth.token_info.refresh_token);
+        let result = self
+            .get(auth, &path, None)
+            .await
+            .context("failed to refresh Smart Life access token")?;
+        auth.token_info = SmartLifeTokenInfo {
+            t: chrono::Utc::now().timestamp_millis(),
+            expire_time: result
+                .get("expireTime")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing expireTime"))?,
+            uid: result
+                .get("uid")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing uid"))?
+                .to_string(),
+            access_token: result
+                .get("accessToken")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing accessToken"))?
+                .to_string(),
+            refresh_token: result
+                .get("refreshToken")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing refreshToken"))?
+                .to_string(),
+        };
+        Ok(())
+    }
+
+    async fn get(
+        &self,
+        auth: &mut SmartLifeAuthCache,
+        path: &str,
+        params: Option<Value>,
+    ) -> Result<Value> {
+        self.request(auth, "GET", path, params, None).await
+    }
+
+    async fn post(
+        &self,
+        auth: &mut SmartLifeAuthCache,
+        path: &str,
+        params: Option<Value>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        self.request(auth, "POST", path, params, body).await
+    }
+
+    async fn request(
+        &self,
+        auth: &mut SmartLifeAuthCache,
+        method: &str,
+        path: &str,
+        params: Option<Value>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let request_id = Uuid::new_v4().to_string();
+        let hash_key = format!(
+            "{:x}",
+            md5::compute(format!("{}{}", request_id, auth.token_info.refresh_token))
+        );
+        let secret = smart_life_secret(&request_id, "", &hash_key)?;
+
+        let query_encdata = match params {
+            Some(params) => Some(encrypt_json(&params, &secret)?),
+            None => None,
+        };
+        let body_encdata = match body {
+            Some(body) => Some(encrypt_json(&body, &secret)?),
+            None => None,
+        };
+        let now_ms = chrono::Utc::now().timestamp_millis().to_string();
+        let sign = smart_life_sign(
+            &hash_key,
+            query_encdata.as_deref().unwrap_or_default(),
+            body_encdata.as_deref().unwrap_or_default(),
+            &auth.token_info.access_token,
+            &request_id,
+            &now_ms,
+        )?;
+
+        let url = format!("{}{}", auth.endpoint, path);
+        let mut request = match method {
+            "GET" => self.http.get(url),
+            "POST" => self.http.post(url),
+            _ => bail!("unsupported Smart Life method {method}"),
+        }
+        .header("X-appKey", SMART_LIFE_CLIENT_ID)
+        .header("X-requestId", request_id)
+        .header("X-sid", "")
+        .header("X-time", now_ms)
+        .header("X-token", &auth.token_info.access_token)
+        .header("X-sign", sign);
+
+        if let Some(query_encdata) = query_encdata {
+            request = request.query(&[("encdata", query_encdata)]);
+        }
+        if let Some(body_encdata) = body_encdata {
+            request = request.json(&json!({ "encdata": body_encdata }));
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Smart Life request failed")?
+            .error_for_status()
+            .context("Smart Life HTTP error")?;
+        let envelope: SmartLifeApiEnvelope = response
+            .json()
+            .await
+            .context("failed to parse Smart Life response")?;
+        if !envelope.success {
+            bail!(
+                "Smart Life API error code={} msg={}",
+                envelope
+                    .code
+                    .as_ref()
+                    .map(Value::to_string)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                envelope
+                    .msg
+                    .as_ref()
+                    .map(Value::to_string)
+                    .unwrap_or_else(|| "unknown".to_string())
+            );
+        }
+
+        match envelope.result {
+            Some(Value::String(encrypted)) => decrypt_result(&encrypted, &secret),
+            Some(value) => Ok(value),
+            None => Ok(Value::Null),
+        }
+    }
+}
+
+fn encrypt_json(value: &Value, secret: &str) -> Result<String> {
+    let raw = serde_json::to_string(value).context("failed to encode Smart Life payload")?;
+    let nonce = random_nonce();
+    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(nonce.as_bytes()), raw.as_bytes())
+        .map_err(|error| anyhow!("failed to encrypt Smart Life payload: {error}"))?;
+    Ok(format!(
+        "{}{}",
+        BASE64.encode(nonce.as_bytes()),
+        BASE64.encode(ciphertext)
+    ))
+}
+
+fn decrypt_result(encrypted: &str, secret: &str) -> Result<Value> {
+    let bytes = BASE64
+        .decode(encrypted)
+        .context("failed to decode Smart Life response")?;
+    if bytes.len() < 12 {
+        bail!("Smart Life response is too short");
+    }
+    let (nonce, ciphertext) = bytes.split_at(12);
+    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(nonce), ciphertext)
+        .map_err(|error| anyhow!("failed to decrypt Smart Life response: {error}"))?;
+    let text = String::from_utf8(plaintext).context("Smart Life response is not valid UTF-8")?;
+    serde_json::from_str(&text).or_else(|_| Ok(Value::String(text)))
+}
+
+fn random_nonce() -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
+    let mut rng = rand::thread_rng();
+    (0..12)
+        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+        .collect()
+}
+
+fn smart_life_secret(request_id: &str, sid: &str, hash_key: &str) -> Result<String> {
+    let mut message = hash_key.to_string();
+    if !sid.is_empty() {
+        let mut ecode = String::new();
+        for character in sid.chars().take(16) {
+            let index = character as usize % 16;
+            let selected = sid
+                .chars()
+                .nth(index)
+                .ok_or_else(|| anyhow!("invalid Smart Life sid"))?;
+            ecode.push(selected);
+        }
+        message.push('_');
+        message.push_str(&ecode);
+    }
+
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(request_id.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life HMAC key: {error}"))?;
+    mac.update(message.as_bytes());
+    let digest = mac.finalize().into_bytes();
+    Ok(to_lower_hex(&digest)[..16].to_string())
+}
+
+fn smart_life_sign(
+    hash_key: &str,
+    query_encdata: &str,
+    body_encdata: &str,
+    access_token: &str,
+    request_id: &str,
+    timestamp_ms: &str,
+) -> Result<String> {
+    let mut sign = format!(
+        "X-appKey={SMART_LIFE_CLIENT_ID}||X-requestId={request_id}||X-time={timestamp_ms}||X-token={access_token}"
+    );
+    sign.push_str(query_encdata);
+    sign.push_str(body_encdata);
+
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(hash_key.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life sign key: {error}"))?;
+    mac.update(sign.as_bytes());
+    Ok(to_lower_hex(&mac.finalize().into_bytes()))
+}
+
+fn to_lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_commands() {
+        assert_eq!(BlindsCommand::parse("open"), Some(BlindsCommand::Open));
+        assert_eq!(BlindsCommand::parse("close"), Some(BlindsCommand::Close));
+        assert_eq!(BlindsCommand::parse("stop"), None);
+    }
+
+    #[test]
+    fn config_accepts_scene_or_local_tuya_identity() {
+        let mut config = BlindsConfig::default();
+        assert!(!config.is_configured());
+
+        config.smart_life_home_id = Some("home-id".to_string());
+        config.open_scene_id = Some("open-scene".to_string());
+        config.close_scene_id = Some("close-scene".to_string());
+        assert!(config.is_configured());
+        assert!(config.smart_life_scene_configured());
+        assert!(!config.local_tuya_configured());
+
+        let mut config = BlindsConfig::default();
+        config.ip = "192.168.1.55".to_string();
+        config.device_id = "device-id".to_string();
+        config.local_key = "local-key".to_string();
+        assert!(config.is_configured());
+        assert!(!config.smart_life_scene_configured());
+        assert!(config.local_tuya_configured());
+    }
+
+    #[test]
+    fn smart_life_crypto_matches_sdk_vectors() {
+        let secret = smart_life_secret(
+            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
+            "",
+            "4b7d14dca2d3df16b3a12219a47a7e56",
+        )
+        .expect("secret");
+        assert_eq!(secret, "60437f64b09370c5");
+
+        let sign = smart_life_sign(
+            "4b7d14dca2d3df16b3a12219a47a7e56",
+            "",
+            "body-encdata",
+            "access-token",
+            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
+            "1783144312258",
+        )
+        .expect("sign");
+        assert_eq!(
+            sign,
+            "0b01f17ddcba9cd54e0305cdd53607ae3b877d88f84690fc406ee719fae94871"
+        );
+    }
+}

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
     artifacts::{ARTIFACT_MAX_SIZE_BYTES, ArtifactStore, ArtifactUploadPolicy},
+    blinds,
     config::AppConfig,
     db, device, edge, erv, http, hvac, migration, presence, telemetry,
     validation::{
@@ -154,6 +155,10 @@ pub enum SmokeTarget {
     Hvac,
     /// Verify macOS keyboard/display presence signals.
     Presence,
+    /// Trigger the configured close-blinds Smart Life scene.
+    BlindsClose,
+    /// Trigger the configured open-blinds Smart Life scene.
+    BlindsOpen,
 }
 
 #[derive(Debug, Subcommand, Clone, Copy, PartialEq, Eq)]
@@ -634,6 +639,14 @@ async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()
                     status.idle_seconds, status.external_monitor, status.display_count
                 );
             }
+            SmokeTarget::BlindsClose => {
+                blinds::set_blinds(&config.blinds, blinds::BlindsCommand::Close).await?;
+                println!("Blinds close scene trigger OK");
+            }
+            SmokeTarget::BlindsOpen => {
+                blinds::set_blinds(&config.blinds, blinds::BlindsCommand::Open).await?;
+                println!("Blinds open scene trigger OK");
+            }
         }
     }
 
@@ -645,6 +658,8 @@ fn smoke_targets(target: Option<SmokeTarget>) -> &'static [SmokeTarget] {
         Some(SmokeTarget::Erv) => &[SmokeTarget::Erv],
         Some(SmokeTarget::Hvac) => &[SmokeTarget::Hvac],
         Some(SmokeTarget::Presence) => &[SmokeTarget::Presence],
+        Some(SmokeTarget::BlindsClose) => &[SmokeTarget::BlindsClose],
+        Some(SmokeTarget::BlindsOpen) => &[SmokeTarget::BlindsOpen],
         None => &[SmokeTarget::Erv, SmokeTarget::Hvac, SmokeTarget::Presence],
     }
 }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use chrono::DateTime;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -16,6 +17,7 @@ pub struct AppConfig {
     pub artifacts: ArtifactConfig,
     pub cloudflare_access: CloudflareAccessConfig,
     pub erv: ErvConfig,
+    pub blinds: BlindsConfig,
     pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
     pub telemetry: TelemetryConfig,
@@ -327,6 +329,79 @@ impl Default for ErvConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BlindsConfig {
+    #[serde(rename = "type")]
+    pub device_type: String,
+    pub ip: String,
+    pub device_id: String,
+    pub local_key: String,
+    pub active_control_enabled: bool,
+    pub version: String,
+    pub port: u16,
+    pub status_timeout_seconds: u64,
+    pub control_dp: String,
+    pub open_value: String,
+    pub close_value: String,
+    pub smart_life_auth_file: Option<PathBuf>,
+    pub smart_life_home_id: Option<String>,
+    pub open_scene_id: Option<String>,
+    pub close_scene_id: Option<String>,
+}
+
+impl BlindsConfig {
+    pub fn is_configured(&self) -> bool {
+        self.local_tuya_configured() || self.smart_life_scene_configured()
+    }
+
+    pub fn local_tuya_configured(&self) -> bool {
+        self.device_type == "tuya"
+            && !self.ip.trim().is_empty()
+            && !self.device_id.trim().is_empty()
+            && !self.local_key.trim().is_empty()
+            && !self.control_dp.trim().is_empty()
+    }
+
+    pub fn smart_life_scene_configured(&self) -> bool {
+        self.device_type == "tuya"
+            && self
+                .smart_life_home_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .open_scene_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .close_scene_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+impl Default for BlindsConfig {
+    fn default() -> Self {
+        Self {
+            device_type: "tuya".to_string(),
+            ip: String::new(),
+            device_id: String::new(),
+            local_key: String::new(),
+            active_control_enabled: false,
+            version: "3.4".to_string(),
+            port: 6668,
+            status_timeout_seconds: 5,
+            control_dp: "1".to_string(),
+            open_value: "open".to_string(),
+            close_value: "close".to_string(),
+            smart_life_auth_file: None,
+            smart_life_home_id: None,
+            open_scene_id: None,
+            close_scene_id: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ThresholdsConfig {
@@ -374,6 +449,14 @@ pub struct ThresholdsConfig {
     pub away_stale_flush_interval_hours: u64,
     pub away_stale_flush_duration_minutes: u64,
     pub away_stale_flush_speed: String,
+    pub post_renovation_enabled: bool,
+    pub post_renovation_expires_at: Option<String>,
+    pub post_renovation_tvoc_threshold: i64,
+    pub post_renovation_present_tvoc_target: i64,
+    pub post_renovation_away_tvoc_target: i64,
+    pub post_renovation_min_speed: String,
+    pub post_renovation_negative_pressure: bool,
+    pub post_renovation_departure_verification_seconds: u64,
 }
 
 impl Default for ThresholdsConfig {
@@ -423,7 +506,32 @@ impl Default for ThresholdsConfig {
             away_stale_flush_interval_hours: 8,
             away_stale_flush_duration_minutes: 30,
             away_stale_flush_speed: "medium".to_string(),
+            post_renovation_enabled: false,
+            post_renovation_expires_at: None,
+            post_renovation_tvoc_threshold: 150,
+            post_renovation_present_tvoc_target: 120,
+            post_renovation_away_tvoc_target: 40,
+            post_renovation_min_speed: "quiet".to_string(),
+            post_renovation_negative_pressure: false,
+            post_renovation_departure_verification_seconds: 30,
         }
+    }
+}
+
+impl ThresholdsConfig {
+    pub fn post_renovation_active_at(&self, now: f64) -> bool {
+        if !self.post_renovation_enabled {
+            return false;
+        }
+
+        let Some(expires_at) = self.post_renovation_expires_at.as_deref() else {
+            return true;
+        };
+
+        let Ok(expires_at) = DateTime::parse_from_rfc3339(expires_at) else {
+            return false;
+        };
+        now < expires_at.timestamp_millis() as f64 / 1_000.0
     }
 }
 
@@ -458,6 +566,7 @@ struct FileConfig {
     artifacts: ArtifactConfig,
     cloudflare_access: CloudflareAccessConfig,
     erv: ErvConfig,
+    blinds: BlindsConfig,
     mitsubishi: MitsubishiConfig,
     thresholds: ThresholdsConfig,
     telemetry: TelemetryConfig,
@@ -569,6 +678,51 @@ impl AppConfig {
             file_config.erv.idle_poll_interval_seconds = seconds.parse().with_context(|| {
                 format!("invalid OFFICE_AUTOMATE_ERV_IDLE_POLL_INTERVAL_SECONDS value {seconds:?}")
             })?;
+        }
+
+        if let Some(ip) = env_lookup("OFFICE_AUTOMATE_BLINDS_IP") {
+            file_config.blinds.ip = ip;
+        }
+
+        if let Some(device_id) = env_lookup("OFFICE_AUTOMATE_BLINDS_DEVICE_ID") {
+            file_config.blinds.device_id = device_id;
+        }
+
+        if let Some(local_key) = env_lookup("OFFICE_AUTOMATE_BLINDS_LOCAL_KEY") {
+            file_config.blinds.local_key = local_key;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_BLINDS_ACTIVE_CONTROL_ENABLED") {
+            file_config.blinds.active_control_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_BLINDS_ACTIVE_CONTROL_ENABLED", &enabled)?;
+        }
+
+        if let Some(control_dp) = env_lookup("OFFICE_AUTOMATE_BLINDS_CONTROL_DP") {
+            file_config.blinds.control_dp = control_dp;
+        }
+
+        if let Some(open_value) = env_lookup("OFFICE_AUTOMATE_BLINDS_OPEN_VALUE") {
+            file_config.blinds.open_value = open_value;
+        }
+
+        if let Some(close_value) = env_lookup("OFFICE_AUTOMATE_BLINDS_CLOSE_VALUE") {
+            file_config.blinds.close_value = close_value;
+        }
+
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_BLINDS_SMART_LIFE_AUTH_FILE") {
+            file_config.blinds.smart_life_auth_file = Some(PathBuf::from(path));
+        }
+
+        if let Some(home_id) = env_lookup("OFFICE_AUTOMATE_BLINDS_SMART_LIFE_HOME_ID") {
+            file_config.blinds.smart_life_home_id = Some(home_id);
+        }
+
+        if let Some(scene_id) = env_lookup("OFFICE_AUTOMATE_BLINDS_OPEN_SCENE_ID") {
+            file_config.blinds.open_scene_id = Some(scene_id);
+        }
+
+        if let Some(scene_id) = env_lookup("OFFICE_AUTOMATE_BLINDS_CLOSE_SCENE_ID") {
+            file_config.blinds.close_scene_id = Some(scene_id);
         }
 
         if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_PRESENCE_ENABLED") {
@@ -752,6 +906,10 @@ impl AppConfig {
             .clone()
             .map(|path| expand_home_relative_path(path, home_dir.as_deref()))
             .unwrap_or_else(|| data_dir.join("engram_concept_registry.md"));
+        file_config.blinds.smart_life_auth_file = file_config
+            .blinds
+            .smart_life_auth_file
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()));
 
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
@@ -781,6 +939,7 @@ impl AppConfig {
             artifacts: file_config.artifacts,
             cloudflare_access: file_config.cloudflare_access,
             erv: file_config.erv,
+            blinds: file_config.blinds,
             mitsubishi: file_config.mitsubishi,
             thresholds: file_config.thresholds,
             telemetry: file_config.telemetry,

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -63,9 +63,12 @@ impl ErvFanSpeed {
         }
     }
 
-    fn speed_preset(self) -> Option<(i64, i64)> {
+    fn speed_preset(self, negative_pressure: bool) -> Option<(i64, i64)> {
         match self {
             Self::Off => None,
+            Self::Quiet if negative_pressure => Some((1, 2)),
+            Self::Medium if negative_pressure => Some((2, 3)),
+            Self::Turbo if negative_pressure => Some((7, 8)),
             Self::Quiet => Some((1, 1)),
             Self::Medium => Some((3, 2)),
             Self::Turbo => Some((8, 8)),
@@ -95,6 +98,7 @@ pub trait ErvSpeedWriter: Send + Sync {
         &'a self,
         config: &'a ErvConfig,
         speed: ErvFanSpeed,
+        negative_pressure: bool,
     ) -> BoxFutureResult<'a, ErvDeviceStatus>;
 }
 
@@ -131,6 +135,7 @@ impl ErvSpeedWriter for RustuyaErvSpeedWriter {
         &'a self,
         config: &'a ErvConfig,
         speed: ErvFanSpeed,
+        negative_pressure: bool,
     ) -> BoxFutureResult<'a, ErvDeviceStatus> {
         Box::pin(async move {
             if !config.is_configured() {
@@ -138,7 +143,7 @@ impl ErvSpeedWriter for RustuyaErvSpeedWriter {
             }
 
             let device = build_rustuya_device(config)?;
-            let result = set_rustuya_speed(&device, config, speed).await;
+            let result = set_rustuya_speed(&device, config, speed, negative_pressure).await;
             device.close().await;
             result
         })
@@ -197,6 +202,7 @@ struct ErvInner {
     manual_override: Option<ErvManualOverride>,
     consecutive_local_failures: u64,
     next_local_retry_at: Option<f64>,
+    next_status_poll_retry_at: Option<f64>,
     recent_local_activity: VecDeque<ErvLocalActivity>,
 }
 
@@ -242,7 +248,7 @@ impl ErvState {
             }
             Err(error) => {
                 let message = format!("{error:#}");
-                if self.record_local_failure(&message) {
+                if self.record_read_only_local_failure(&message) {
                     self.notify_status();
                 }
                 Err(error)
@@ -255,6 +261,7 @@ impl ErvState {
         config: &ErvConfig,
         writer: &W,
         speed: ErvFanSpeed,
+        negative_pressure: bool,
         reason: &str,
         co2_ppm: Option<i64>,
     ) -> Result<ErvDeviceStatus>
@@ -293,8 +300,15 @@ impl ErvState {
             return Ok(smoked_status);
         }
 
-        self.write_speed_after_gate_locked(config, writer, speed, reason, co2_ppm)
-            .await
+        self.write_speed_after_gate_locked(
+            config,
+            writer,
+            speed,
+            negative_pressure,
+            reason,
+            co2_ppm,
+        )
+        .await
     }
 
     pub(crate) async fn set_speed_after_smoke_with<W>(
@@ -302,6 +316,7 @@ impl ErvState {
         config: &ErvConfig,
         writer: &W,
         speed: ErvFanSpeed,
+        negative_pressure: bool,
         reason: &str,
         co2_ppm: Option<i64>,
     ) -> Result<ErvDeviceStatus>
@@ -319,8 +334,15 @@ impl ErvState {
         }
 
         let _local_io_guard = self.local_io_lock.lock().await;
-        self.write_speed_after_gate_locked(config, writer, speed, reason, co2_ppm)
-            .await
+        self.write_speed_after_gate_locked(
+            config,
+            writer,
+            speed,
+            negative_pressure,
+            reason,
+            co2_ppm,
+        )
+        .await
     }
 
     async fn write_speed_after_gate_locked<W>(
@@ -328,6 +350,7 @@ impl ErvState {
         config: &ErvConfig,
         writer: &W,
         speed: ErvFanSpeed,
+        negative_pressure: bool,
         reason: &str,
         co2_ppm: Option<i64>,
     ) -> Result<ErvDeviceStatus>
@@ -344,7 +367,7 @@ impl ErvState {
             );
         }
 
-        match writer.set_speed(config, speed).await {
+        match writer.set_speed(config, speed, negative_pressure).await {
             Ok(status) => {
                 self.record_speed_success(status.clone(), speed, reason, co2_ppm);
                 self.record_write_success(status.clone(), speed, reason, co2_ppm, &attempt);
@@ -391,7 +414,7 @@ impl ErvState {
 
     pub fn status_poll_delay(&self, config: &ErvConfig, now: f64) -> Duration {
         let inner = self.inner.read().expect("ERV state lock poisoned");
-        if let Some(retry_at) = inner.next_local_retry_at
+        if let Some(retry_at) = inner.next_status_poll_retry_at
             && retry_at > now
         {
             return Duration::from_secs(((retry_at - now).ceil() as u64).max(1));
@@ -805,6 +828,7 @@ impl ErvState {
             inner.consecutive_local_failures = 0;
             inner.control.consecutive_local_key_errors = 0;
             inner.next_local_retry_at = None;
+            inner.next_status_poll_retry_at = None;
 
             if was_invalid {
                 inner.notification = Some(recovered_notification(&now));
@@ -828,6 +852,14 @@ impl ErvState {
     }
 
     fn record_local_failure(&self, message: &str) -> bool {
+        self.record_local_failure_with_retry(message, true)
+    }
+
+    fn record_read_only_local_failure(&self, message: &str) -> bool {
+        self.record_local_failure_with_retry(message, false)
+    }
+
+    fn record_local_failure_with_retry(&self, message: &str, active_retry: bool) -> bool {
         let now = local_iso_now();
         let at = unix_timestamp_now();
         let mut invalid_event = None;
@@ -839,10 +871,13 @@ impl ErvState {
             inner.control.last_error_at = Some(now.clone());
             inner.control.using_cloud = false;
             inner.consecutive_local_failures = inner.consecutive_local_failures.saturating_add(1);
-            inner.next_local_retry_at = Some(
-                unix_timestamp_now()
-                    + local_failure_retry_delay_seconds(inner.consecutive_local_failures),
-            );
+            let retry_at = unix_timestamp_now()
+                + local_failure_retry_delay_seconds(inner.consecutive_local_failures);
+            if active_retry {
+                inner.next_local_retry_at = Some(retry_at);
+            } else {
+                inner.next_status_poll_retry_at = Some(retry_at);
+            }
             let recent_write_attempts_5m =
                 recent_write_attempts_locked(&inner, at, LOCAL_WRITE_BURST_WINDOW_SECONDS);
 
@@ -1060,6 +1095,7 @@ async fn set_rustuya_speed(
     device: &rustuya::Device,
     config: &ErvConfig,
     speed: ErvFanSpeed,
+    negative_pressure: bool,
 ) -> Result<ErvDeviceStatus> {
     if speed == ErvFanSpeed::Off {
         let result = device
@@ -1068,7 +1104,9 @@ async fn set_rustuya_speed(
             .context("failed to set ERV power off")?;
         ensure_tuya_command_ok("Local set power off failed", result.as_deref())?;
     } else {
-        let (supply, exhaust) = speed.speed_preset().expect("non-off speed has preset");
+        let (supply, exhaust) = speed
+            .speed_preset(negative_pressure)
+            .expect("non-off speed has preset");
         let result = device
             .set_value(DP_POWER, true)
             .await
@@ -1093,7 +1131,7 @@ async fn set_rustuya_speed(
         .context("failed to verify ERV local Tuya status")?
         .ok_or_else(|| anyhow!("ERV local Tuya verification returned no payload"))?;
     let status = parse_erv_status_payload(&payload)?;
-    verify_speed(speed, &status)?;
+    verify_speed(speed, &status, negative_pressure)?;
     Ok(status)
 }
 
@@ -1104,7 +1142,11 @@ fn ensure_tuya_command_ok(context: &str, payload: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn verify_speed(expected: ErvFanSpeed, actual: &ErvDeviceStatus) -> Result<()> {
+fn verify_speed(
+    expected: ErvFanSpeed,
+    actual: &ErvDeviceStatus,
+    negative_pressure: bool,
+) -> Result<()> {
     if expected == ErvFanSpeed::Off {
         if actual.power {
             bail!("ERV verification failed: expected power OFF, got ON");
@@ -1115,8 +1157,9 @@ fn verify_speed(expected: ErvFanSpeed, actual: &ErvDeviceStatus) -> Result<()> {
     if !actual.power {
         bail!("ERV verification failed: expected power ON, got OFF");
     }
-    let (expected_supply, expected_exhaust) =
-        expected.speed_preset().expect("non-off speed has preset");
+    let (expected_supply, expected_exhaust) = expected
+        .speed_preset(negative_pressure)
+        .expect("non-off speed has preset");
     if actual.supply_speed != Some(expected_supply)
         || actual.exhaust_speed != Some(expected_exhaust)
     {
@@ -1179,8 +1222,11 @@ fn fan_speed(
 
     match (supply_speed, exhaust_speed) {
         (Some(1), Some(1)) => Some(ErvFanSpeed::Quiet),
+        (Some(1), Some(2)) => Some(ErvFanSpeed::Quiet),
         (Some(3), Some(2)) => Some(ErvFanSpeed::Medium),
+        (Some(2), Some(3)) => Some(ErvFanSpeed::Medium),
         (Some(8), Some(8)) => Some(ErvFanSpeed::Turbo),
+        (Some(7), Some(8)) => Some(ErvFanSpeed::Turbo),
         _ => None,
     }
 }
@@ -1356,6 +1402,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
             speed: ErvFanSpeed,
+            _negative_pressure: bool,
         ) -> BoxFutureResult<'a, ErvDeviceStatus> {
             self.write_speeds
                 .lock()
@@ -1398,6 +1445,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv,
+            blinds: crate::config::BlindsConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),
@@ -1444,6 +1492,24 @@ mod tests {
             parse_erv_status_payload(r#"{"dps":{"1":false,"101":"1","102":"1"}}"#).expect("status");
         assert!(!status.power);
         assert_eq!(status.fan_speed, Some(ErvFanSpeed::Off));
+    }
+
+    #[test]
+    fn maps_negative_pressure_presets_and_status_payloads() {
+        assert_eq!(ErvFanSpeed::Quiet.speed_preset(true), Some((1, 2)));
+        assert_eq!(ErvFanSpeed::Medium.speed_preset(true), Some((2, 3)));
+        assert_eq!(ErvFanSpeed::Turbo.speed_preset(true), Some((7, 8)));
+
+        let quiet =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":1,"102":2}}"#).expect("status");
+        let medium =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":2,"102":3}}"#).expect("status");
+        let turbo =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":7,"102":8}}"#).expect("status");
+
+        assert_eq!(quiet.fan_speed, Some(ErvFanSpeed::Quiet));
+        assert_eq!(medium.fan_speed, Some(ErvFanSpeed::Medium));
+        assert_eq!(turbo.fan_speed, Some(ErvFanSpeed::Turbo));
     }
 
     #[tokio::test]
@@ -1547,7 +1613,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_status_failure_sets_immediate_retry_backoff() {
+    async fn local_status_failure_backs_off_polling_without_blocking_writes() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
@@ -1560,13 +1626,17 @@ mod tests {
         assert!(state.refresh_with(&test_config(), &reader).await.is_err());
 
         let now = unix_timestamp_now();
-        assert!(!state.local_retry_allowed(now));
-        assert!(state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
+        assert!(state.local_retry_allowed(now));
+        let delay = state.status_poll_delay(&test_config(), now);
+        assert!(delay >= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64 - 1));
+        assert!(delay <= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64));
 
         assert!(state.refresh_with(&test_config(), &reader).await.is_err());
         let now = unix_timestamp_now();
-        assert!(!state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
-        assert!(state.local_retry_allowed(now + (LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) + 1.0));
+        assert!(state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
+        let delay = state.status_poll_delay(&test_config(), now);
+        assert!(delay >= Duration::from_secs((LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) as u64 - 1));
+        assert!(delay <= Duration::from_secs((LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) as u64));
     }
 
     #[tokio::test]
@@ -1653,6 +1723,7 @@ mod tests {
                 &test_config(),
                 &writer,
                 ErvFanSpeed::Turbo,
+                false,
                 "manual_override",
                 Some(2100),
             )
@@ -1677,6 +1748,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Turbo,
+                false,
                 "away_refresh_CO2=2100ppm",
                 Some(2100),
             )
@@ -1733,6 +1805,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Turbo,
+                false,
                 "away_refresh_CO2=2100ppm",
                 Some(2100),
             )
@@ -1776,6 +1849,7 @@ mod tests {
                     &active_config(),
                     &writer,
                     ErvFanSpeed::Turbo,
+                    false,
                     &format!("away_refresh_{index}"),
                     Some(900),
                 )
@@ -1788,6 +1862,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Turbo,
+                false,
                 "away_refresh_suppressed",
                 Some(900),
             )
@@ -1840,6 +1915,7 @@ mod tests {
                     &active_config(),
                     &writer,
                     ErvFanSpeed::Turbo,
+                    false,
                     "away_refresh",
                     Some(900),
                 )
@@ -1852,6 +1928,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Turbo,
+                false,
                 "safety_interlock",
                 Some(900),
             )
@@ -1885,6 +1962,7 @@ mod tests {
                     &active_config(),
                     &writer,
                     ErvFanSpeed::Turbo,
+                    false,
                     &format!("away_refresh_{index}"),
                     Some(900),
                 )
@@ -1897,6 +1975,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Quiet,
+                false,
                 "away_refresh_suppressed",
                 Some(900),
             )
@@ -1928,6 +2007,7 @@ mod tests {
                         &active_config(),
                         &writer,
                         ErvFanSpeed::Turbo,
+                        false,
                         "manual_override",
                         None,
                     )
@@ -1947,6 +2027,7 @@ mod tests {
                 &active_config(),
                 &writer,
                 ErvFanSpeed::Quiet,
+                false,
                 "manual_override",
                 None,
             )

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -155,6 +155,7 @@ pub struct ErvRuntimeSnapshot {
     pub status_known: bool,
     pub running: bool,
     pub speed: ErvFanSpeed,
+    pub negative_pressure: Option<bool>,
     pub last_speed_changed_at: Option<f64>,
     pub local_key_invalid: bool,
 }
@@ -296,7 +297,7 @@ impl ErvState {
             .await
             .context("ERV smoke check failed before active write")?;
 
-        if device_status_matches_speed(&smoked_status, speed) {
+        if device_status_matches_target(&smoked_status, speed, negative_pressure) {
             return Ok(smoked_status);
         }
 
@@ -394,11 +395,16 @@ impl ErvState {
             .as_ref()
             .and_then(|status| status.fan_speed)
             .unwrap_or(ErvFanSpeed::Off);
+        let negative_pressure = inner
+            .latest_status
+            .as_ref()
+            .and_then(ErvDeviceStatus::negative_pressure);
 
         ErvRuntimeSnapshot {
             status_known,
             running,
             speed,
+            negative_pressure,
             last_speed_changed_at: inner.last_speed_changed_at,
             local_key_invalid: inner.control.local_key_invalid,
         }
@@ -1013,6 +1019,7 @@ fn runtime_snapshot_json(snapshot: ErvRuntimeSnapshot) -> Value {
         "status_known": snapshot.status_known,
         "running": snapshot.running,
         "speed": snapshot.speed.as_str(),
+        "negative_pressure": snapshot.negative_pressure,
         "last_speed_changed_at": snapshot.last_speed_changed_at,
         "local_key_invalid": snapshot.local_key_invalid,
     })
@@ -1231,10 +1238,28 @@ fn fan_speed(
     }
 }
 
-fn device_status_matches_speed(status: &ErvDeviceStatus, speed: ErvFanSpeed) -> bool {
+impl ErvDeviceStatus {
+    fn negative_pressure(&self) -> Option<bool> {
+        match (self.supply_speed, self.exhaust_speed) {
+            (Some(1), Some(2)) | (Some(2), Some(3)) | (Some(7), Some(8)) => Some(true),
+            (Some(1), Some(1)) | (Some(3), Some(2)) | (Some(8), Some(8)) => Some(false),
+            _ => None,
+        }
+    }
+}
+
+fn device_status_matches_target(
+    status: &ErvDeviceStatus,
+    speed: ErvFanSpeed,
+    negative_pressure: bool,
+) -> bool {
     match speed {
         ErvFanSpeed::Off => !status.power,
-        _ => status.power && status.fan_speed == Some(speed),
+        _ => {
+            status.power
+                && status.fan_speed == Some(speed)
+                && status.negative_pressure() == Some(negative_pressure)
+        }
     }
 }
 
@@ -1510,6 +1535,35 @@ mod tests {
         assert_eq!(quiet.fan_speed, Some(ErvFanSpeed::Quiet));
         assert_eq!(medium.fan_speed, Some(ErvFanSpeed::Medium));
         assert_eq!(turbo.fan_speed, Some(ErvFanSpeed::Turbo));
+    }
+
+    #[test]
+    fn target_match_includes_pressure_bias() {
+        let normal_quiet =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":1,"102":1}}"#).expect("status");
+        let negative_quiet =
+            parse_erv_status_payload(r#"{"dps":{"1":true,"101":1,"102":2}}"#).expect("status");
+
+        assert!(device_status_matches_target(
+            &normal_quiet,
+            ErvFanSpeed::Quiet,
+            false
+        ));
+        assert!(!device_status_matches_target(
+            &normal_quiet,
+            ErvFanSpeed::Quiet,
+            true
+        ));
+        assert!(device_status_matches_target(
+            &negative_quiet,
+            ErvFanSpeed::Quiet,
+            true
+        ));
+        assert!(!device_status_matches_target(
+            &negative_quiet,
+            ErvFanSpeed::Quiet,
+            false
+        ));
     }
 
     #[tokio::test]

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -44,6 +44,7 @@ use crate::{
         WebSocketAuth,
     },
     automation::ErvPolicyCoordinator,
+    blinds::{BlindsCommand, set_blinds},
     config::{AppConfig, ThresholdsConfig},
     db,
     erv::{
@@ -422,6 +423,7 @@ fn router_from_state(state: AppState) -> Router {
         .route("/occupancy", post(occupancy))
         .route("/presence", post(presence))
         .route("/erv", post(erv))
+        .route("/blinds", post(blinds))
         .route("/hvac", post(hvac))
         .route(
             "/hvac/temperature-bands",
@@ -665,7 +667,7 @@ fn door_grace_policy_delay(state: &AppState) -> Option<Duration> {
         }
         let deadline = state_status.sensors.door_closed_at
             + state.config.thresholds.erv_door_close_grace_seconds as f64;
-        return (deadline > now).then(|| Duration::from_secs_f64(deadline - now));
+        return (deadline > now).then(|| Duration::from_secs_f64((deadline - now).max(0.0)));
     }
 
     if state_status.sensors.door_opened_at <= 0.0 {
@@ -1480,6 +1482,37 @@ async fn erv(State(state): State<AppState>, Json(payload): Json<ErvRequest>) -> 
             }))
             .into_response()
         }
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BlindsRequest {
+    command: String,
+}
+
+async fn blinds(State(state): State<AppState>, Json(payload): Json<BlindsRequest>) -> Response {
+    let command = payload.command.to_ascii_lowercase();
+    let Some(command) = BlindsCommand::parse(&command) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": "Invalid blinds command"})),
+        )
+            .into_response();
+    };
+
+    match set_blinds(&state.config.blinds, command).await {
+        Ok(()) => Json(json!({
+            "ok": true,
+            "blinds": {
+                "command": command.as_str(),
+            }
+        }))
+        .into_response(),
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"ok": false, "error": error.to_string()})),
@@ -2950,6 +2983,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
             speed: ErvFanSpeed,
+            _negative_pressure: bool,
         ) -> ErvBoxFutureResult<'a, ErvDeviceStatus> {
             self.write_speeds
                 .lock()
@@ -3062,6 +3096,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),
@@ -3480,6 +3515,7 @@ mod tests {
                 &state.config.erv,
                 erv_writer.as_ref(),
                 ErvFanSpeed::Turbo,
+                false,
                 "test",
                 None,
             )
@@ -3609,6 +3645,7 @@ mod tests {
                 &state.config.erv,
                 erv_writer.as_ref(),
                 ErvFanSpeed::Turbo,
+                false,
                 "test",
                 None,
             )

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -914,6 +914,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: crate::config::ErvConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             mitsubishi: crate::config::MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod artifacts;
 pub mod auth;
 pub mod automation;
+pub mod blinds;
 pub mod cli;
 pub mod cloudflare;
 pub mod config;

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -908,6 +908,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: TelemetryConfig::default(),

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -58,6 +58,8 @@ pub struct ErvPolicyInput {
     pub current_status_known: bool,
     pub current_running: bool,
     pub current_speed: VentilationSpeed,
+    pub current_negative_pressure: Option<bool>,
+    pub target_negative_pressure: bool,
     pub manual_override: Option<VentilationSpeed>,
     pub last_speed_changed_at: Option<f64>,
     pub bypass_dwell: bool,
@@ -841,6 +843,7 @@ fn target_decision(
     if target_speed != VentilationSpeed::Off
         && input.current_running
         && input.current_speed == target_speed
+        && input.current_negative_pressure == Some(input.target_negative_pressure)
     {
         return ErvDecision::NoChange;
     }
@@ -961,6 +964,8 @@ mod tests {
             current_status_known: true,
             current_running: false,
             current_speed: VentilationSpeed::Off,
+            current_negative_pressure: Some(false),
+            target_negative_pressure: false,
             manual_override: None,
             last_speed_changed_at: None,
             bypass_dwell: false,
@@ -1029,6 +1034,56 @@ mod tests {
         );
 
         assert_eq!(decision, ErvDecision::NoChange);
+    }
+
+    #[test]
+    fn pressure_bias_change_rewrites_same_logical_speed() {
+        let thresholds = ThresholdsConfig::default();
+        let normal_to_negative = target_decision(
+            &thresholds,
+            &ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: true,
+                ..away_input(Some(700), None)
+            },
+            1_000.0,
+            VentilationSpeed::Quiet,
+            "pressure_bias_enable".to_string(),
+            false,
+        );
+        assert_eq!(
+            normal_to_negative,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "pressure_bias_enable".to_string(),
+                bypass_dwell: false,
+            }
+        );
+
+        let negative_to_normal = target_decision(
+            &thresholds,
+            &ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Quiet,
+                current_negative_pressure: Some(true),
+                target_negative_pressure: false,
+                ..away_input(Some(700), None)
+            },
+            1_000.0,
+            VentilationSpeed::Quiet,
+            "pressure_bias_disable".to_string(),
+            false,
+        );
+        assert_eq!(
+            negative_to_normal,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "pressure_bias_disable".to_string(),
+                bypass_dwell: false,
+            }
+        );
     }
 
     #[test]
@@ -1120,6 +1175,8 @@ mod tests {
                 current_status_known: true,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: false,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1149,6 +1206,8 @@ mod tests {
                 current_status_known: true,
                 current_running: true,
                 current_speed: VentilationSpeed::Quiet,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: false,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1183,6 +1242,8 @@ mod tests {
                 current_status_known: true,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: true,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1212,6 +1273,8 @@ mod tests {
                 current_status_known: true,
                 current_running: true,
                 current_speed: VentilationSpeed::Medium,
+                current_negative_pressure: Some(true),
+                target_negative_pressure: true,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1241,6 +1304,8 @@ mod tests {
                 current_status_known: true,
                 current_running: true,
                 current_speed: VentilationSpeed::Medium,
+                current_negative_pressure: Some(true),
+                target_negative_pressure: true,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1270,6 +1335,8 @@ mod tests {
                 current_status_known: true,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: true,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1297,6 +1364,8 @@ mod tests {
                 current_status_known: false,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
+                current_negative_pressure: None,
+                target_negative_pressure: true,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,
@@ -1416,6 +1485,8 @@ mod tests {
                 current_status_known: true,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
+                current_negative_pressure: Some(false),
+                target_negative_pressure: false,
                 manual_override: None,
                 door_open: false,
                 door_open_seconds: None,

--- a/rust/office-automate-server/src/policy.rs
+++ b/rust/office-automate-server/src/policy.rs
@@ -55,6 +55,7 @@ pub struct ErvPolicyInput {
     pub window_open: bool,
     pub co2_ppm: Option<i64>,
     pub tvoc: Option<i64>,
+    pub current_status_known: bool,
     pub current_running: bool,
     pub current_speed: VentilationSpeed,
     pub manual_override: Option<VentilationSpeed>,
@@ -284,9 +285,21 @@ impl ErvPolicyState {
         let tvoc_needs_clearing = input
             .tvoc
             .is_some_and(|tvoc| tvoc > thresholds.tvoc_away_threshold);
-        let tvoc_at_target = input
-            .tvoc
-            .is_some_and(|tvoc| tvoc <= thresholds.tvoc_away_target);
+        let post_renovation_active = thresholds.post_renovation_active_at(now);
+        let post_renovation_tvoc_needs_clearing = post_renovation_active
+            && input
+                .tvoc
+                .is_some_and(|tvoc| tvoc > thresholds.post_renovation_tvoc_threshold);
+        let tvoc_at_target = input.tvoc.is_some_and(|tvoc| {
+            tvoc <= if post_renovation_active {
+                match input.occupancy {
+                    OccupancyState::Present => thresholds.post_renovation_present_tvoc_target,
+                    OccupancyState::Away => thresholds.post_renovation_away_tvoc_target,
+                }
+            } else {
+                thresholds.tvoc_away_target
+            }
+        });
         let air_quality_available = input.co2_ppm.is_some() || input.tvoc.is_some();
 
         match input.occupancy {
@@ -305,7 +318,47 @@ impl ErvPolicyState {
                     );
                 }
 
-                if input.current_running && input.current_speed == VentilationSpeed::Quiet {
+                if post_renovation_active {
+                    if post_renovation_tvoc_needs_clearing {
+                        return target_decision(
+                            thresholds,
+                            &input,
+                            now,
+                            VentilationSpeed::Quiet,
+                            format!(
+                                "post_renovation_present_tVOC={}",
+                                input.tvoc.expect("post-renovation tVOC checked")
+                            ),
+                            true,
+                        );
+                    }
+
+                    if let Some(tvoc) = input.tvoc {
+                        if tvoc <= thresholds.post_renovation_present_tvoc_target {
+                            return target_decision(
+                                thresholds,
+                                &input,
+                                now,
+                                VentilationSpeed::Off,
+                                format!("post_renovation_present_tVOC_target={tvoc}"),
+                                input.bypass_dwell,
+                            );
+                        }
+
+                        if input.current_running {
+                            return target_decision(
+                                thresholds,
+                                &input,
+                                now,
+                                VentilationSpeed::Quiet,
+                                format!("post_renovation_present_tVOC={tvoc}"),
+                                input.bypass_dwell,
+                            );
+                        }
+
+                        return ErvDecision::NoChange;
+                    }
+                } else if input.current_running && input.current_speed == VentilationSpeed::Quiet {
                     if co2_critical_off {
                         return target_decision(
                             thresholds,
@@ -364,13 +417,18 @@ impl ErvPolicyState {
                     }
                 }
 
-                if tvoc_needs_clearing || self.tvoc_away_ventilation_active {
+                if tvoc_needs_clearing
+                    || post_renovation_tvoc_needs_clearing
+                    || self.tvoc_away_ventilation_active
+                {
                     if tvoc_at_target && self.tvoc_away_ventilation_active {
                         self.tvoc_away_ventilation_active = false;
                         self.tvoc_plateau_detected = false;
                     } else if let Some(tvoc) = latest_tvoc {
                         tvoc_speed = self.adaptive_tvoc_speed(thresholds, tvoc, now);
-                        if !self.tvoc_away_ventilation_active && tvoc_needs_clearing {
+                        if !self.tvoc_away_ventilation_active
+                            && (tvoc_needs_clearing || post_renovation_tvoc_needs_clearing)
+                        {
                             self.tvoc_away_ventilation_active = true;
                         }
                     }
@@ -381,6 +439,16 @@ impl ErvPolicyState {
                     && (tvoc_speed == Some(VentilationSpeed::Off)
                         || !self.tvoc_away_ventilation_active)
                 {
+                    if post_renovation_active {
+                        return target_decision(
+                            thresholds,
+                            &input,
+                            now,
+                            post_renovation_min_speed(thresholds),
+                            "post_renovation_minimum_ventilation".to_string(),
+                            input.bypass_dwell,
+                        );
+                    }
                     if input.current_running {
                         let reason = if self.plateau_detected {
                             "co2_plateau"
@@ -402,6 +470,16 @@ impl ErvPolicyState {
                 let selected = select_away_candidate(co2_speed, tvoc_speed, stale_speed);
                 if let Some((source, target_speed)) = selected {
                     if target_speed == VentilationSpeed::Off {
+                        if post_renovation_active {
+                            return target_decision(
+                                thresholds,
+                                &input,
+                                now,
+                                post_renovation_min_speed(thresholds),
+                                "post_renovation_minimum_ventilation".to_string(),
+                                input.bypass_dwell,
+                            );
+                        }
                         return ErvDecision::NoChange;
                     }
 
@@ -436,6 +514,16 @@ impl ErvPolicyState {
                     && input.current_running
                     && air_quality_available
                 {
+                    if post_renovation_active {
+                        return target_decision(
+                            thresholds,
+                            &input,
+                            now,
+                            post_renovation_min_speed(thresholds),
+                            "post_renovation_minimum_ventilation".to_string(),
+                            input.bypass_dwell,
+                        );
+                    }
                     return target_decision(
                         thresholds,
                         &input,
@@ -446,7 +534,7 @@ impl ErvPolicyState {
                     );
                 }
 
-                if co2_needs_refresh || tvoc_needs_clearing {
+                if co2_needs_refresh || tvoc_needs_clearing || post_renovation_tvoc_needs_clearing {
                     let trigger = if co2_needs_refresh {
                         format!("CO2={}ppm", input.co2_ppm.expect("co2 trigger"))
                     } else {
@@ -459,6 +547,17 @@ impl ErvPolicyState {
                         VentilationSpeed::Turbo,
                         format!("away_refresh_{trigger}"),
                         input.bypass_dwell || self.initial_away_turbo_active(thresholds, now),
+                    );
+                }
+
+                if post_renovation_active {
+                    return target_decision(
+                        thresholds,
+                        &input,
+                        now,
+                        post_renovation_min_speed(thresholds),
+                        "post_renovation_minimum_ventilation".to_string(),
+                        input.bypass_dwell,
                     );
                 }
 
@@ -596,6 +695,9 @@ impl ErvPolicyState {
 
         if self.detect_tvoc_plateau(thresholds) {
             self.tvoc_plateau_detected = true;
+            if thresholds.post_renovation_active_at(now) {
+                return Some(VentilationSpeed::Quiet);
+            }
             return Some(VentilationSpeed::Off);
         }
 
@@ -732,7 +834,8 @@ fn target_decision(
     reason: String,
     bypass_dwell: bool,
 ) -> ErvDecision {
-    if target_speed == VentilationSpeed::Off && !input.current_running {
+    if target_speed == VentilationSpeed::Off && input.current_status_known && !input.current_running
+    {
         return ErvDecision::NoChange;
     }
     if target_speed != VentilationSpeed::Off
@@ -816,6 +919,18 @@ fn stale_flush_speed(thresholds: &ThresholdsConfig) -> VentilationSpeed {
     }
 }
 
+fn post_renovation_min_speed(thresholds: &ThresholdsConfig) -> VentilationSpeed {
+    match thresholds
+        .post_renovation_min_speed
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "medium" => VentilationSpeed::Medium,
+        "turbo" => VentilationSpeed::Turbo,
+        _ => VentilationSpeed::Quiet,
+    }
+}
+
 fn door_open_safety_delay_elapsed(thresholds: &ThresholdsConfig, input: &ErvPolicyInput) -> bool {
     thresholds.erv_door_open_grace_seconds == 0
         || input
@@ -843,11 +958,27 @@ mod tests {
             window_open: false,
             co2_ppm,
             tvoc,
+            current_status_known: true,
             current_running: false,
             current_speed: VentilationSpeed::Off,
             manual_override: None,
             last_speed_changed_at: None,
             bypass_dwell: false,
+        }
+    }
+
+    fn post_renovation_thresholds() -> ThresholdsConfig {
+        ThresholdsConfig {
+            post_renovation_enabled: true,
+            post_renovation_expires_at: Some("2099-01-01T00:00:00-07:00".to_string()),
+            post_renovation_tvoc_threshold: 150,
+            post_renovation_present_tvoc_target: 120,
+            post_renovation_away_tvoc_target: 40,
+            post_renovation_min_speed: "quiet".to_string(),
+            post_renovation_negative_pressure: true,
+            min_away_seconds_before_erv: 0,
+            away_stale_flush_enabled: false,
+            ..ThresholdsConfig::default()
         }
     }
 
@@ -986,6 +1117,7 @@ mod tests {
                 occupancy: OccupancyState::Present,
                 co2_ppm: Some(2_000),
                 tvoc: Some(500),
+                current_status_known: true,
                 current_running: false,
                 current_speed: VentilationSpeed::Off,
                 manual_override: None,
@@ -1014,6 +1146,7 @@ mod tests {
                 occupancy: OccupancyState::Present,
                 co2_ppm: Some(1_799),
                 tvoc: Some(500),
+                current_status_known: true,
                 current_running: true,
                 current_speed: VentilationSpeed::Quiet,
                 manual_override: None,
@@ -1035,6 +1168,266 @@ mod tests {
                 bypass_dwell: true,
             }
         );
+    }
+
+    #[test]
+    fn post_renovation_present_high_tvoc_uses_quiet_until_present_target() {
+        let thresholds = post_renovation_thresholds();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(151),
+                current_status_known: true,
+                current_running: false,
+                current_speed: VentilationSpeed::Off,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: None,
+                bypass_dwell: false,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "post_renovation_present_tVOC=151".to_string(),
+                bypass_dwell: true,
+            }
+        );
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(130),
+                current_status_known: true,
+                current_running: true,
+                current_speed: VentilationSpeed::Medium,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: Some(1_000.0),
+                bypass_dwell: true,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "post_renovation_present_tVOC=130".to_string(),
+                bypass_dwell: true,
+            }
+        );
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(90),
+                current_status_known: true,
+                current_running: true,
+                current_speed: VentilationSpeed::Medium,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: Some(1_000.0),
+                bypass_dwell: true,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Off,
+                reason: "post_renovation_present_tVOC_target=90".to_string(),
+                bypass_dwell: true,
+            }
+        );
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(130),
+                current_status_known: true,
+                current_running: false,
+                current_speed: VentilationSpeed::Off,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: None,
+                bypass_dwell: false,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(decision, ErvDecision::NoChange);
+    }
+
+    #[test]
+    fn post_renovation_present_target_sends_off_when_status_unknown() {
+        let thresholds = post_renovation_thresholds();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(117),
+                current_status_known: false,
+                current_running: false,
+                current_speed: VentilationSpeed::Off,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: None,
+                bypass_dwell: false,
+            },
+            1_001.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Off,
+                reason: "post_renovation_present_tVOC_target=117".to_string(),
+                bypass_dwell: false,
+            }
+        );
+    }
+
+    #[test]
+    fn post_renovation_away_targets_tvoc_40_but_never_turns_off() {
+        let thresholds = post_renovation_thresholds();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(1_000.0);
+        let decision = policy.decide_erv(&thresholds, away_input(Some(450), Some(151)), 1_100.0);
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Turbo,
+                reason: "away_adaptive_turbo_tVOC=151".to_string(),
+                bypass_dwell: false,
+            }
+        );
+
+        policy.tvoc_away_ventilation_active = true;
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Turbo,
+                tvoc: Some(35),
+                last_speed_changed_at: Some(2_000.0),
+                ..away_input(Some(450), Some(35))
+            },
+            2_200.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "post_renovation_minimum_ventilation".to_string(),
+                bypass_dwell: false,
+            }
+        );
+    }
+
+    #[test]
+    fn post_renovation_tvoc_plateau_steps_down_to_quiet_floor() {
+        let thresholds = post_renovation_thresholds();
+        let mut policy = ErvPolicyState::new(&thresholds);
+        policy.away_start_at = Some(0.0);
+        policy.tvoc_away_ventilation_active = true;
+        for index in 0..24 {
+            let value = [55, 56, 54, 55][index % 4];
+            policy.record_reading(
+                &thresholds,
+                index as f64 * 30.0,
+                AirQualityReading {
+                    co2_ppm: Some(450),
+                    tvoc: Some(value),
+                    temp_c: None,
+                },
+            );
+        }
+
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                current_running: true,
+                current_speed: VentilationSpeed::Turbo,
+                tvoc: Some(55),
+                last_speed_changed_at: Some(1_600.0),
+                ..away_input(Some(450), Some(55))
+            },
+            2_000.0,
+        );
+
+        assert_eq!(
+            decision,
+            ErvDecision::SetSpeed {
+                target_speed: VentilationSpeed::Quiet,
+                reason: "away_adaptive_quiet_tVOC=55".to_string(),
+                bypass_dwell: false,
+            }
+        );
+        assert!(policy.tvoc_plateau_detected);
+    }
+
+    #[test]
+    fn expired_post_renovation_mode_restores_present_tvoc_ignore() {
+        let thresholds = ThresholdsConfig {
+            post_renovation_enabled: true,
+            post_renovation_expires_at: Some("2020-01-01T00:00:00-07:00".to_string()),
+            ..post_renovation_thresholds()
+        };
+        let mut policy = ErvPolicyState::new(&thresholds);
+        let decision = policy.decide_erv(
+            &thresholds,
+            ErvPolicyInput {
+                occupancy: OccupancyState::Present,
+                co2_ppm: Some(450),
+                tvoc: Some(500),
+                current_status_known: true,
+                current_running: false,
+                current_speed: VentilationSpeed::Off,
+                manual_override: None,
+                door_open: false,
+                door_open_seconds: None,
+                door_closed_seconds: None,
+                window_open: false,
+                last_speed_changed_at: None,
+                bypass_dwell: false,
+            },
+            1_700_000_000.0,
+        );
+
+        assert_eq!(decision, ErvDecision::NoChange);
     }
 
     #[test]

--- a/rust/office-automate-server/src/state.rs
+++ b/rust/office-automate-server/src/state.rs
@@ -22,6 +22,10 @@ impl OccupancyState {
 pub struct StateConfig {
     pub motion_timeout_seconds: f64,
     pub departure_verification_seconds: f64,
+    pub post_renovation_departure_verification_seconds: f64,
+    pub post_renovation_enabled: bool,
+    pub post_renovation_expires_at: Option<f64>,
+    pub post_renovation_expiry_valid: bool,
     pub door_open_threshold_minutes: f64,
     pub door_open_away_timeout_minutes: f64,
     pub co2_critical_ppm: i64,
@@ -41,6 +45,12 @@ impl StateConfig {
         Self {
             motion_timeout_seconds: thresholds.motion_timeout_seconds as f64,
             departure_verification_seconds: thresholds.departure_verification_seconds as f64,
+            post_renovation_departure_verification_seconds: thresholds
+                .post_renovation_departure_verification_seconds
+                as f64,
+            post_renovation_enabled: thresholds.post_renovation_enabled,
+            post_renovation_expires_at: post_renovation_expires_at_unix(thresholds),
+            post_renovation_expiry_valid: post_renovation_expiry_valid(thresholds),
             door_open_threshold_minutes: thresholds.door_open_threshold_minutes as f64,
             door_open_away_timeout_minutes: thresholds.door_open_away_timeout_minutes as f64,
             co2_critical_ppm: thresholds.co2_critical_ppm,
@@ -55,12 +65,54 @@ impl Default for StateConfig {
         Self {
             motion_timeout_seconds: 60.0,
             departure_verification_seconds: 120.0,
+            post_renovation_departure_verification_seconds: 30.0,
+            post_renovation_enabled: false,
+            post_renovation_expires_at: None,
+            post_renovation_expiry_valid: true,
             door_open_threshold_minutes: 5.0,
             door_open_away_timeout_minutes: 5.0,
             co2_critical_ppm: 2000,
             co2_refresh_target_ppm: 500,
             contact_sensors_enabled: true,
         }
+    }
+}
+
+impl StateConfig {
+    fn departure_verification_seconds_at(&self, now: f64) -> f64 {
+        if self.post_renovation_active_at(now) {
+            self.post_renovation_departure_verification_seconds
+        } else {
+            self.departure_verification_seconds
+        }
+    }
+
+    fn post_renovation_active_at(&self, now: f64) -> bool {
+        if !self.post_renovation_enabled {
+            return false;
+        }
+        if !self.post_renovation_expiry_valid {
+            return false;
+        }
+        match self.post_renovation_expires_at {
+            Some(expires_at) => now < expires_at,
+            None => true,
+        }
+    }
+}
+
+fn post_renovation_expires_at_unix(thresholds: &ThresholdsConfig) -> Option<f64> {
+    thresholds
+        .post_renovation_expires_at
+        .as_deref()
+        .and_then(|expires_at| chrono::DateTime::parse_from_rfc3339(expires_at).ok())
+        .map(|expires_at| expires_at.timestamp_millis() as f64 / 1_000.0)
+}
+
+fn post_renovation_expiry_valid(thresholds: &ThresholdsConfig) -> bool {
+    match thresholds.post_renovation_expires_at.as_deref() {
+        Some(expires_at) => chrono::DateTime::parse_from_rfc3339(expires_at).is_ok(),
+        None => true,
     }
 }
 
@@ -514,7 +566,7 @@ impl StateMachine {
     fn start_departure_verification(&mut self, now: f64) {
         if self.config.contact_sensors_enabled && self.state == OccupancyState::Present {
             self.departure_verification_deadline =
-                Some(now + self.config.departure_verification_seconds);
+                Some(now + self.config.departure_verification_seconds_at(now));
         }
     }
 
@@ -645,6 +697,69 @@ mod tests {
         assert!(!machine.sensors.motion_detected);
         assert_eq!(machine.sensors.motion_last_seen, 0.0);
         assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn post_renovation_uses_aggressive_departure_verification() {
+        let mut machine = StateMachine::new(
+            StateConfig {
+                departure_verification_seconds: 120.0,
+                post_renovation_departure_verification_seconds: 30.0,
+                post_renovation_enabled: true,
+                post_renovation_expires_at: Some(2_000.0),
+                ..StateConfig::default()
+            },
+            1_000.0,
+        );
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        assert_eq!(machine.advance_timers(1_049.0), None);
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        let transition = machine.advance_timers(1_050.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
+        assert!(!machine.verifying_departure());
+    }
+
+    #[test]
+    fn expired_post_renovation_uses_normal_departure_verification() {
+        let mut machine = StateMachine::new(
+            StateConfig {
+                departure_verification_seconds: 120.0,
+                post_renovation_departure_verification_seconds: 30.0,
+                post_renovation_enabled: true,
+                post_renovation_expires_at: Some(1_000.0),
+                ..StateConfig::default()
+            },
+            1_000.0,
+        );
+        machine.set_manual_presence(true, 1_001.0);
+        machine.update_door(true, 1_010.0);
+        machine.update_motion(false, 1_019.0);
+        machine.update_door(false, 1_020.0);
+
+        assert!(machine.verifying_departure());
+        assert_eq!(machine.advance_timers(1_050.0), None);
+        assert_eq!(machine.state, OccupancyState::Present);
+
+        let transition = machine.advance_timers(1_140.0);
+        assert_eq!(
+            transition,
+            Some(StateTransition {
+                old_state: OccupancyState::Present,
+                new_state: OccupancyState::Away,
+            })
+        );
     }
 
     #[test]

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -296,8 +296,9 @@ mod tests {
 
     use super::*;
     use crate::config::{
-        ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig, QingpingConfig,
-        RoomModeConfig, RuntimeConfig, TelemetryConfig, ThresholdsConfig, YoLinkConfig,
+        BlindsConfig, ErvConfig, MitsubishiConfig, OrchestratorConfig, PresenceConfig,
+        QingpingConfig, RoomModeConfig, RuntimeConfig, TelemetryConfig, ThresholdsConfig,
+        YoLinkConfig,
     };
 
     fn test_config() -> AppConfig {
@@ -313,6 +314,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
+            blinds: BlindsConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig {
                 hvac_heat_on_temp_f: 70,

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -3412,6 +3412,7 @@ mod tests {
             artifacts: crate::config::ArtifactConfig::default(),
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -960,6 +960,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
             speed: ErvFanSpeed,
+            _negative_pressure: bool,
         ) -> crate::erv::BoxFutureResult<'a, ErvDeviceStatus> {
             self.write_speeds
                 .lock()
@@ -1012,6 +1013,7 @@ mod tests {
                 ..ErvConfig::default()
             },
             mitsubishi: MitsubishiConfig::default(),
+            blinds: crate::config::BlindsConfig::default(),
             thresholds: ThresholdsConfig {
                 erv_min_dwell_seconds: 0,
                 ..ThresholdsConfig::default()

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Refresh the configured ERV Tuya local key from Smart Life sharing APIs."""
+"""Refresh configured Tuya local keys from Smart Life sharing APIs."""
 
 from __future__ import annotations
 
@@ -88,31 +88,35 @@ def load_config_data(config_file: Path) -> tuple[Any, Any]:
     return yaml, data
 
 
-def read_erv_config(config_file: Path) -> tuple[str, str | None]:
+def read_device_config(config_file: Path, section: str) -> tuple[str, str | None]:
     _, data = load_config_data(config_file)
-    erv = data.get("erv")
-    if not isinstance(erv, dict):
-        raise RefreshError(f"{config_file} is missing an erv mapping")
+    device_config = data.get(section)
+    if not isinstance(device_config, dict):
+        raise RefreshError(f"{config_file} is missing a {section} mapping")
 
-    device_id = erv.get("device_id")
+    device_id = device_config.get("device_id")
     if not isinstance(device_id, str) or not device_id.strip():
-        raise RefreshError(f"{config_file} is missing erv.device_id")
+        raise RefreshError(f"{config_file} is missing {section}.device_id")
 
-    local_key = erv.get("local_key")
+    local_key = device_config.get("local_key")
     if local_key is not None and not isinstance(local_key, str):
-        raise RefreshError(f"{config_file} has a non-string erv.local_key")
+        raise RefreshError(f"{config_file} has a non-string {section}.local_key")
 
     return device_id.strip(), local_key
 
 
-def update_config_local_key(config_file: Path, new_local_key: str) -> None:
-    yaml, data = load_config_data(config_file)
-    erv = data.get("erv")
-    if not isinstance(erv, dict):
-        raise RefreshError(f"{config_file} is missing an erv mapping")
+def read_erv_config(config_file: Path) -> tuple[str, str | None]:
+    return read_device_config(config_file, "erv")
 
-    old_value = erv.get("local_key")
-    erv["local_key"] = preserve_scalar_style(old_value, new_local_key)
+
+def update_config_local_key(config_file: Path, section: str, new_local_key: str) -> None:
+    yaml, data = load_config_data(config_file)
+    device_config = data.get(section)
+    if not isinstance(device_config, dict):
+        raise RefreshError(f"{config_file} is missing a {section} mapping")
+
+    old_value = device_config.get("local_key")
+    device_config["local_key"] = preserve_scalar_style(old_value, new_local_key)
 
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{config_file.name}.",
@@ -410,6 +414,85 @@ def fetch_current_local_key(
     return local_key, name if isinstance(name, str) else None
 
 
+def list_smart_life_devices(auth_file: Path, auth_cache: dict[str, Any]) -> list[Any]:
+    ensure_tuya_sdk()
+    listener = AuthCacheTokenListener(auth_file, auth_cache)
+    manager = Manager(
+        CLIENT_ID,
+        auth_cache["user_code"],
+        auth_cache["terminal_id"],
+        auth_cache["endpoint"],
+        auth_cache["token_info"],
+        listener,
+    )
+    try:
+        manager.update_device_cache()
+    except Exception as exc:
+        raise RefreshError(f"failed to list Smart Life devices: {exc}") from exc
+    listener.raise_if_persist_failed()
+
+    device_map = getattr(manager, "device_map", {})
+    if isinstance(device_map, dict):
+        return list(device_map.values())
+    return []
+
+
+def print_device_list(devices: Iterable[Any], stdout: TextIO) -> None:
+    rows: list[tuple[str, str, str, str]] = []
+    for device in devices:
+        device_id = get_device_field(device, "id", "devId", "device_id")
+        name = get_device_field(device, "name")
+        product_name = get_device_field(device, "product_name", "productName", "product_id", "productId")
+        has_local_key = bool(get_device_field(device, "local_key", "localKey"))
+        rows.append(
+            (
+                str(name or "-"),
+                str(device_id or "-"),
+                str(product_name or "-"),
+                "yes" if has_local_key else "no",
+            )
+        )
+
+    for name, device_id, product_name, has_local_key in sorted(rows):
+        print(
+            f"name={name} device_id={device_id} product={product_name} local_key={has_local_key}",
+            file=stdout,
+        )
+
+
+def list_smart_life_scenes(auth_file: Path, auth_cache: dict[str, Any]) -> list[Any]:
+    ensure_tuya_sdk()
+    listener = AuthCacheTokenListener(auth_file, auth_cache)
+    manager = Manager(
+        CLIENT_ID,
+        auth_cache["user_code"],
+        auth_cache["terminal_id"],
+        auth_cache["endpoint"],
+        auth_cache["token_info"],
+        listener,
+    )
+    manager.update_device_cache()
+    scenes = manager.query_scenes()
+    listener.raise_if_persist_failed()
+    return scenes
+
+
+def print_scene_list(scenes: Iterable[Any], stdout: TextIO) -> None:
+    rows: list[tuple[str, str, str, bool]] = []
+    for scene in scenes:
+        name = get_device_field(scene, "name")
+        scene_id = get_device_field(scene, "scene_id", "sceneId")
+        home_id = get_device_field(scene, "home_id", "homeId")
+        enabled = bool(get_device_field(scene, "enabled"))
+        rows.append((str(name or "-"), str(scene_id or "-"), str(home_id or "-"), enabled))
+
+    for name, scene_id, home_id, enabled in sorted(rows):
+        print(
+            f"name={name} scene_id={scene_id} home_id={home_id} enabled={'yes' if enabled else 'no'}",
+            file=stdout,
+        )
+
+
 def fetch_device_detail(manager: Any, device_id: str) -> Any | None:
     customer_api = getattr(manager, "customer_api", None)
     if customer_api is None or not hasattr(customer_api, "get"):
@@ -493,9 +576,15 @@ def format_tuya_error(prefix: str, response: dict[str, Any]) -> str:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Fetch the current ERV Tuya local key via the Smart Life HA sharing API.",
+        description="Fetch current Tuya local keys via the Smart Life HA sharing API.",
     )
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_FILE)
+    parser.add_argument(
+        "--section",
+        default="erv",
+        choices=["erv", "blinds"],
+        help="config section whose device_id/local_key should be used",
+    )
     parser.add_argument("--auth-file", type=Path, default=DEFAULT_AUTH_FILE)
     parser.add_argument(
         "--init-auth",
@@ -515,9 +604,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="print the current local key (default unless --update-config is used)",
     )
     parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="list Smart Life devices visible to the sharing API without printing local keys",
+    )
+    parser.add_argument(
+        "--list-scenes",
+        action="store_true",
+        help="list Smart Life scenes visible to the sharing API",
+    )
+    parser.add_argument(
         "--update-config",
         action="store_true",
-        help="replace erv.local_key in config.yaml if it changed",
+        help="replace <section>.local_key in config.yaml if it changed",
     )
     parser.add_argument(
         "--restart",
@@ -537,14 +636,20 @@ def main(
 
     if args.print_key and args.update_config:
         parser.error("--print and --update-config are mutually exclusive")
+    if (args.list_devices or args.list_scenes) and (
+        args.print_key or args.update_config or args.restart
+    ):
+        parser.error(
+            "--list-devices/--list-scenes cannot be combined with --print, --update-config, or --restart"
+        )
+    if args.list_devices and args.list_scenes:
+        parser.error("--list-devices and --list-scenes are mutually exclusive")
     if args.restart and not args.update_config:
         parser.error("--restart requires --update-config")
     if args.init_auth and not args.user_code:
         parser.error("--init-auth requires --user-code")
 
     try:
-        device_id, configured_key = read_erv_config(args.config)
-
         if args.init_auth:
             auth_cache = init_auth(
                 args.user_code,
@@ -557,6 +662,14 @@ def main(
         else:
             auth_cache = load_auth_cache(args.auth_file)
 
+        if args.list_devices:
+            print_device_list(list_smart_life_devices(args.auth_file, auth_cache), stdout)
+            return 0
+        if args.list_scenes:
+            print_scene_list(list_smart_life_scenes(args.auth_file, auth_cache), stdout)
+            return 0
+
+        device_id, configured_key = read_device_config(args.config, args.section)
         current_key, device_name = fetch_current_local_key(
             args.auth_file,
             auth_cache,
@@ -568,9 +681,12 @@ def main(
                 print("no rotation needed", file=stdout)
                 return 0
 
-            update_config_local_key(args.config, current_key)
+            update_config_local_key(args.config, args.section, current_key)
             suffix = f" for {device_name}" if device_name else ""
-            print(f"updated {args.config}: erv.local_key refreshed{suffix}", file=stdout)
+            print(
+                f"updated {args.config}: {args.section}.local_key refreshed{suffix}",
+                file=stdout,
+            )
             if args.restart:
                 restart_orchestrator()
                 print(f"restarted {SERVICE_LABEL}", file=stdout)

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -64,7 +64,14 @@ class FakeManager:
                 id="erv-device-id",
                 name="ERVQ-H-F-BM",
                 local_key="new-local-key",
-            )
+                productName="Ventilation System",
+            ),
+            "bridge-device-id": SimpleNamespace(
+                id="bridge-device-id",
+                name="WiFi Bridge",
+                local_key="bridge-local-key",
+                productName="WiFi Bridge",
+            ),
         }
         FakeManager.latest_listener = listener
 
@@ -78,6 +85,16 @@ class FakeManager:
                 "refresh_token": "new-refresh-token",
             }
         )
+
+    def query_scenes(self):
+        return [
+            SimpleNamespace(
+                name="Open office blinds",
+                scene_id="open-scene-id",
+                home_id="home-id",
+                enabled=True,
+            )
+        ]
 
 
 class SwallowingRefreshErrorManager(FakeManager):
@@ -282,6 +299,111 @@ def test_print_mode_outputs_key_without_updating_config(tmp_path, monkeypatch):
     assert rc == 0
     assert stdout.getvalue().strip() == "new-local-key"
     assert config.read_text() == before
+
+
+def test_blinds_section_can_refresh_bridge_key(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "\n".join(
+            [
+                "erv:",
+                '  device_id: "erv-device-id"',
+                '  local_key: "old-local-key"',
+                "blinds:",
+                '  device_id: "bridge-device-id"',
+                '  local_key: "old-bridge-key"  # keep this comment',
+                "",
+            ]
+        )
+    )
+    auth = tmp_path / "auth.json"
+    write_auth(auth)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+            "--section",
+            "blinds",
+            "--update-config",
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert rc == 0
+    assert "blinds.local_key refreshed for WiFi Bridge" in stdout.getvalue()
+    assert 'local_key: "bridge-local-key" # keep this comment' in config.read_text()
+    assert 'local_key: "old-local-key"' in config.read_text()
+
+
+def test_list_devices_prints_names_without_keys(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    write_config(config)
+    auth = tmp_path / "auth.json"
+    write_auth(auth)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+            "--list-devices",
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    output = stdout.getvalue()
+    assert rc == 0
+    assert "name=WiFi Bridge device_id=bridge-device-id" in output
+    assert "name=ERVQ-H-F-BM device_id=erv-device-id" in output
+    assert "bridge-local-key" not in output
+    assert "new-local-key" not in output
+
+
+def test_list_scenes_prints_scene_ids(tmp_path, monkeypatch):
+    module = load_script_module()
+    monkeypatch.setattr(module, "Manager", FakeManager)
+    monkeypatch.setattr(module, "LoginControl", object)
+
+    config = tmp_path / "config.yaml"
+    write_config(config)
+    auth = tmp_path / "auth.json"
+    write_auth(auth)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = module.main(
+        [
+            "--config",
+            str(config),
+            "--auth-file",
+            str(auth),
+            "--list-scenes",
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    output = stdout.getvalue()
+    assert rc == 0
+    assert "name=Open office blinds scene_id=open-scene-id home_id=home-id enabled=yes" in output
 
 
 def test_qr_payload_wraps_home_assistant_qrcode_token():


### PR DESCRIPTION
## Summary

- add Tuya/Smart Life blinds control support to the Rust server, CLI smoke commands, config, and refresh script device/scene discovery
- expose blinds open/close controls in the web dashboard and Android app
- update Android enrollment so new device keys are non-exportable AndroidKeyStore EC keys while retaining the software-key fallback for already-enrolled devices
- fold in the pending automation/policy state-machine changes already present in the working tree
- fix ERV pressure-bias no-op handling so normal and exhaust-biased supply/exhaust presets are rewritten when post-renovation negative pressure toggles

## Notes

The blinds are exposed by Smart Life as an RF subdevice behind the Wifi Bridge. The only reliable control surface observed is Smart Life scene trigger. I smoke-tested Tuya state reads separately: Smart Life reports the blinds device as online but returns empty `status`, `functions`, `status_range`, and `dpStatusRelationDTOS`; nearby status endpoints return Tuya `1108 uri path invalid`. Because of that, this PR keeps explicit Open/Close controls and does not add a stale guessed state readout.

Android re-enrollment was required once because the prior enrolled credential path could not complete the TLS handshake on the device. This PR keeps existing enrolled software credentials usable so normal future updates should not require re-enrollment, while new enrollments go back to non-exportable AndroidKeyStore EC keys.

## Validation

- `cargo build --release --manifest-path rust/office-automate-server/Cargo.toml`
- `launchctl kickstart -k gui/$(id -u)/com.office-automate.server`
- `cargo test --manifest-path rust/office-automate-server/Cargo.toml`
- `cargo audit --deny warnings`
- `npm run build`
- `./gradlew :app:assembleRelease -x lintVitalAnalyzeRelease -x lintVitalReportRelease`
- `python3 -m pytest tests/test_refresh_erv_key.py`
- `git diff --check`
- GitHub Security Gates: Rust, Frontend, and Android supply-chain checks passed on `99f53c7d9c`
- Codex review re-run on `99f53c7d9c`: no major issues

## Operational

- LaunchAgent verified at `~/Library/LaunchAgents/com.office-automate.server.plist` with `KeepAlive` and `RunAtLoad`
- pairing/APK helper ports `19191` and `19192` verified not listening after use