### PR TITLE
ERV: Smart Life scene control with local read-only verification

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -48,8 +48,31 @@ erv:
   device_id: "your_tuya_device_id"
   local_key: "your_tuya_local_key"
   ip: "192.168.1.xxx"
-  poll_interval_seconds: 60       # Poll while ERV state is unknown/running
-  idle_poll_interval_seconds: 300  # Back off status polling when ERV is known off
+
+  # Writes go out as Smart Life tap-to-run scenes; local Tuya is read-only.
+  # Scenes are the only cloud mechanism that reaches fan speed, because the
+  # speed data points (101/102) are private and the sharing API hides them.
+  # Scenes cannot be created via API -- hand-build them in the Smart Life app.
+  smart_life_home_id: "your_smart_life_home_id"
+  off_scene_id: "scene_id_for_off"
+  quiet_scene_id: "scene_id_for_quiet"
+  medium_scene_id: "scene_id_for_medium"
+  turbo_scene_id: "scene_id_for_turbo"
+  # Negative-pressure (exhaust-biased) variants, used while renovation mode is armed.
+  quiet_negative_pressure_scene_id: "scene_id_for_quiet_np"
+  medium_negative_pressure_scene_id: "scene_id_for_medium_np"
+  turbo_negative_pressure_scene_id: "scene_id_for_turbo_np"
+
+  control_mode: "scene"                # scene | local -- which transport issues writes
+  local_readback_enabled: true         # local read-after-write for true supply/exhaust
+  local_write_fallback_enabled: true   # write locally if a scene trigger fails and local is healthy
+  # smart_life_auth_file: "~/.office-automate/tuya-sharing-auth.json"  # defaults to this
+
+# Smart Life (Tuya sharing API) credentials shared by the ERV and the blinds.
+smart_life:
+  # Shared Home Assistant Tuya integration identifier. Not a secret, but it has
+  # changed before; overriding it here avoids needing a rebuild to track it.
+  client_id: "HA_3y9q4ak7g4ephrvke"
 
 # Tuya smart blinds over the office window. This is independent of the
 # window open/closed contact sensor.

--- a/docs/tuya-local-key.md
+++ b/docs/tuya-local-key.md
@@ -1,6 +1,16 @@
 # Tuya Local Key Recovery (Smart Life / ERV)
 
-This is the repeatable process to restore ERV local control when Tuya local commands start failing (e.g., Err 914 or dashboard control not working). Two paths depending on whether the local key has actually rotated or just gotten out of sync:
+> **Since #154, this restores *speed readback*, not control.** ERV writes go out
+> over Smart Life tap-to-run scenes, which do not use the local key at all. A
+> broken local key means the reported fan speed is assumed rather than observed
+> (`erv.control.status_source` in `/status` reads `assumed`), and the
+> `erv_local_key_invalid` notification is a warning, not an outage. Ventilation
+> keeps working. Run this at your convenience, not at 2am.
+>
+> The exception is `control_mode: "local"` in `config.yaml`, where the local key
+> is still the control path and this is urgent.
+
+This is the repeatable process to restore ERV local reads when Tuya local traffic starts failing (e.g., Err 914). Two paths depending on whether the local key has actually rotated or just gotten out of sync:
 
 - **Preferred: Smart Life sharing API refresh** using `scripts/refresh-erv-key.py`. This avoids the Android emulator and does **not** require a Tuya IoT Platform subscription.
 - **Path A: Re-extract** the cached local key from the Smart Life app. Works if the key in `config.yaml` is wrong but Smart Life still has working local control.
@@ -10,7 +20,7 @@ Start with the preferred path. Use Path A only if Smart Life sharing auth fails,
 
 ## When To Run This
 
-- Local control fails with Err 914 (“Check device key or version”).
+- Local reads fail with Err 914 (“Check device key or version”), so `/status` reports `erv.control.status_source: "assumed"`.
 - Dashboard or automations can’t turn on the ERV but the Smart Life app still works locally.
 - The device firmware was updated.
 - Orchestrator (or another local Tuya client) issued a rapid burst of commands that the device interpreted as adversarial. This is what happened on 2026-05-21 and is fixed by issue #59.
@@ -62,6 +72,8 @@ scripts/refresh-erv-key.py --update-config --restart
 ```
 
 If the API returns the same key that is already in `config.yaml`, the script prints `no rotation needed` and exits 0 without editing or restarting.
+
+**This script cannot fix a both-copies-stale desync.** It only helps when the cloud holds a *newer* key than `config.yaml`. The recurring failure is different: the configured key matches the cloud's copy exactly, the protocol version matches the device's own broadcast, and the handshake still returns Err 914 — because the *device* has moved on from the key both copies share. `no rotation needed` plus continued Err 914 is exactly that case. The only fix is a hardware re-pair (Path B).
 
 ## Prereqs
 
@@ -228,10 +240,12 @@ ssh USER@SERVER_IP 'U=$(id -u); launchctl kickstart -k gui/$U/com.office-automat
 ssh USER@SERVER_IP 'tail -n 50 /tmp/office-automate.error.log'
 ```
 
-You should see:
+You should see the boot read succeed:
 ```
-Connected to ERV via local API. Status: ...
+ERV boot read: running=... speed=...
 ```
+
+`/status` should then report `erv.control.status_source: "local"` and clear `erv.control.local_key_invalid`.
 
 ## 6) Tear Down (Reclaim ~1.7GB)
 
@@ -269,6 +283,11 @@ Known Err 914 triggers for this ERV:
 - **Firmware OTA** — disabling auto firmware updates in Smart Life is still useful if the toggle exists (look for "Check for firmware updates" or similar), though we have not confirmed that Smart Life reliably honors it.
 - **Command burst from a misbehaving local client** — the orchestrator-side cause from 2026-05-21 was fixed in issue #59 with CO2 plateau latching and a minimum ERV dwell timer.
 - **Alert on 914** in the orchestrator logs so you catch the rotation immediately, not days/weeks later when CO2 is high and the dashboard is silent.
+
+Since #154 the orchestrator issues no local *commands* in normal operation and no
+longer polls status on a cadence, which removes both documented triggers. Local
+traffic is now a boot read plus one read after each write (~30/day, down from
+288–1440).
 
 ## Notes
 

--- a/docs/working/154_erv_scene_fallback.md
+++ b/docs/working/154_erv_scene_fallback.md
@@ -1,0 +1,176 @@
+# ERV: Smart Life Scene Control with Local Read-Only Verification
+
+Issue: #154
+
+## Summary
+
+ERV automation was dead for roughly a month. Local Tuya control failed with Err 914 and there was no fallback path, so a single credential failure took out all ERV control while every other subsystem kept running.
+
+Move ERV writes onto Smart Life tap-to-run scenes, make local Tuya read-only, and remove the status polling loop that aggravates the failure mode.
+
+**The two transports are split by direction, not by preference order:**
+
+| Trait method | Default transport | Effect |
+|---|---|---|
+| `set_speed` | Smart Life scene trigger | no local command is ever issued |
+| `smoke_status` | local Tuya read | read-only; the only view of the speed DPs |
+
+Issuing no local *commands* removes the documented cause of the Err 914 lockout (`docs/tuya-local-key.md`), while local reads remain the only way to observe fan speed.
+
+## Why local can't just be fixed
+
+The recurring failure is a local-key desync: the configured key can match the cloud's copy *exactly*, and the protocol version can match the device's own broadcast, and the handshake still returns Err 914. `scripts/refresh-erv-key.py` cannot repair this — it only helps when the cloud holds a *newer* key than config. The only fix is a hardware re-pair, which is manual and has happened more than once.
+
+So local control cannot be the sole path. But it also cannot be dropped, because of the constraint below.
+
+## Hard Constraints (measured — do not re-derive)
+
+These were established empirically against the live device. Several are counter-intuitive.
+
+### The cloud cannot see or set fan speed
+
+Fan speed lives in private data points (`101` = supply, `102` = exhaust; see `DP_SUPPLY_SPEED` / `DP_EXHAUST_SPEED` in `erv.rs`). The Smart Life sharing API does not expose them:
+
+- **Status** returns only standard codes — `switch`, `mode`, `pm25`, `eco2`, `tvoc`, `humidity_indoor`, `temp_indoor`, `filter_reset`, `fault`. The speed DPs are absent.
+- **Writable functions** are only `switch`, `mode`, `filter_reset`. There is no cloud path to set speed directly.
+
+Scenes are the *only* cloud mechanism that reaches speed, because the scene replays private DPs server-side.
+
+### ⚠ The scene read view is lossy — do not be misled by it
+
+Listing scenes renders every ERV speed scene's action as the same JSON:
+
+```json
+{"action_executor": "dpIssue", "entity_id": "<device>",
+ "executor_property": {"switch": true}}
+```
+
+**This is a rendering artifact, not the stored scene.** The sharing API hides private DPs, and it hides them in scene actions exactly as it hides them in device status — so the part that distinguishes a high-speed scene from a low-speed one is precisely the part the view drops. The scenes were verified physically (display readout and audible fan speed) to set distinct supply/exhaust values. Scene execution happens server-side against the real stored definition; the trigger endpoint only names the scene and is not constrained by what the read endpoint can display.
+
+Do not "fix" the scenes based on this JSON. Do not assert scene equivalence from it.
+
+### Scenes cannot be created or edited via API
+
+All create/modify/delete paths return `1108 uri path invalid`; the sharing credential is read + trigger only. Scenes are hand-built in the Smart Life app. Budget for manual work if scene definitions ever need to change, and never assume a missing scene can be provisioned in code.
+
+## Design
+
+Four independent changes; they can land separately.
+
+### 1. Split the writer by direction
+
+`ErvSpeedWriter` (`erv.rs`) is already a trait behind `Arc<dyn>`, injected in `http.rs` and consumed by the coordinator in `automation.rs`. **Keep the trait signature unchanged** — that keeps policy, dwell, manual override, burst guard, DB logging, the `/erv` endpoint, and both clients untouched, and keeps every existing `FakeErvWriter` test compiling.
+
+Add:
+
+- `SceneErvSpeedWriter` — maps `ErvFanSpeed` + negative-pressure flag to a configured scene id and triggers it.
+- `SplitErvWriter { writer, reader }` — `set_speed` delegates to the scene writer, then verifies; `smoke_status` delegates to the local reader.
+
+This combination is strictly better than either path alone: scenes reach every speed, and the local read confirms the scene actually landed, so `verify_speed` keeps working unchanged against real supply/exhaust values.
+
+### 2. Verification ladder
+
+Verification happens **only when we change device state** — never on a cadence. After a write, wait `verify_delay_seconds`, then confirm using the best available source:
+
+1. **Local read** (default) — returns true supply/exhaust. Full verification against `verify_speed`.
+2. **Cloud read** — used *only when the local key is dead*. Returns the `switch` bit and nothing else, so it can only confirm power state. Note this is worth doing on power transitions but is **uninformative on speed-only changes** (`switch` is `true` before and after); skip it there rather than spend a call for no signal.
+3. **Assumed state** — if neither is available, trust the command and mark the status accordingly.
+
+A failed verification must **not** fail the write. Degrade observability, never control.
+
+### 3. Automatic local-write fallback
+
+If a scene trigger fails (WAN down, Tuya cloud unreachable) **and** the local path is healthy, issue the write locally. Automatically, with no prompt and no toggle.
+
+This is what "fallback" means: the system stays controllable on a LAN-only network without anyone being in the loop. An outage is precisely the moment the owner is least able to intervene, and a manual switch would be unreachable anyway — the phone app depends on the same connectivity. Do not surface this as a choice; decide it in code from observed health.
+
+The local-write path stays rare by construction (it only runs when the cloud is down), so it does not reintroduce the command volume that causes the lockout.
+
+### 4. Remove the polling loop
+
+Delete `start_erv_status_poll` and its call site in `http.rs`. Replace with:
+
+- **one read at boot** to establish true state; if it fails, trigger the off-scene to force a known state;
+- **read-after-write** only, per the ladder above.
+
+This drops local traffic from hundreds or thousands of reads/day to roughly the number of actual writes (~30/day measured). Keep the burst guard unchanged — it protects the device regardless of path.
+
+### 5. Status truth and its source
+
+`ErvState.latest_status` becomes either observed or assumed. Add a source marker (e.g. `Local | Cloud | Assumed`) surfaced in `ErvControlStatus` (`status.rs`) so clients can distinguish "the ERV is at turbo" from "we told it turbo and could not confirm".
+
+### 6. Stop letting a broken local key block control
+
+`local_key_invalid` currently hard-bails every write path in `erv.rs`, and `set_speed_with` additionally requires a *local read* to succeed before writing. Together these are why one credential failure killed all control.
+
+Under this design those gates are simply wrong: the local key has no bearing on whether a scene trigger will work. A stale local key must cost **speed readback only** — never control. Scope every one of these checks to the local path.
+
+Rework the `erv_local_key_invalid` notification from "control is dead, run the runbook" to "speed readback degraded, control unaffected". It is no longer a critical outage.
+
+## Config
+
+All values live in `config.yaml` (gitignored) under `erv:`. Mirror the dual-mode pattern from `BlindsConfig` in `config.rs`, including a `scene_configured()` predicate alongside `is_configured()`.
+
+Keys to read (values are site-specific and already populated on the host):
+
+- `smart_life_home_id`
+- `off_scene_id`, `quiet_scene_id`, `medium_scene_id`, `turbo_scene_id`
+- `quiet_negative_pressure_scene_id`, `medium_negative_pressure_scene_id`, `turbo_negative_pressure_scene_id`
+- `smart_life_auth_file` — optional, defaults to the same path `blinds.rs` uses
+- `control_mode` — `scene` | `local`, which transport issues writes
+- `local_readback_enabled` — local read-after-write for true speed
+- `local_write_fallback_enabled` — automatic local write when a scene trigger fails
+
+**Intended defaults:** `control_mode: "scene"`, `local_readback_enabled: true`, `local_write_fallback_enabled: true`. Encode them in `ErvConfig::default()`, not just in the YAML.
+
+### Negative-pressure coverage is complete
+
+`speed_preset` in `erv.rs` defines negative-pressure variants for all three speeds. **All three now have scenes**, so the scene path covers the full `(speed × pressure)` matrix with no gaps. Negative pressure is dormant while `post_renovation_expires_at` is in the past; re-arming it needs only a date change, no new scenes.
+
+Still implement the missing-scene case defensively: if a `(speed, pressure)` pair ever resolves to no configured scene id, **fail loudly and surface it in status** rather than silently substituting the normal-pressure variant. A system that reports a mode it is not delivering is worse than one that reports an error.
+
+## Implementation Steps
+
+1. **Extract a shared `smart_life` module** from `blinds.rs` — the auth cache, token refresh, client, and AES-GCM/HMAC helpers are all device-agnostic. `blinds.rs` keeps only its scene trigger. Pure refactor; existing `blinds.rs` tests cover it.
+
+   **Move the hardcoded Smart Life client id into config as part of this step.** It is currently a literal in both `blinds.rs` and `scripts/refresh-erv-key.py`, where the two copies can silently drift. It is not a secret — it is the shared Home Assistant Tuya integration identifier — but it is a third-party constant that has changed before, and needing a Rust rebuild to track it is wrong. Give it a config key with the current value as the default so existing deployments are unaffected.
+
+2. **Add an auth-cache mutex.** Token refresh *rotates the refresh token*. Once blinds and ERV share one cache file, two concurrent refreshes can clobber each other and lose cloud auth for both devices. This bug does not exist today only because blinds is the sole caller — adding the ERV is what introduces it. Guard load/refresh/save with a process-wide async mutex.
+
+3. **Extend `ErvConfig`** with the scene fields and mode flags; add `scene_configured()`. Add matching env overrides if following the existing pattern in `config.rs`.
+
+4. **Add `SceneErvSpeedWriter` and `SplitErvWriter`.**
+
+5. **Wire writer selection** in `http.rs` from the mode flags. Default assembly is `SplitErvWriter { writer: SceneErvSpeedWriter, reader: RustuyaErvStatusReader }`.
+
+6. **Implement the verification ladder** (§2) and the automatic local-write fallback (§3), driven by observed path health rather than configuration alone.
+
+7. **Remove the polling loop**; add the boot read.
+
+8. **Re-scope the gates** — the `local_key_invalid` bails and the pre-write local smoke read in `erv.rs`.
+
+9. **Fix the read-only smoke paths.** `smoke_erv` is called from `cli.rs` and `validation.rs`; `validation.rs` hard-bails when local ERV credentials are absent, which breaks shadow validation in scene-only mode.
+
+10. **Update status and notifications** — `status.rs`, and the ERV notification constructors in `erv.rs`.
+
+11. **Docs** — update `docs/tuya-local-key.md` to describe re-pair as the path for restoring *speed readback* rather than restoring control, and note that the refresh script cannot fix a both-copies-stale desync.
+
+## Testing
+
+- Existing `FakeErvWriter` suites in `automation.rs`, `http.rs`, and `yolink.rs` must keep passing unchanged — if they don't, the trait was altered and shouldn't have been.
+- In the default config, a `set_speed` issues a scene trigger and **no local command** — assert the local writer is never invoked. This is the property the whole design rests on; test it directly.
+- Scene write succeeds + local read succeeds → status source `Local`, real supply/exhaust values.
+- Scene write succeeds + local read fails → write still succeeds, status source `Assumed`, control not blocked.
+- `local_key_invalid` does not block a scene write.
+- Scene trigger fails + local healthy → automatic local write, no prompt.
+- Scene trigger fails + local unhealthy → error surfaced.
+- Cloud verification is skipped on speed-only changes and used on power transitions.
+- Missing scene for a `(speed, pressure)` pair fails loudly rather than substituting.
+- Auth-cache refresh under concurrent blinds + ERV access does not lose the refresh token.
+- Manual: trigger each speed and confirm supply/exhaust on the unit's display, since no automated check can observe speed through the cloud.
+
+## Out of Scope
+
+- **Local/cloud toggle in the Android app** — tracked separately. The Android client is the primary control surface; the web dashboard is rarely used.
+- Reviving the Tuya IoT Cloud developer API. It is unavailable (expired subscription) and no code reads its config block today.
+- Using the ERV's own air-quality readings — the existing sensor already covers this.

--- a/rust/office-automate-server/src/automation.rs
+++ b/rust/office-automate-server/src/automation.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, RwLock};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tokio::sync::{Mutex as AsyncMutex, broadcast};
 
 use crate::{
@@ -91,12 +91,21 @@ impl ErvPolicyCoordinator {
             qingping_reading.as_ref(),
             manual_override,
         ) {
-            self.erv
+            // A failed read must not stop the policy from acting: it only means
+            // the decision is made without fresh state.
+            match self
+                .erv
                 .smoke_status_with(&self.config.erv, self.writer.as_ref())
                 .await
-                .context("ERV smoke check failed before policy evaluation")?;
-            erv_snapshot = self.erv.snapshot();
-            fresh_status_checked = true;
+            {
+                Ok(_) => {
+                    erv_snapshot = self.erv.snapshot();
+                    fresh_status_checked = true;
+                }
+                Err(error) => {
+                    tracing::warn!("ERV read before policy evaluation failed: {error:#}");
+                }
+            }
         }
 
         let negative_pressure_active = self.post_renovation_negative_pressure_active();
@@ -154,7 +163,7 @@ impl ErvPolicyCoordinator {
                 reason,
                 ..
             } => {
-                if !self.erv.local_retry_allowed(now) {
+                if !self.erv.write_retry_allowed(now) {
                     return Ok(());
                 }
                 self.apply_policy_erv_speed(
@@ -288,11 +297,12 @@ impl ErvPolicyCoordinator {
         qingping_reading: Option<&crate::qingping::QingpingReading>,
         manual_override: Option<VentilationSpeed>,
     ) -> bool {
+        // This decides whether to spend a *local read*, so it is gated on local
+        // health only. Control does not depend on the answer.
         if snapshot.status_known
             || !self.config.erv.active_control_enabled
-            || !self.config.erv.is_configured()
-            || snapshot.local_key_invalid
-            || !self.erv.local_retry_allowed(unix_timestamp_now())
+            || !self.config.erv.local_readback_active()
+            || !self.erv.read_retry_allowed(unix_timestamp_now())
         {
             return false;
         }
@@ -508,6 +518,7 @@ mod tests {
             },
             mitsubishi: MitsubishiConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: TelemetryConfig::default(),
             runtime: RuntimeConfig {
@@ -906,8 +917,11 @@ mod tests {
         );
     }
 
+    /// A local read is the only view of true fan speed, but it is not a
+    /// prerequisite for control: when it fails the policy still acts, it just
+    /// acts without fresh state.
     #[tokio::test]
-    async fn automated_policy_write_respects_local_failure_backoff() {
+    async fn failed_local_read_does_not_block_the_automated_write() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
@@ -941,16 +955,13 @@ mod tests {
         coordinator
             .evaluate_erv_policy(false)
             .await
-            .expect_err("first automated write should fail");
-        assert_eq!(writer.smoke_calls(), 1);
-        assert!(writer.writes().is_empty());
+            .expect("policy still applies without a fresh status read");
 
-        coordinator
-            .evaluate_erv_policy(false)
-            .await
-            .expect("second policy evaluation respects backoff");
         assert_eq!(writer.smoke_calls(), 1);
-        assert!(writer.writes().is_empty());
+        assert!(
+            !writer.writes().is_empty(),
+            "a failed read must not suppress the write"
+        );
     }
 
     #[tokio::test]
@@ -995,7 +1006,7 @@ mod tests {
         )
         .await
         .expect_err("fourth automated write is suppressed");
-        assert!(!erv.local_retry_allowed(unix_timestamp_now()));
+        assert!(!erv.write_retry_allowed(unix_timestamp_now()));
 
         let policy = Arc::new(RwLock::new(ErvPolicyState::new(&config.thresholds)));
         let (status_broadcast, _) = broadcast::channel(4);

--- a/rust/office-automate-server/src/blinds.rs
+++ b/rust/office-automate-server/src/blinds.rs
@@ -1,25 +1,11 @@
-use std::{env, fs, path::PathBuf, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
-use aes_gcm::{
-    Aes128Gcm, Nonce,
-    aead::{Aead, KeyInit},
-};
 use anyhow::{Context, Result, anyhow, bail};
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use hmac::{Hmac, Mac};
-use rand::Rng;
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
-use sha2::Sha256;
-use uuid::Uuid;
 
-use crate::config::BlindsConfig;
-
-const SMART_LIFE_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
-const DEFAULT_SMART_LIFE_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
-
-type HmacSha256 = Hmac<Sha256>;
+use crate::{
+    config::{AppConfig, BlindsConfig, SmartLifeConfig},
+    smart_life::{SmartLifeClient, auth_file_or_default},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlindsCommand {
@@ -60,18 +46,19 @@ impl BlindsCommand {
     }
 }
 
-pub async fn set_blinds(config: &BlindsConfig, command: BlindsCommand) -> Result<()> {
-    if !config.active_control_enabled {
+pub async fn set_blinds(config: &AppConfig, command: BlindsCommand) -> Result<()> {
+    let blinds = &config.blinds;
+    if !blinds.active_control_enabled {
         bail!("Blinds active control is disabled");
     }
-    if !config.is_configured() {
+    if !blinds.is_configured() {
         bail!("Blinds config is incomplete");
     }
 
-    if config.smart_life_scene_configured() {
-        trigger_smart_life_scene(config, command).await
+    if blinds.smart_life_scene_configured() {
+        trigger_smart_life_scene(blinds, &config.smart_life, command).await
     } else {
-        set_local_tuya_blinds(config, command).await
+        set_local_tuya_blinds(blinds, command).await
     }
 }
 
@@ -91,7 +78,11 @@ async fn set_local_tuya_blinds(config: &BlindsConfig, command: BlindsCommand) ->
     ensure_tuya_command_ok("Local blinds command failed", payload.as_deref())
 }
 
-async fn trigger_smart_life_scene(config: &BlindsConfig, command: BlindsCommand) -> Result<()> {
+async fn trigger_smart_life_scene(
+    config: &BlindsConfig,
+    smart_life: &SmartLifeConfig,
+    command: BlindsCommand,
+) -> Result<()> {
     let home_id = config
         .smart_life_home_id
         .as_deref()
@@ -102,35 +93,17 @@ async fn trigger_smart_life_scene(config: &BlindsConfig, command: BlindsCommand)
         .scene_id(config)
         .ok_or_else(|| anyhow!("Blinds Smart Life {} scene id is missing", command.as_str()))?;
 
-    let auth_file = smart_life_auth_file(config);
-    let mut auth_cache = SmartLifeAuthCache::load(&auth_file)?;
-    let client = SmartLifeClient::new();
-    client.refresh_auth_if_needed(&mut auth_cache).await?;
-    auth_cache.save(&auth_file)?;
-    client
-        .post(
-            &mut auth_cache,
-            "/v1.0/m/scene/ha/trigger",
-            None,
-            Some(json!({"homeId": home_id, "sceneId": scene_id})),
+    SmartLifeClient::new(
+        smart_life.client_id.clone(),
+        auth_file_or_default(config.smart_life_auth_file.as_ref()),
+    )
+    .trigger_scene(home_id, scene_id)
+    .await
+    .with_context(|| {
+        format!(
+            "failed to trigger Smart Life {} blinds scene",
+            command.as_str()
         )
-        .await
-        .with_context(|| {
-            format!(
-                "failed to trigger Smart Life {} blinds scene",
-                command.as_str()
-            )
-        })?;
-    auth_cache.save(&auth_file)?;
-    Ok(())
-}
-
-fn smart_life_auth_file(config: &BlindsConfig) -> PathBuf {
-    config.smart_life_auth_file.clone().unwrap_or_else(|| {
-        env::var_os("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(DEFAULT_SMART_LIFE_AUTH_FILE)
     })
 }
 
@@ -156,288 +129,6 @@ fn ensure_tuya_command_ok(context: &str, payload: Option<&str>) -> Result<()> {
         }
         _ => Ok(()),
     }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct SmartLifeAuthCache {
-    user_code: String,
-    terminal_id: String,
-    endpoint: String,
-    token_info: SmartLifeTokenInfo,
-}
-
-impl SmartLifeAuthCache {
-    fn load(path: &PathBuf) -> Result<Self> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("failed to read Smart Life auth cache {}", path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("failed to parse Smart Life auth cache {}", path.display()))
-    }
-
-    fn save(&self, path: &PathBuf) -> Result<()> {
-        let content = serde_json::to_string_pretty(self)
-            .context("failed to serialize Smart Life auth cache")?;
-        fs::write(path, format!("{content}\n"))
-            .with_context(|| format!("failed to write Smart Life auth cache {}", path.display()))
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct SmartLifeTokenInfo {
-    t: i64,
-    expire_time: i64,
-    uid: String,
-    access_token: String,
-    refresh_token: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct SmartLifeApiEnvelope {
-    success: bool,
-    result: Option<Value>,
-    code: Option<Value>,
-    msg: Option<Value>,
-}
-
-struct SmartLifeClient {
-    http: Client,
-}
-
-impl SmartLifeClient {
-    fn new() -> Self {
-        Self {
-            http: Client::new(),
-        }
-    }
-
-    async fn refresh_auth_if_needed(&self, auth: &mut SmartLifeAuthCache) -> Result<()> {
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let expires_at = auth.token_info.t + auth.token_info.expire_time * 1_000;
-        if expires_at - 60_000 > now_ms {
-            return Ok(());
-        }
-
-        let path = format!("/v1.0/m/token/{}", auth.token_info.refresh_token);
-        let result = self
-            .get(auth, &path, None)
-            .await
-            .context("failed to refresh Smart Life access token")?;
-        auth.token_info = SmartLifeTokenInfo {
-            t: chrono::Utc::now().timestamp_millis(),
-            expire_time: result
-                .get("expireTime")
-                .and_then(Value::as_i64)
-                .ok_or_else(|| anyhow!("Smart Life token refresh missing expireTime"))?,
-            uid: result
-                .get("uid")
-                .and_then(Value::as_str)
-                .ok_or_else(|| anyhow!("Smart Life token refresh missing uid"))?
-                .to_string(),
-            access_token: result
-                .get("accessToken")
-                .and_then(Value::as_str)
-                .ok_or_else(|| anyhow!("Smart Life token refresh missing accessToken"))?
-                .to_string(),
-            refresh_token: result
-                .get("refreshToken")
-                .and_then(Value::as_str)
-                .ok_or_else(|| anyhow!("Smart Life token refresh missing refreshToken"))?
-                .to_string(),
-        };
-        Ok(())
-    }
-
-    async fn get(
-        &self,
-        auth: &mut SmartLifeAuthCache,
-        path: &str,
-        params: Option<Value>,
-    ) -> Result<Value> {
-        self.request(auth, "GET", path, params, None).await
-    }
-
-    async fn post(
-        &self,
-        auth: &mut SmartLifeAuthCache,
-        path: &str,
-        params: Option<Value>,
-        body: Option<Value>,
-    ) -> Result<Value> {
-        self.request(auth, "POST", path, params, body).await
-    }
-
-    async fn request(
-        &self,
-        auth: &mut SmartLifeAuthCache,
-        method: &str,
-        path: &str,
-        params: Option<Value>,
-        body: Option<Value>,
-    ) -> Result<Value> {
-        let request_id = Uuid::new_v4().to_string();
-        let hash_key = format!(
-            "{:x}",
-            md5::compute(format!("{}{}", request_id, auth.token_info.refresh_token))
-        );
-        let secret = smart_life_secret(&request_id, "", &hash_key)?;
-
-        let query_encdata = match params {
-            Some(params) => Some(encrypt_json(&params, &secret)?),
-            None => None,
-        };
-        let body_encdata = match body {
-            Some(body) => Some(encrypt_json(&body, &secret)?),
-            None => None,
-        };
-        let now_ms = chrono::Utc::now().timestamp_millis().to_string();
-        let sign = smart_life_sign(
-            &hash_key,
-            query_encdata.as_deref().unwrap_or_default(),
-            body_encdata.as_deref().unwrap_or_default(),
-            &auth.token_info.access_token,
-            &request_id,
-            &now_ms,
-        )?;
-
-        let url = format!("{}{}", auth.endpoint, path);
-        let mut request = match method {
-            "GET" => self.http.get(url),
-            "POST" => self.http.post(url),
-            _ => bail!("unsupported Smart Life method {method}"),
-        }
-        .header("X-appKey", SMART_LIFE_CLIENT_ID)
-        .header("X-requestId", request_id)
-        .header("X-sid", "")
-        .header("X-time", now_ms)
-        .header("X-token", &auth.token_info.access_token)
-        .header("X-sign", sign);
-
-        if let Some(query_encdata) = query_encdata {
-            request = request.query(&[("encdata", query_encdata)]);
-        }
-        if let Some(body_encdata) = body_encdata {
-            request = request.json(&json!({ "encdata": body_encdata }));
-        }
-
-        let response = request
-            .send()
-            .await
-            .context("Smart Life request failed")?
-            .error_for_status()
-            .context("Smart Life HTTP error")?;
-        let envelope: SmartLifeApiEnvelope = response
-            .json()
-            .await
-            .context("failed to parse Smart Life response")?;
-        if !envelope.success {
-            bail!(
-                "Smart Life API error code={} msg={}",
-                envelope
-                    .code
-                    .as_ref()
-                    .map(Value::to_string)
-                    .unwrap_or_else(|| "unknown".to_string()),
-                envelope
-                    .msg
-                    .as_ref()
-                    .map(Value::to_string)
-                    .unwrap_or_else(|| "unknown".to_string())
-            );
-        }
-
-        match envelope.result {
-            Some(Value::String(encrypted)) => decrypt_result(&encrypted, &secret),
-            Some(value) => Ok(value),
-            None => Ok(Value::Null),
-        }
-    }
-}
-
-fn encrypt_json(value: &Value, secret: &str) -> Result<String> {
-    let raw = serde_json::to_string(value).context("failed to encode Smart Life payload")?;
-    let nonce = random_nonce();
-    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
-        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
-    let ciphertext = cipher
-        .encrypt(Nonce::from_slice(nonce.as_bytes()), raw.as_bytes())
-        .map_err(|error| anyhow!("failed to encrypt Smart Life payload: {error}"))?;
-    Ok(format!(
-        "{}{}",
-        BASE64.encode(nonce.as_bytes()),
-        BASE64.encode(ciphertext)
-    ))
-}
-
-fn decrypt_result(encrypted: &str, secret: &str) -> Result<Value> {
-    let bytes = BASE64
-        .decode(encrypted)
-        .context("failed to decode Smart Life response")?;
-    if bytes.len() < 12 {
-        bail!("Smart Life response is too short");
-    }
-    let (nonce, ciphertext) = bytes.split_at(12);
-    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
-        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
-    let plaintext = cipher
-        .decrypt(Nonce::from_slice(nonce), ciphertext)
-        .map_err(|error| anyhow!("failed to decrypt Smart Life response: {error}"))?;
-    let text = String::from_utf8(plaintext).context("Smart Life response is not valid UTF-8")?;
-    serde_json::from_str(&text).or_else(|_| Ok(Value::String(text)))
-}
-
-fn random_nonce() -> String {
-    const ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
-    let mut rng = rand::thread_rng();
-    (0..12)
-        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
-        .collect()
-}
-
-fn smart_life_secret(request_id: &str, sid: &str, hash_key: &str) -> Result<String> {
-    let mut message = hash_key.to_string();
-    if !sid.is_empty() {
-        let mut ecode = String::new();
-        for character in sid.chars().take(16) {
-            let index = character as usize % 16;
-            let selected = sid
-                .chars()
-                .nth(index)
-                .ok_or_else(|| anyhow!("invalid Smart Life sid"))?;
-            ecode.push(selected);
-        }
-        message.push('_');
-        message.push_str(&ecode);
-    }
-
-    let mut mac = <HmacSha256 as Mac>::new_from_slice(request_id.as_bytes())
-        .map_err(|error| anyhow!("invalid Smart Life HMAC key: {error}"))?;
-    mac.update(message.as_bytes());
-    let digest = mac.finalize().into_bytes();
-    Ok(to_lower_hex(&digest)[..16].to_string())
-}
-
-fn smart_life_sign(
-    hash_key: &str,
-    query_encdata: &str,
-    body_encdata: &str,
-    access_token: &str,
-    request_id: &str,
-    timestamp_ms: &str,
-) -> Result<String> {
-    let mut sign = format!(
-        "X-appKey={SMART_LIFE_CLIENT_ID}||X-requestId={request_id}||X-time={timestamp_ms}||X-token={access_token}"
-    );
-    sign.push_str(query_encdata);
-    sign.push_str(body_encdata);
-
-    let mut mac = <HmacSha256 as Mac>::new_from_slice(hash_key.as_bytes())
-        .map_err(|error| anyhow!("invalid Smart Life sign key: {error}"))?;
-    mac.update(sign.as_bytes());
-    Ok(to_lower_hex(&mac.finalize().into_bytes()))
-}
-
-fn to_lower_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 #[cfg(test)]
@@ -470,30 +161,5 @@ mod tests {
         assert!(config.is_configured());
         assert!(!config.smart_life_scene_configured());
         assert!(config.local_tuya_configured());
-    }
-
-    #[test]
-    fn smart_life_crypto_matches_sdk_vectors() {
-        let secret = smart_life_secret(
-            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
-            "",
-            "4b7d14dca2d3df16b3a12219a47a7e56",
-        )
-        .expect("secret");
-        assert_eq!(secret, "60437f64b09370c5");
-
-        let sign = smart_life_sign(
-            "4b7d14dca2d3df16b3a12219a47a7e56",
-            "",
-            "body-encdata",
-            "access-token",
-            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
-            "1783144312258",
-        )
-        .expect("sign");
-        assert_eq!(
-            sign,
-            "0b01f17ddcba9cd54e0305cdd53607ae3b877d88f84690fc406ee719fae94871"
-        );
     }
 }

--- a/rust/office-automate-server/src/cli.rs
+++ b/rust/office-automate-server/src/cli.rs
@@ -640,11 +640,11 @@ async fn run_smoke(config: &AppConfig, target: Option<SmokeTarget>) -> Result<()
                 );
             }
             SmokeTarget::BlindsClose => {
-                blinds::set_blinds(&config.blinds, blinds::BlindsCommand::Close).await?;
+                blinds::set_blinds(config, blinds::BlindsCommand::Close).await?;
                 println!("Blinds close scene trigger OK");
             }
             SmokeTarget::BlindsOpen => {
-                blinds::set_blinds(&config.blinds, blinds::BlindsCommand::Open).await?;
+                blinds::set_blinds(config, blinds::BlindsCommand::Open).await?;
                 println!("Blinds open scene trigger OK");
             }
         }

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -778,6 +778,43 @@ impl AppConfig {
             file_config.erv.smart_life_home_id = Some(home_id);
         }
 
+        // The whole matrix, not just the home id: a partial set would look like
+        // env configuration works while every write failed on a missing scene.
+        for (variable, target) in [
+            (
+                "OFFICE_AUTOMATE_ERV_OFF_SCENE_ID",
+                &mut file_config.erv.off_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_QUIET_SCENE_ID",
+                &mut file_config.erv.quiet_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_MEDIUM_SCENE_ID",
+                &mut file_config.erv.medium_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_TURBO_SCENE_ID",
+                &mut file_config.erv.turbo_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_QUIET_NEGATIVE_PRESSURE_SCENE_ID",
+                &mut file_config.erv.quiet_negative_pressure_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_MEDIUM_NEGATIVE_PRESSURE_SCENE_ID",
+                &mut file_config.erv.medium_negative_pressure_scene_id,
+            ),
+            (
+                "OFFICE_AUTOMATE_ERV_TURBO_NEGATIVE_PRESSURE_SCENE_ID",
+                &mut file_config.erv.turbo_negative_pressure_scene_id,
+            ),
+        ] {
+            if let Some(scene_id) = env_lookup(variable) {
+                *target = Some(scene_id);
+            }
+        }
+
         if let Some(mode) = env_lookup("OFFICE_AUTOMATE_ERV_CONTROL_MODE") {
             file_config.erv.control_mode = parse_erv_control_mode(&mode)?;
         }
@@ -1162,6 +1199,58 @@ smart_life:
         assert!(config.erv.local_write_fallback_enabled);
         assert_eq!(config.erv.smart_life_home_id(), Some("8171319"));
         assert_eq!(config.smart_life.client_id, "HA_custom_client");
+    }
+
+    /// An env-configured scene deployment must be able to supply the whole
+    /// matrix. A partial set would look like env configuration works while
+    /// every write failed on a missing scene.
+    #[test]
+    fn env_overrides_cover_the_whole_erv_scene_matrix() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_path = temp_dir.path().join("config.yaml");
+        fs::write(&config_path, "erv:\n  type: \"tuya\"\n").expect("write config");
+
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "OFFICE_AUTOMATE_ROOT" => Some(temp_dir.path().display().to_string()),
+            "OFFICE_AUTOMATE_ERV_SMART_LIFE_HOME_ID" => Some("env-home".to_string()),
+            "OFFICE_AUTOMATE_ERV_OFF_SCENE_ID" => Some("env-off".to_string()),
+            "OFFICE_AUTOMATE_ERV_QUIET_SCENE_ID" => Some("env-quiet".to_string()),
+            "OFFICE_AUTOMATE_ERV_MEDIUM_SCENE_ID" => Some("env-medium".to_string()),
+            "OFFICE_AUTOMATE_ERV_TURBO_SCENE_ID" => Some("env-turbo".to_string()),
+            "OFFICE_AUTOMATE_ERV_QUIET_NEGATIVE_PRESSURE_SCENE_ID" => {
+                Some("env-quiet-np".to_string())
+            }
+            "OFFICE_AUTOMATE_ERV_MEDIUM_NEGATIVE_PRESSURE_SCENE_ID" => {
+                Some("env-medium-np".to_string())
+            }
+            "OFFICE_AUTOMATE_ERV_TURBO_NEGATIVE_PRESSURE_SCENE_ID" => {
+                Some("env-turbo-np".to_string())
+            }
+            _ => None,
+        })
+        .expect("load config");
+
+        assert!(
+            config.erv.scene_configured(),
+            "an env-only scene deployment could not be configured"
+        );
+        assert_eq!(config.erv.smart_life_home_id(), Some("env-home"));
+        assert_eq!(config.erv.off_scene_id.as_deref(), Some("env-off"));
+        assert_eq!(config.erv.quiet_scene_id.as_deref(), Some("env-quiet"));
+        assert_eq!(config.erv.medium_scene_id.as_deref(), Some("env-medium"));
+        assert_eq!(config.erv.turbo_scene_id.as_deref(), Some("env-turbo"));
+        assert_eq!(
+            config.erv.quiet_negative_pressure_scene_id.as_deref(),
+            Some("env-quiet-np")
+        );
+        assert_eq!(
+            config.erv.medium_negative_pressure_scene_id.as_deref(),
+            Some("env-medium-np")
+        );
+        assert_eq!(
+            config.erv.turbo_negative_pressure_scene_id.as_deref(),
+            Some("env-turbo-np")
+        );
     }
 
     /// The intended defaults live in code, not only in the deployed YAML.

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -359,6 +359,18 @@ impl ErvConfig {
         self.control_mode == ErvControlMode::Scene && self.scene_configured()
     }
 
+    /// True when *some* transport could carry a write.
+    ///
+    /// Deliberately weaker than [`Self::is_configured`]: scene control needs
+    /// only a home id here, because which individual scene is missing is the
+    /// writer's diagnostic to make. Gating writes on the complete matrix would
+    /// reject a boot recovery that only needs the off scene, and would turn a
+    /// precise missing-scene error into a vague "config incomplete".
+    pub fn write_transport_configured(&self) -> bool {
+        self.local_tuya_configured()
+            || (self.device_type == "tuya" && self.smart_life_home_id().is_some())
+    }
+
     /// True when local reads are both wanted and possible.
     pub fn local_readback_active(&self) -> bool {
         self.local_readback_enabled && self.local_tuya_configured()

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -355,8 +355,13 @@ impl ErvConfig {
 
     /// True when writes go over Smart Life scenes, so no local command is ever
     /// issued in normal operation.
-    pub fn scene_control_active(&self) -> bool {
-        self.control_mode == ErvControlMode::Scene && self.scene_configured()
+    ///
+    /// This asks only what transport is *selected*, deliberately: an incomplete
+    /// scene matrix does not demote the deployment to local control, it fails
+    /// the affected writes. Anything that reasons about which transport carries
+    /// control must ask this, not whether the matrix happens to be complete.
+    pub fn scene_control_selected(&self) -> bool {
+        self.control_mode == ErvControlMode::Scene
     }
 
     /// True when *some* transport could carry a write.
@@ -1194,7 +1199,7 @@ smart_life:
         assert_eq!(config.erv.control_mode, ErvControlMode::Scene);
         assert!(config.erv.scene_configured());
         assert!(config.erv.local_tuya_configured());
-        assert!(config.erv.scene_control_active());
+        assert!(config.erv.scene_control_selected());
         assert!(config.erv.local_readback_active());
         assert!(config.erv.local_write_fallback_enabled);
         assert_eq!(config.erv.smart_life_home_id(), Some("8171319"));

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -834,8 +834,14 @@ impl AppConfig {
                 parse_bool_env("OFFICE_AUTOMATE_ERV_LOCAL_WRITE_FALLBACK_ENABLED", &enabled)?;
         }
 
-        if let Some(client_id) = env_lookup("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID") {
-            file_config.smart_life.client_id = client_id;
+        // Trim and ignore blanks, matching scripts/refresh-erv-key.py exactly.
+        // Secret and env injection routinely produce padded or empty values,
+        // and disagreeing about them here would have the script authorize with
+        // one app key while the server signed requests with another.
+        if let Some(client_id) = env_lookup("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID")
+            && !client_id.trim().is_empty()
+        {
+            file_config.smart_life.client_id = client_id.trim().to_string();
         }
 
         if let Some(ip) = env_lookup("OFFICE_AUTOMATE_BLINDS_IP") {
@@ -1256,6 +1262,34 @@ smart_life:
             config.erv.turbo_negative_pressure_scene_id.as_deref(),
             Some("env-turbo-np")
         );
+    }
+
+    /// The server and `scripts/refresh-erv-key.py` must resolve the client id
+    /// identically, including how they treat padded and blank env values --
+    /// disagreeing means one authorizes with a different app key than the
+    /// other signs with.
+    #[test]
+    fn smart_life_client_id_env_is_trimmed_and_blank_is_ignored() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_path = temp_dir.path().join("config.yaml");
+        fs::write(&config_path, "smart_life:\n  client_id: \"HA_from_yaml\"\n")
+            .expect("write config");
+
+        let load = |client_id: Option<&str>| {
+            AppConfig::load_with_env(&config_path, |key| match key {
+                "OFFICE_AUTOMATE_ROOT" => Some(temp_dir.path().display().to_string()),
+                "OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID" => client_id.map(str::to_string),
+                _ => None,
+            })
+            .expect("load config")
+            .smart_life
+            .client_id
+        };
+
+        assert_eq!(load(None), "HA_from_yaml");
+        assert_eq!(load(Some("  HA_from_env  ")), "HA_from_env");
+        assert_eq!(load(Some("   ")), "HA_from_yaml");
+        assert_eq!(load(Some("")), "HA_from_yaml");
     }
 
     /// The intended defaults live in code, not only in the deployed YAML.

--- a/rust/office-automate-server/src/config.rs
+++ b/rust/office-automate-server/src/config.rs
@@ -18,6 +18,7 @@ pub struct AppConfig {
     pub cloudflare_access: CloudflareAccessConfig,
     pub erv: ErvConfig,
     pub blinds: BlindsConfig,
+    pub smart_life: SmartLifeConfig,
     pub mitsubishi: MitsubishiConfig,
     pub thresholds: ThresholdsConfig,
     pub telemetry: TelemetryConfig,
@@ -285,6 +286,18 @@ impl Default for MitsubishiConfig {
     }
 }
 
+/// Which transport issues ERV writes. Reads are always local — the cloud
+/// cannot see the private speed data points at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ErvControlMode {
+    /// Smart Life tap-to-run scenes. No local command is ever issued.
+    #[default]
+    Scene,
+    /// Local Tuya commands, the pre-#154 behaviour.
+    Local,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ErvConfig {
@@ -298,17 +311,66 @@ pub struct ErvConfig {
     pub port: u16,
     pub status_timeout_seconds: u64,
     pub verify_delay_seconds: u64,
-    pub poll_interval_seconds: u64,
-    pub idle_poll_interval_seconds: u64,
+    pub smart_life_auth_file: Option<PathBuf>,
+    pub smart_life_home_id: Option<String>,
+    pub off_scene_id: Option<String>,
+    pub quiet_scene_id: Option<String>,
+    pub medium_scene_id: Option<String>,
+    pub turbo_scene_id: Option<String>,
+    pub quiet_negative_pressure_scene_id: Option<String>,
+    pub medium_negative_pressure_scene_id: Option<String>,
+    pub turbo_negative_pressure_scene_id: Option<String>,
+    /// Which transport issues writes.
+    pub control_mode: ErvControlMode,
+    /// Local read-after-write, the only view of the true supply/exhaust speeds.
+    pub local_readback_enabled: bool,
+    /// Automatic local write when a scene trigger fails and local is healthy.
+    pub local_write_fallback_enabled: bool,
 }
 
 impl ErvConfig {
+    /// True when *some* transport can control the ERV. Mirrors `BlindsConfig`.
     pub fn is_configured(&self) -> bool {
+        self.local_tuya_configured() || self.scene_configured()
+    }
+
+    pub fn local_tuya_configured(&self) -> bool {
         self.device_type == "tuya"
             && !self.ip.trim().is_empty()
             && !self.device_id.trim().is_empty()
             && !self.local_key.trim().is_empty()
     }
+
+    /// True when the full normal-pressure scene set is present. The
+    /// negative-pressure variants are resolved per write so a missing one fails
+    /// loudly instead of silently substituting the normal-pressure scene.
+    pub fn scene_configured(&self) -> bool {
+        self.device_type == "tuya"
+            && configured_value(self.smart_life_home_id.as_deref()).is_some()
+            && configured_value(self.off_scene_id.as_deref()).is_some()
+            && configured_value(self.quiet_scene_id.as_deref()).is_some()
+            && configured_value(self.medium_scene_id.as_deref()).is_some()
+            && configured_value(self.turbo_scene_id.as_deref()).is_some()
+    }
+
+    /// True when writes go over Smart Life scenes, so no local command is ever
+    /// issued in normal operation.
+    pub fn scene_control_active(&self) -> bool {
+        self.control_mode == ErvControlMode::Scene && self.scene_configured()
+    }
+
+    /// True when local reads are both wanted and possible.
+    pub fn local_readback_active(&self) -> bool {
+        self.local_readback_enabled && self.local_tuya_configured()
+    }
+
+    pub fn smart_life_home_id(&self) -> Option<&str> {
+        configured_value(self.smart_life_home_id.as_deref())
+    }
+}
+
+fn configured_value(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 impl Default for ErvConfig {
@@ -323,8 +385,35 @@ impl Default for ErvConfig {
             port: 6668,
             status_timeout_seconds: 5,
             verify_delay_seconds: 1,
-            poll_interval_seconds: 60,
-            idle_poll_interval_seconds: 300,
+            smart_life_auth_file: None,
+            smart_life_home_id: None,
+            off_scene_id: None,
+            quiet_scene_id: None,
+            medium_scene_id: None,
+            turbo_scene_id: None,
+            quiet_negative_pressure_scene_id: None,
+            medium_negative_pressure_scene_id: None,
+            turbo_negative_pressure_scene_id: None,
+            control_mode: ErvControlMode::Scene,
+            local_readback_enabled: true,
+            local_write_fallback_enabled: true,
+        }
+    }
+}
+
+/// Credentials shared by every Smart Life device (blinds, ERV scenes).
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SmartLifeConfig {
+    /// Shared Home Assistant Tuya integration identifier. Not a secret, but it
+    /// has changed before and should not need a rebuild to track.
+    pub client_id: String,
+}
+
+impl Default for SmartLifeConfig {
+    fn default() -> Self {
+        Self {
+            client_id: crate::smart_life::DEFAULT_CLIENT_ID.to_string(),
         }
     }
 }
@@ -567,6 +656,7 @@ struct FileConfig {
     cloudflare_access: CloudflareAccessConfig,
     erv: ErvConfig,
     blinds: BlindsConfig,
+    smart_life: SmartLifeConfig,
     mitsubishi: MitsubishiConfig,
     thresholds: ThresholdsConfig,
     telemetry: TelemetryConfig,
@@ -668,16 +758,30 @@ impl AppConfig {
                 parse_bool_env("OFFICE_AUTOMATE_ERV_ACTIVE_CONTROL_ENABLED", &enabled)?;
         }
 
-        if let Some(seconds) = env_lookup("OFFICE_AUTOMATE_ERV_POLL_INTERVAL_SECONDS") {
-            file_config.erv.poll_interval_seconds = seconds.parse().with_context(|| {
-                format!("invalid OFFICE_AUTOMATE_ERV_POLL_INTERVAL_SECONDS value {seconds:?}")
-            })?;
+        if let Some(path) = env_lookup("OFFICE_AUTOMATE_ERV_SMART_LIFE_AUTH_FILE") {
+            file_config.erv.smart_life_auth_file = Some(PathBuf::from(path));
         }
 
-        if let Some(seconds) = env_lookup("OFFICE_AUTOMATE_ERV_IDLE_POLL_INTERVAL_SECONDS") {
-            file_config.erv.idle_poll_interval_seconds = seconds.parse().with_context(|| {
-                format!("invalid OFFICE_AUTOMATE_ERV_IDLE_POLL_INTERVAL_SECONDS value {seconds:?}")
-            })?;
+        if let Some(home_id) = env_lookup("OFFICE_AUTOMATE_ERV_SMART_LIFE_HOME_ID") {
+            file_config.erv.smart_life_home_id = Some(home_id);
+        }
+
+        if let Some(mode) = env_lookup("OFFICE_AUTOMATE_ERV_CONTROL_MODE") {
+            file_config.erv.control_mode = parse_erv_control_mode(&mode)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_ERV_LOCAL_READBACK_ENABLED") {
+            file_config.erv.local_readback_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_ERV_LOCAL_READBACK_ENABLED", &enabled)?;
+        }
+
+        if let Some(enabled) = env_lookup("OFFICE_AUTOMATE_ERV_LOCAL_WRITE_FALLBACK_ENABLED") {
+            file_config.erv.local_write_fallback_enabled =
+                parse_bool_env("OFFICE_AUTOMATE_ERV_LOCAL_WRITE_FALLBACK_ENABLED", &enabled)?;
+        }
+
+        if let Some(client_id) = env_lookup("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID") {
+            file_config.smart_life.client_id = client_id;
         }
 
         if let Some(ip) = env_lookup("OFFICE_AUTOMATE_BLINDS_IP") {
@@ -910,6 +1014,10 @@ impl AppConfig {
             .blinds
             .smart_life_auth_file
             .map(|path| expand_home_relative_path(path, home_dir.as_deref()));
+        file_config.erv.smart_life_auth_file = file_config
+            .erv
+            .smart_life_auth_file
+            .map(|path| expand_home_relative_path(path, home_dir.as_deref()));
 
         let runtime = RuntimeConfig {
             frontend_dist: root.join("frontend").join("dist"),
@@ -940,11 +1048,22 @@ impl AppConfig {
             cloudflare_access: file_config.cloudflare_access,
             erv: file_config.erv,
             blinds: file_config.blinds,
+            smart_life: file_config.smart_life,
             mitsubishi: file_config.mitsubishi,
             thresholds: file_config.thresholds,
             telemetry: file_config.telemetry,
             runtime,
         })
+    }
+}
+
+fn parse_erv_control_mode(value: &str) -> Result<ErvControlMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "scene" => Ok(ErvControlMode::Scene),
+        "local" => Ok(ErvControlMode::Local),
+        _ => anyhow::bail!(
+            "invalid OFFICE_AUTOMATE_ERV_CONTROL_MODE value {value:?}; expected scene/local"
+        ),
     }
 }
 
@@ -983,6 +1102,71 @@ mod tests {
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 8080);
         assert!(config.admin_emails.is_empty());
+    }
+
+    /// Parses the shape the deployed `config.yaml` uses, so a schema change
+    /// that would silently fall back to defaults fails here instead.
+    #[test]
+    fn loads_scene_control_erv_config() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let config_path = temp_dir.path().join("config.yaml");
+        fs::write(
+            &config_path,
+            r#"
+erv:
+  type: "tuya"
+  active_control_enabled: true
+  device_id: "erv-device"
+  local_key: "erv-key"
+  ip: "192.0.2.59"
+  smart_life_home_id: "8171319"
+  off_scene_id: "off-scene"
+  quiet_scene_id: "quiet-scene"
+  medium_scene_id: "medium-scene"
+  turbo_scene_id: "turbo-scene"
+  quiet_negative_pressure_scene_id: "quiet-np-scene"
+  medium_negative_pressure_scene_id: "medium-np-scene"
+  turbo_negative_pressure_scene_id: "turbo-np-scene"
+  control_mode: "scene"
+  local_readback_enabled: true
+  local_write_fallback_enabled: true
+smart_life:
+  client_id: "HA_custom_client"
+"#,
+        )
+        .expect("write config");
+
+        let config = AppConfig::load_with_env(&config_path, |key| match key {
+            "OFFICE_AUTOMATE_ROOT" => Some(temp_dir.path().display().to_string()),
+            _ => None,
+        })
+        .expect("load config");
+
+        assert_eq!(config.erv.control_mode, ErvControlMode::Scene);
+        assert!(config.erv.scene_configured());
+        assert!(config.erv.local_tuya_configured());
+        assert!(config.erv.scene_control_active());
+        assert!(config.erv.local_readback_active());
+        assert!(config.erv.local_write_fallback_enabled);
+        assert_eq!(config.erv.smart_life_home_id(), Some("8171319"));
+        assert_eq!(config.smart_life.client_id, "HA_custom_client");
+    }
+
+    /// The intended defaults live in code, not only in the deployed YAML.
+    #[test]
+    fn erv_defaults_to_scene_control_with_local_readback_and_fallback() {
+        let config = ErvConfig::default();
+
+        assert_eq!(config.control_mode, ErvControlMode::Scene);
+        assert!(config.local_readback_enabled);
+        assert!(config.local_write_fallback_enabled);
+        // No scenes configured yet, so nothing claims to be able to control it.
+        assert!(!config.scene_configured());
+        assert!(!config.is_configured());
+        assert_eq!(
+            SmartLifeConfig::default().client_id,
+            crate::smart_life::DEFAULT_CLIENT_ID
+        );
     }
 
     #[test]
@@ -1146,8 +1330,6 @@ thresholds:
         assert!(config.erv.active_control_enabled);
         assert_eq!(config.erv.version, "3.4");
         assert_eq!(config.erv.port, 6668);
-        assert_eq!(config.erv.poll_interval_seconds, 60);
-        assert_eq!(config.erv.idle_poll_interval_seconds, 300);
         assert!(config.erv.is_configured());
         assert_eq!(config.runtime.mqtt_host, "rust-broker");
         assert_eq!(config.runtime.mqtt_port, 2883);

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1887,6 +1887,16 @@ pub async fn run_erv_boot_read<W>(config: &AppConfig, erv: &ErvState, writer: &W
 where
     W: ErvSpeedWriter + ?Sized,
 {
+    // Say so at startup rather than at the first ventilation request. This is
+    // the moment after someone re-arms negative pressure with a date change,
+    // which is exactly when a scene id nobody has looked at in months starts
+    // carrying every command.
+    if config.erv.scene_control_selected()
+        && let Err(error) = check_erv_scene_config(config)
+    {
+        tracing::warn!("ERV scene configuration is incomplete: {error:#}");
+    }
+
     if config.erv.local_readback_active() {
         match erv.smoke_status_with(&config.erv, writer).await {
             Ok(status) => {
@@ -1969,24 +1979,31 @@ pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
     Arc::new(writer)
 }
 
-/// Read-only check of the Smart Life scene transport.
+/// Check that every preset this deployment will actually command has a scene
+/// id configured. Returns how many were checked.
 ///
-/// Scene ids being non-empty strings proves nothing: the auth cache can be
-/// missing, unreadable, or holding a dead refresh token, and every ERV command
-/// would fail. This exercises the credentials without commanding the device.
-pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
+/// Pure configuration, no network. A selected transport that cannot deliver is
+/// otherwise invisible until ventilation is requested, and that matters most
+/// for the negative-pressure scenes: re-arming that mode is a one-line date
+/// change made months after anyone last looked at the scene list, and from
+/// that moment they are the only scenes automation uses.
+///
+/// Whether a configured id still *exists* in Smart Life, and whether the
+/// credentials work, needs a live call — see the follow-up issue.
+pub fn check_erv_scene_config(config: &AppConfig) -> Result<usize> {
     if !config.erv.scene_control_selected() {
         bail!("ERV scene control is not the selected transport");
     }
 
-    // Check the matrix this deployment will actually command, not the one that
-    // happens to be filled in. An incomplete set does not demote anything to
-    // local control -- the affected writes just fail -- so validation has to
-    // reject it here rather than skip itself.
-    let unconfigured = required_scene_presets(config)
-        .into_iter()
+    // The matrix this deployment will command, not the one that happens to be
+    // filled in. An incomplete set does not demote anything to local control --
+    // the affected writes just fail -- so this has to reject it rather than
+    // skip itself.
+    let required = required_scene_presets(config);
+    let unconfigured = required
+        .iter()
         .filter(|(_, scene_id)| scene_id.is_none())
-        .map(|(label, _)| label)
+        .map(|(label, _)| *label)
         .collect::<Vec<_>>();
     if !unconfigured.is_empty() {
         bail!(
@@ -1995,58 +2012,7 @@ pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
         );
     }
 
-    let client = SmartLifeClient::new(
-        config.smart_life.client_id.clone(),
-        auth_file_or_default(config.erv.smart_life_auth_file.as_ref()),
-    );
-    let endpoint = client
-        .check_credentials()
-        .await
-        .context("Smart Life credentials are not usable")?;
-
-    // Every configured scene id must actually exist. A stale, deleted, or
-    // mistyped id otherwise passes validation and fails at the first
-    // ventilation request. Existence only -- what a scene *does* cannot be read
-    // back, which is why the ids are hand-built and verified physically.
-    let home_id = config
-        .erv
-        .smart_life_home_id()
-        .ok_or(SceneConfigError::MissingHomeId)?;
-    let present = client
-        .list_scene_ids(home_id)
-        .await
-        .context("Smart Life scene list failed")?;
-    let missing = configured_scene_ids(&config.erv)
-        .into_iter()
-        .filter(|(_, scene_id)| !present.iter().any(|found| found == scene_id))
-        .map(|(label, scene_id)| format!("{label}={scene_id}"))
-        .collect::<Vec<_>>();
-    if !missing.is_empty() {
-        bail!(
-            "configured ERV scene ids are not present in Smart Life home {home_id}: {}",
-            missing.join(", ")
-        );
-    }
-    let scene_count = configured_scene_ids(&config.erv).len();
-
-    let device_id = config.erv.device_id.trim();
-    if device_id.is_empty() {
-        return Ok(format!(
-            "Smart Life auth OK at {endpoint}; {scene_count} scene ids present"
-        ));
-    }
-
-    let status = client
-        .device_status(device_id)
-        .await
-        .context("Smart Life device read failed")?;
-    let power = status_code_value(&status, "switch")
-        .and_then(value_as_bool)
-        .map(|power| power.to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-    Ok(format!(
-        "Smart Life auth OK at {endpoint}; {scene_count} scene ids present; switch={power}"
-    ))
+    Ok(required.len())
 }
 
 fn configured_scene_id(value: &Option<String>) -> Option<&str> {
@@ -2095,37 +2061,6 @@ fn required_scene_presets(config: &AppConfig) -> Vec<(&'static str, Option<&str>
         ]);
     }
     required
-}
-
-/// Every scene id the configuration actually sets, labelled by preset.
-fn configured_scene_ids(config: &ErvConfig) -> Vec<(&'static str, &str)> {
-    [
-        ("off", &config.off_scene_id),
-        ("quiet", &config.quiet_scene_id),
-        ("medium", &config.medium_scene_id),
-        ("turbo", &config.turbo_scene_id),
-        (
-            "quiet_negative_pressure",
-            &config.quiet_negative_pressure_scene_id,
-        ),
-        (
-            "medium_negative_pressure",
-            &config.medium_negative_pressure_scene_id,
-        ),
-        (
-            "turbo_negative_pressure",
-            &config.turbo_negative_pressure_scene_id,
-        ),
-    ]
-    .into_iter()
-    .filter_map(|(label, configured)| {
-        configured
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(|scene_id| (label, scene_id))
-    })
-    .collect()
 }
 
 pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -34,6 +34,7 @@ const LOCAL_ACTIVITY_HISTORY_LIMIT: usize = 32;
 const LOCAL_FAILURE_RCA_THRESHOLD: u64 = 3;
 const LOCAL_WRITE_BURST_WINDOW_SECONDS: f64 = 5.0 * 60.0;
 const LOCAL_WRITE_BURST_ATTEMPT_LIMIT: usize = 3;
+const BOOT_RECOVERY_REASON: &str = "boot_unknown_state";
 pub const ERV_MANUAL_OVERRIDE_SECONDS: i64 = 30 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1421,7 +1422,9 @@ impl ErvState {
             // missing-scene state. A successful read says nothing about
             // whether the transport recovered or the scene hole was filled.
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
-            inner.last_speed_changed_at = Some(unix_timestamp_now());
+            if !dwell_exempt(reason) {
+                inner.last_speed_changed_at = Some(unix_timestamp_now());
+            }
             inner.consecutive_scene_failures = 0;
             inner.next_write_retry_at = None;
 
@@ -1661,6 +1664,14 @@ fn write_burst_guard_exempt(reason: &str) -> bool {
     matches!(reason, "manual_override")
 }
 
+/// Dwell damps oscillation between *policy* speed decisions. Boot recovery is
+/// not one: it forces a known state the policy never asked for, so charging its
+/// timestamp to the dwell budget would suppress the first real decision for the
+/// whole window. The burst guard still bounds the device-facing write rate.
+fn dwell_exempt(reason: &str) -> bool {
+    matches!(reason, BOOT_RECOVERY_REASON)
+}
+
 fn push_local_activity_locked(inner: &mut ErvInner, activity: ErvLocalActivity) {
     while inner.recent_local_activity.len() >= LOCAL_ACTIVITY_HISTORY_LIMIT {
         inner.recent_local_activity.pop_front();
@@ -1804,7 +1815,7 @@ where
             writer,
             ErvFanSpeed::Off,
             false,
-            "boot_unknown_state",
+            BOOT_RECOVERY_REASON,
             None,
         )
         .await
@@ -3317,6 +3328,39 @@ mod tests {
             local.write_speeds().is_empty(),
             "a local path that just failed its read must not be used as a fallback"
         );
+    }
+
+    /// Boot recovery forces a state the policy never asked for, so it must not
+    /// spend the dwell budget. Otherwise the first real decision after startup
+    /// -- an AWAY ventilation command, or a PRESENT air-quality response -- is
+    /// suppressed for the whole dwell window while the ERV sits off.
+    #[tokio::test]
+    async fn boot_recovery_does_not_start_the_policy_dwell_timer() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path.clone());
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Connection reset by peer"
+            ))])),
+            None,
+        );
+
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
+
+        assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
+        assert!(
+            state.snapshot().last_speed_changed_at.is_none(),
+            "boot recovery charged its forced off to the dwell budget"
+        );
+
+        // It is still a real action and still logged as one.
+        let history = db::read_history(&database_path, 1, 20).expect("history");
+        assert_eq!(history.climate_actions[0]["action"], "off");
+        assert_eq!(history.climate_actions[0]["reason"], BOOT_RECOVERY_REASON);
     }
 
     /// Boot recovery must never overwrite a decision that has already landed.

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -18,7 +18,7 @@ use tokio::{
 };
 
 use crate::{
-    config::{AppConfig, ErvConfig, ErvControlMode},
+    config::{AppConfig, ErvConfig},
     db,
     smart_life::{SmartLifeClient, auth_file_or_default, status_code_value},
     status::{AppNotification, ErvControlStatus, ErvStatusSource, Status},
@@ -870,7 +870,7 @@ impl ErvState {
         // In local control mode it is still a gate, because there the local key
         // *is* the control path. Writing through credentials a read just
         // rejected is the command pattern that produces the lockout.
-        let local_control = config.control_mode == ErvControlMode::Local;
+        let local_control = !config.scene_control_selected();
         if self.pre_write_read_allowed(config) {
             match self.smoke_status_with_locked(config, writer).await {
                 Ok(status) if device_status_matches_target(&status, speed, negative_pressure) => {
@@ -1718,7 +1718,7 @@ impl ErvState {
                     inner.control.local_key_invalid_since = Some(now.clone());
                     inner.notification = Some(invalid_key_notification(
                         &now,
-                        config.scene_control_active(),
+                        config.scene_control_selected(),
                     ));
                     invalid_event = Some(json!({
                         "type": "erv_local_key_invalid",
@@ -1910,7 +1910,7 @@ where
     // scene is the one this needs, and a hole elsewhere in the matrix is no
     // reason to leave a possibly-running ERV in an unknown state. A missing
     // off scene fails loudly on its own.
-    if config.erv.control_mode != ErvControlMode::Scene || !config.erv.active_control_enabled {
+    if !config.erv.scene_control_selected() || !config.erv.active_control_enabled {
         return;
     }
 
@@ -1948,7 +1948,7 @@ where
 /// per write with a missing-scene diagnostic, never quietly demote the whole
 /// deployment to the local transport this change exists to stop using.
 pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
-    if config.erv.control_mode == ErvControlMode::Local {
+    if !config.erv.scene_control_selected() {
         return Arc::new(RustuyaErvSpeedWriter);
     }
 
@@ -1975,8 +1975,24 @@ pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
 /// missing, unreadable, or holding a dead refresh token, and every ERV command
 /// would fail. This exercises the credentials without commanding the device.
 pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
-    if !config.erv.scene_control_active() {
-        bail!("ERV scene control is not configured");
+    if !config.erv.scene_control_selected() {
+        bail!("ERV scene control is not the selected transport");
+    }
+
+    // Check the matrix this deployment will actually command, not the one that
+    // happens to be filled in. An incomplete set does not demote anything to
+    // local control -- the affected writes just fail -- so validation has to
+    // reject it here rather than skip itself.
+    let unconfigured = required_scene_presets(config)
+        .into_iter()
+        .filter(|(_, scene_id)| scene_id.is_none())
+        .map(|(label, _)| label)
+        .collect::<Vec<_>>();
+    if !unconfigured.is_empty() {
+        bail!(
+            "ERV scene control is selected but these scene ids are not configured: {}",
+            unconfigured.join(", ")
+        );
     }
 
     let client = SmartLifeClient::new(
@@ -2031,6 +2047,54 @@ pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
     Ok(format!(
         "Smart Life auth OK at {endpoint}; {scene_count} scene ids present; switch={power}"
     ))
+}
+
+fn configured_scene_id(value: &Option<String>) -> Option<&str> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+/// True when automation will pass `negative_pressure = true` on every non-off
+/// command, which makes those scenes mandatory rather than optional.
+fn negative_pressure_armed(config: &AppConfig) -> bool {
+    config.thresholds.post_renovation_negative_pressure
+        && config
+            .thresholds
+            .post_renovation_active_at(unix_timestamp_now())
+}
+
+/// The presets this deployment will actually command, and whether each has a
+/// scene id. The negative-pressure variants are required only while that mode
+/// is armed -- but while it *is* armed they are the only ones automation uses,
+/// so treating them as optional would let validation pass a configuration in
+/// which every non-off command fails.
+fn required_scene_presets(config: &AppConfig) -> Vec<(&'static str, Option<&str>)> {
+    let erv = &config.erv;
+    let mut required = vec![
+        ("off", configured_scene_id(&erv.off_scene_id)),
+        ("quiet", configured_scene_id(&erv.quiet_scene_id)),
+        ("medium", configured_scene_id(&erv.medium_scene_id)),
+        ("turbo", configured_scene_id(&erv.turbo_scene_id)),
+    ];
+    if negative_pressure_armed(config) {
+        required.extend([
+            (
+                "quiet_negative_pressure",
+                configured_scene_id(&erv.quiet_negative_pressure_scene_id),
+            ),
+            (
+                "medium_negative_pressure",
+                configured_scene_id(&erv.medium_negative_pressure_scene_id),
+            ),
+            (
+                "turbo_negative_pressure",
+                configured_scene_id(&erv.turbo_negative_pressure_scene_id),
+            ),
+        ]);
+    }
+    required
 }
 
 /// Every scene id the configuration actually sets, labelled by preset.
@@ -2276,10 +2340,10 @@ fn looks_like_tuya_error(message: &str) -> bool {
     message.contains("\"Error\"") || message.contains("\"Err\"") || message.contains("Error:")
 }
 
-fn invalid_key_notification(created_at: &str, scene_control_active: bool) -> AppNotification {
+fn invalid_key_notification(created_at: &str, scene_control_selected: bool) -> AppNotification {
     // With scene control this is a degraded-observability notice, not an
     // outage: writes never touch the local key.
-    let (severity, title, message) = if scene_control_active {
+    let (severity, title, message) = if scene_control_selected {
         (
             "warning",
             "ERV speed readback degraded",
@@ -2365,8 +2429,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            AppConfig, ErvConfig, MitsubishiConfig, OrchestratorConfig, QingpingConfig,
-            RuntimeConfig, ThresholdsConfig, YoLinkConfig,
+            AppConfig, ErvConfig, ErvControlMode, MitsubishiConfig, OrchestratorConfig,
+            QingpingConfig, RuntimeConfig, ThresholdsConfig, YoLinkConfig,
         },
         db,
         status::Status,
@@ -4316,6 +4380,41 @@ mod tests {
                 .last_error
                 .as_deref()
                 .is_some_and(|error| error.starts_with("Scene trigger failed:"))
+        );
+    }
+
+    /// While negative pressure is armed, those are the only scenes automation
+    /// uses, so treating them as optional would let validation pass a
+    /// configuration in which every non-off command fails.
+    #[test]
+    fn armed_negative_pressure_makes_those_scenes_required() {
+        let normal = app_config(scene_config());
+        assert!(
+            required_scene_presets(&normal)
+                .iter()
+                .all(|(label, _)| !label.contains("negative_pressure")),
+            "negative-pressure scenes are not required while the mode is dormant"
+        );
+
+        let mut armed = app_config(scene_config());
+        armed.thresholds.post_renovation_enabled = true;
+        armed.thresholds.post_renovation_negative_pressure = true;
+        armed.thresholds.post_renovation_expires_at = Some("2099-01-01T00:00:00Z".to_string());
+        assert!(negative_pressure_armed(&armed));
+
+        let missing = required_scene_presets(&armed)
+            .into_iter()
+            .filter(|(_, scene_id)| scene_id.is_none())
+            .map(|(label, _)| label)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            missing,
+            vec![
+                "quiet_negative_pressure",
+                "medium_negative_pressure",
+                "turbo_negative_pressure"
+            ],
+            "an armed negative-pressure deployment must require its scenes"
         );
     }
 

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1,10 +1,11 @@
 use std::{
     collections::VecDeque,
+    fmt,
     future::Future,
     path::PathBuf,
     pin::Pin,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -13,14 +14,14 @@ use chrono::Local;
 use serde_json::{Map, Value, json};
 use tokio::{
     sync::{Mutex as AsyncMutex, broadcast},
-    task::JoinHandle,
     time,
 };
 
 use crate::{
     config::{AppConfig, ErvConfig},
     db,
-    status::{AppNotification, ErvControlStatus, Status},
+    smart_life::{SmartLifeClient, auth_file_or_default, status_code_value},
+    status::{AppNotification, ErvControlStatus, ErvStatusSource, Status},
 };
 
 const DP_POWER: &str = "1";
@@ -100,6 +101,480 @@ pub trait ErvSpeedWriter: Send + Sync {
         speed: ErvFanSpeed,
         negative_pressure: bool,
     ) -> BoxFutureResult<'a, ErvDeviceStatus>;
+
+    /// Which transport carried the most recent `set_speed`, and how well the
+    /// returned status was confirmed. Defaults to a local command verified by a
+    /// local read, which is what every writer did before scene control existed.
+    fn last_write_report(&self) -> ErvWriteReport {
+        ErvWriteReport::default()
+    }
+}
+
+/// Which transport issued a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ErvTransport {
+    #[default]
+    Local,
+    Scene,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErvWriteReport {
+    pub transport: ErvTransport,
+    pub source: ErvStatusSource,
+}
+
+impl Default for ErvWriteReport {
+    fn default() -> Self {
+        Self {
+            transport: ErvTransport::Local,
+            source: ErvStatusSource::Local,
+        }
+    }
+}
+
+/// The cloud half of ERV control: triggering tap-to-run scenes, and reading the
+/// one status code the sharing API exposes for this device.
+pub trait ErvCloudClient: Send + Sync {
+    fn trigger_scene<'a>(&'a self, home_id: &'a str, scene_id: &'a str) -> BoxFutureResult<'a, ()>;
+
+    /// The device's `switch` bit. `None` when the device reports no `switch`
+    /// code at all. Speed is never available here — the speed data points are
+    /// private and the sharing API hides them.
+    fn read_power<'a>(&'a self, device_id: &'a str) -> BoxFutureResult<'a, Option<bool>>;
+}
+
+pub struct SmartLifeErvCloud {
+    client: SmartLifeClient,
+}
+
+impl SmartLifeErvCloud {
+    pub fn new(client_id: impl Into<String>, config: &ErvConfig) -> Self {
+        Self {
+            client: SmartLifeClient::new(
+                client_id,
+                auth_file_or_default(config.smart_life_auth_file.as_ref()),
+            ),
+        }
+    }
+}
+
+impl ErvCloudClient for SmartLifeErvCloud {
+    fn trigger_scene<'a>(&'a self, home_id: &'a str, scene_id: &'a str) -> BoxFutureResult<'a, ()> {
+        Box::pin(async move { self.client.trigger_scene(home_id, scene_id).await })
+    }
+
+    fn read_power<'a>(&'a self, device_id: &'a str) -> BoxFutureResult<'a, Option<bool>> {
+        Box::pin(async move {
+            let status = self.client.device_status(device_id).await?;
+            Ok(status_code_value(&status, "switch").and_then(value_as_bool))
+        })
+    }
+}
+
+/// A `(speed, pressure)` pair that resolved to no configured scene. Surfaced
+/// rather than silently substituted: a system that reports a mode it is not
+/// delivering is worse than one that reports an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingSceneError {
+    pub preset: String,
+}
+
+impl fmt::Display for MissingSceneError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "ERV Smart Life scene id for {} is not configured",
+            self.preset
+        )
+    }
+}
+
+impl std::error::Error for MissingSceneError {}
+
+fn scene_preset_label(speed: ErvFanSpeed, negative_pressure: bool) -> String {
+    if speed == ErvFanSpeed::Off || !negative_pressure {
+        speed.as_str().to_string()
+    } else {
+        format!("{} (negative pressure)", speed.as_str())
+    }
+}
+
+fn scene_id_for(
+    config: &ErvConfig,
+    speed: ErvFanSpeed,
+    negative_pressure: bool,
+) -> Result<&str, MissingSceneError> {
+    let configured = match (speed, negative_pressure) {
+        (ErvFanSpeed::Off, _) => &config.off_scene_id,
+        (ErvFanSpeed::Quiet, false) => &config.quiet_scene_id,
+        (ErvFanSpeed::Medium, false) => &config.medium_scene_id,
+        (ErvFanSpeed::Turbo, false) => &config.turbo_scene_id,
+        (ErvFanSpeed::Quiet, true) => &config.quiet_negative_pressure_scene_id,
+        (ErvFanSpeed::Medium, true) => &config.medium_negative_pressure_scene_id,
+        (ErvFanSpeed::Turbo, true) => &config.turbo_negative_pressure_scene_id,
+    };
+
+    configured
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| MissingSceneError {
+            preset: scene_preset_label(speed, negative_pressure),
+        })
+}
+
+/// The state a command asks for, used when nothing could observe the result.
+fn assumed_status(speed: ErvFanSpeed, negative_pressure: bool) -> ErvDeviceStatus {
+    let power = speed != ErvFanSpeed::Off;
+    let (supply_speed, exhaust_speed) = match speed.speed_preset(negative_pressure) {
+        Some((supply, exhaust)) => (Some(supply), Some(exhaust)),
+        None => (None, None),
+    };
+    let mut dps = Map::new();
+    dps.insert(DP_POWER.to_string(), Value::Bool(power));
+    if let (Some(supply), Some(exhaust)) = (supply_speed, exhaust_speed) {
+        dps.insert(DP_SUPPLY_SPEED.to_string(), json!(supply));
+        dps.insert(DP_EXHAUST_SPEED.to_string(), json!(exhaust));
+    }
+
+    ErvDeviceStatus {
+        power,
+        fan_speed: Some(speed),
+        supply_speed,
+        exhaust_speed,
+        raw_dps: Value::Object(dps),
+    }
+}
+
+/// Writes through Smart Life tap-to-run scenes. Issues no local command ever —
+/// local commands are the documented cause of the Err 914 lockout.
+pub struct SceneErvSpeedWriter {
+    cloud: Arc<dyn ErvCloudClient>,
+}
+
+impl SceneErvSpeedWriter {
+    pub fn new(cloud: Arc<dyn ErvCloudClient>) -> Self {
+        Self { cloud }
+    }
+}
+
+impl ErvSpeedWriter for SceneErvSpeedWriter {
+    fn smoke_status<'a>(&'a self, _config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            bail!("ERV scene control cannot read status; the cloud does not expose the speed DPs")
+        })
+    }
+
+    fn set_speed<'a>(
+        &'a self,
+        config: &'a ErvConfig,
+        speed: ErvFanSpeed,
+        negative_pressure: bool,
+    ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            let home_id = config
+                .smart_life_home_id()
+                .ok_or_else(|| anyhow!("ERV Smart Life home id is missing"))?;
+            let preset = scene_preset_label(speed, negative_pressure);
+            let scene_id = scene_id_for(config, speed, negative_pressure)?;
+
+            self.cloud
+                .trigger_scene(home_id, scene_id)
+                .await
+                .with_context(|| format!("failed to trigger ERV {preset} scene"))?;
+
+            Ok(assumed_status(speed, negative_pressure))
+        })
+    }
+
+    fn last_write_report(&self) -> ErvWriteReport {
+        ErvWriteReport {
+            transport: ErvTransport::Scene,
+            source: ErvStatusSource::Assumed,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SplitWriterState {
+    report: ErvWriteReport,
+    last_known_power: Option<bool>,
+    consecutive_read_failures: u64,
+    read_retry_at: Option<f64>,
+}
+
+/// Splits the two transports by direction: writes go out over `writer` (the
+/// scene path by default), reads come back over `reader` (local Tuya, the only
+/// view of the speed DPs).
+pub struct SplitErvWriter {
+    writer: Arc<dyn ErvSpeedWriter>,
+    reader: Arc<dyn ErvStatusReader>,
+    fallback: Option<Arc<dyn ErvSpeedWriter>>,
+    cloud: Option<Arc<dyn ErvCloudClient>>,
+    state: Mutex<SplitWriterState>,
+}
+
+impl SplitErvWriter {
+    pub fn new(writer: Arc<dyn ErvSpeedWriter>, reader: Arc<dyn ErvStatusReader>) -> Self {
+        Self {
+            writer,
+            reader,
+            fallback: None,
+            cloud: None,
+            state: Mutex::new(SplitWriterState::default()),
+        }
+    }
+
+    /// The local writer used when a scene trigger fails and local is healthy.
+    pub fn with_local_write_fallback(mut self, fallback: Arc<dyn ErvSpeedWriter>) -> Self {
+        self.fallback = Some(fallback);
+        self
+    }
+
+    /// The cloud client used to confirm power transitions when local reads are
+    /// unavailable.
+    pub fn with_cloud_verifier(mut self, cloud: Arc<dyn ErvCloudClient>) -> Self {
+        self.cloud = Some(cloud);
+        self
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, SplitWriterState> {
+        self.state.lock().expect("ERV split writer lock poisoned")
+    }
+
+    /// Local reads back off after failures so a dead local key costs one slow
+    /// read every few minutes instead of one per write.
+    fn local_read_allowed(&self, config: &ErvConfig) -> bool {
+        if !config.local_readback_active() {
+            return false;
+        }
+        self.state()
+            .read_retry_at
+            .is_none_or(|retry_at| unix_timestamp_now() >= retry_at)
+    }
+
+    fn record_read_outcome(&self, succeeded: bool) {
+        let mut state = self.state();
+        if succeeded {
+            state.consecutive_read_failures = 0;
+            state.read_retry_at = None;
+            return;
+        }
+        state.consecutive_read_failures = state.consecutive_read_failures.saturating_add(1);
+        state.read_retry_at = Some(
+            unix_timestamp_now()
+                + local_failure_retry_delay_seconds(state.consecutive_read_failures),
+        );
+    }
+
+    fn finish(&self, report: ErvWriteReport, status: Option<&ErvDeviceStatus>) {
+        let mut state = self.state();
+        state.report = report;
+        if let Some(status) = status {
+            state.last_known_power = Some(status.power);
+        }
+    }
+
+    /// A power transition is the only change the cloud's `switch` bit can
+    /// confirm; on a speed-only change it reads `true` before and after.
+    fn is_power_transition(&self, speed: ErvFanSpeed) -> bool {
+        self.state()
+            .last_known_power
+            .is_none_or(|power| power != (speed != ErvFanSpeed::Off))
+    }
+
+    async fn read_local(&self, config: &ErvConfig) -> Result<ErvDeviceStatus> {
+        let result = self.reader.read_status(config).await;
+        self.record_read_outcome(result.is_ok());
+        if let Ok(status) = &result {
+            self.state().last_known_power = Some(status.power);
+        }
+        result
+    }
+
+    async fn write_fallback(
+        &self,
+        config: &ErvConfig,
+        speed: ErvFanSpeed,
+        negative_pressure: bool,
+    ) -> Option<Result<ErvDeviceStatus>> {
+        let fallback = self.fallback.as_ref()?;
+        if !config.local_write_fallback_enabled || !config.local_tuya_configured() {
+            return None;
+        }
+        // "Healthy" is the same signal the readback path uses: a local key that
+        // has been failing is not going to accept a command either.
+        if self
+            .state()
+            .read_retry_at
+            .is_some_and(|retry_at| unix_timestamp_now() < retry_at)
+        {
+            return None;
+        }
+        Some(fallback.set_speed(config, speed, negative_pressure).await)
+    }
+
+    async fn verify_locally(
+        &self,
+        config: &ErvConfig,
+        speed: ErvFanSpeed,
+        negative_pressure: bool,
+    ) -> Option<ErvDeviceStatus> {
+        if !self.local_read_allowed(config) {
+            return None;
+        }
+
+        match self.read_local(config).await {
+            Ok(status) => {
+                // A mismatch is real information, not a reason to fail the
+                // write: report what the device says and let policy re-decide.
+                if let Err(error) = verify_speed(speed, &status, negative_pressure) {
+                    tracing::warn!("ERV scene write did not verify: {error:#}");
+                }
+                Some(status)
+            }
+            Err(error) => {
+                tracing::warn!("ERV local readback after write failed: {error:#}");
+                None
+            }
+        }
+    }
+
+    async fn verify_via_cloud(
+        &self,
+        config: &ErvConfig,
+        speed: ErvFanSpeed,
+        negative_pressure: bool,
+    ) -> Option<ErvDeviceStatus> {
+        let cloud = self.cloud.as_ref()?;
+        let device_id = config.device_id.trim();
+        if device_id.is_empty() {
+            return None;
+        }
+
+        match cloud.read_power(device_id).await {
+            Ok(Some(power)) if power == (speed != ErvFanSpeed::Off) => {
+                Some(assumed_status(speed, negative_pressure))
+            }
+            Ok(Some(power)) => {
+                tracing::warn!(
+                    "ERV cloud verification says power={power} after a {} command",
+                    speed.as_str()
+                );
+                let mut dps = Map::new();
+                dps.insert(DP_POWER.to_string(), Value::Bool(power));
+                Some(ErvDeviceStatus {
+                    power,
+                    fan_speed: (!power).then_some(ErvFanSpeed::Off),
+                    supply_speed: None,
+                    exhaust_speed: None,
+                    raw_dps: Value::Object(dps),
+                })
+            }
+            Ok(None) => None,
+            Err(error) => {
+                tracing::warn!("ERV cloud verification failed: {error:#}");
+                None
+            }
+        }
+    }
+}
+
+impl ErvSpeedWriter for SplitErvWriter {
+    fn smoke_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            if !config.local_readback_active() {
+                bail!("ERV local readback is not configured");
+            }
+            self.read_local(config).await
+        })
+    }
+
+    fn set_speed<'a>(
+        &'a self,
+        config: &'a ErvConfig,
+        speed: ErvFanSpeed,
+        negative_pressure: bool,
+    ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+        Box::pin(async move {
+            let power_transition = self.is_power_transition(speed);
+
+            let (report, status) = match self
+                .writer
+                .set_speed(config, speed, negative_pressure)
+                .await
+            {
+                Ok(status) => (self.writer.last_write_report(), status),
+                Err(error) => {
+                    let primary_report = self.writer.last_write_report();
+                    match self.write_fallback(config, speed, negative_pressure).await {
+                        Some(Ok(status)) => {
+                            tracing::warn!(
+                                "ERV scene trigger failed ({error:#}); wrote locally instead"
+                            );
+                            let report = self
+                                .fallback
+                                .as_ref()
+                                .map(|fallback| fallback.last_write_report())
+                                .unwrap_or_default();
+                            (report, status)
+                        }
+                        Some(Err(fallback_error)) => {
+                            self.finish(primary_report, None);
+                            return Err(error.context(format!(
+                                "ERV local write fallback also failed: {fallback_error:#}"
+                            )));
+                        }
+                        None => {
+                            self.finish(primary_report, None);
+                            return Err(error);
+                        }
+                    }
+                }
+            };
+
+            // A local write verifies itself, so only an assumed status needs
+            // the ladder below.
+            if report.source != ErvStatusSource::Assumed {
+                self.finish(report, Some(&status));
+                return Ok(status);
+            }
+
+            if config.verify_delay_seconds > 0 {
+                time::sleep(Duration::from_secs(config.verify_delay_seconds)).await;
+            }
+
+            if let Some(observed) = self.verify_locally(config, speed, negative_pressure).await {
+                let report = ErvWriteReport {
+                    source: ErvStatusSource::Local,
+                    ..report
+                };
+                self.finish(report, Some(&observed));
+                return Ok(observed);
+            }
+
+            if power_transition
+                && let Some(observed) = self
+                    .verify_via_cloud(config, speed, negative_pressure)
+                    .await
+            {
+                let report = ErvWriteReport {
+                    source: ErvStatusSource::Cloud,
+                    ..report
+                };
+                self.finish(report, Some(&observed));
+                return Ok(observed);
+            }
+
+            self.finish(report, Some(&status));
+            Ok(status)
+        })
+    }
+
+    fn last_write_report(&self) -> ErvWriteReport {
+        self.state().report
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -108,7 +583,7 @@ pub struct RustuyaErvStatusReader;
 impl ErvStatusReader for RustuyaErvStatusReader {
     fn read_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
         Box::pin(async move {
-            if !config.is_configured() {
+            if !config.local_tuya_configured() {
                 bail!("ERV local Tuya config is incomplete");
             }
 
@@ -138,7 +613,7 @@ impl ErvSpeedWriter for RustuyaErvSpeedWriter {
         negative_pressure: bool,
     ) -> BoxFutureResult<'a, ErvDeviceStatus> {
         Box::pin(async move {
-            if !config.is_configured() {
+            if !config.local_tuya_configured() {
                 bail!("ERV local Tuya config is incomplete");
             }
 
@@ -202,8 +677,11 @@ struct ErvInner {
     last_speed_changed_at: Option<f64>,
     manual_override: Option<ErvManualOverride>,
     consecutive_local_failures: u64,
-    next_local_retry_at: Option<f64>,
-    next_status_poll_retry_at: Option<f64>,
+    consecutive_scene_failures: u64,
+    /// Backoff on the *write* path: burst suppression and failed writes.
+    next_write_retry_at: Option<f64>,
+    /// Backoff on the *read* path: failed local status reads.
+    next_read_retry_at: Option<f64>,
     recent_local_activity: VecDeque<ErvLocalActivity>,
 }
 
@@ -242,14 +720,14 @@ impl ErvState {
     {
         match reader.read_status(config).await {
             Ok(status) => {
-                if self.record_local_success(status.clone()) {
+                if self.record_status_success(status.clone(), ErvStatusSource::Local) {
                     self.notify_status();
                 }
                 Ok(status)
             }
             Err(error) => {
                 let message = format!("{error:#}");
-                if self.record_read_only_local_failure(&message) {
+                if self.record_read_only_local_failure(config, &message) {
                     self.notify_status();
                 }
                 Err(error)
@@ -273,10 +751,7 @@ impl ErvState {
             bail!("ERV active control is disabled");
         }
         if !config.is_configured() {
-            bail!("ERV local Tuya config is incomplete");
-        }
-        if self.snapshot().local_key_invalid {
-            bail!("ERV local Tuya key is invalid");
+            bail!("ERV control config is incomplete");
         }
 
         let _local_io_guard = self.local_io_lock.lock().await;
@@ -292,13 +767,19 @@ impl ErvState {
             }
         }
 
-        let smoked_status = self
-            .smoke_status_with_locked(config, writer)
-            .await
-            .context("ERV smoke check failed before active write")?;
-
-        if device_status_matches_target(&smoked_status, speed, negative_pressure) {
-            return Ok(smoked_status);
+        // The pre-write read is an optimisation that skips redundant writes, not
+        // a gate. Requiring it to succeed is what let one dead local key take
+        // out every control path for a month.
+        if self.pre_write_read_allowed(config) {
+            match self.smoke_status_with_locked(config, writer).await {
+                Ok(status) if device_status_matches_target(&status, speed, negative_pressure) => {
+                    return Ok(status);
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!("ERV read before write failed, writing anyway: {error:#}");
+                }
+            }
         }
 
         self.write_speed_after_gate_locked(
@@ -310,6 +791,12 @@ impl ErvState {
             co2_ppm,
         )
         .await
+    }
+
+    /// Only read before writing when local readback is available and not in
+    /// failure backoff. In scene mode with a dead local key this simply skips.
+    fn pre_write_read_allowed(&self, config: &ErvConfig) -> bool {
+        config.local_readback_active() && self.read_retry_allowed(unix_timestamp_now())
     }
 
     pub(crate) async fn set_speed_after_smoke_with<W>(
@@ -328,10 +815,7 @@ impl ErvState {
             bail!("ERV active control is disabled");
         }
         if !config.is_configured() {
-            bail!("ERV local Tuya config is incomplete");
-        }
-        if self.snapshot().local_key_invalid {
-            bail!("ERV local Tuya key is invalid");
+            bail!("ERV control config is incomplete");
         }
 
         let _local_io_guard = self.local_io_lock.lock().await;
@@ -370,14 +854,23 @@ impl ErvState {
 
         match writer.set_speed(config, speed, negative_pressure).await {
             Ok(status) => {
-                self.record_speed_success(status.clone(), speed, reason, co2_ppm);
-                self.record_write_success(status.clone(), speed, reason, co2_ppm, &attempt);
+                let report = writer.last_write_report();
+                self.record_speed_success(status.clone(), report, speed, reason, co2_ppm);
+                self.record_write_success(status.clone(), report, speed, reason, co2_ppm, &attempt);
                 Ok(status)
             }
             Err(error) => {
+                let report = writer.last_write_report();
                 let message = format!("{error:#}");
-                self.record_write_failure(speed, reason, co2_ppm, &message);
-                self.record_local_failure(&message);
+                self.record_write_failure(report, speed, reason, co2_ppm, &message);
+                self.record_missing_scene(&error);
+                match report.transport {
+                    ErvTransport::Local => {
+                        self.record_local_failure(config, &message);
+                    }
+                    ErvTransport::Scene => self.record_scene_failure(&message),
+                }
+                self.notify_status();
                 Err(error)
             }
         }
@@ -410,34 +903,31 @@ impl ErvState {
         }
     }
 
-    pub fn local_retry_allowed(&self, now: f64) -> bool {
+    /// Whether the write path is out of backoff. Failed local *reads* never set
+    /// this — a stale local key costs speed readback, never control.
+    pub fn write_retry_allowed(&self, now: f64) -> bool {
         self.inner
             .read()
             .expect("ERV state lock poisoned")
-            .next_local_retry_at
-            .map_or(true, |retry_at| now >= retry_at)
+            .next_write_retry_at
+            .is_none_or(|retry_at| now >= retry_at)
     }
 
-    pub fn status_poll_delay(&self, config: &ErvConfig, now: f64) -> Duration {
-        let inner = self.inner.read().expect("ERV state lock poisoned");
-        if let Some(retry_at) = inner.next_status_poll_retry_at
-            && retry_at > now
-        {
-            return Duration::from_secs(((retry_at - now).ceil() as u64).max(1));
-        }
+    #[cfg(test)]
+    fn clear_read_backoff_for_test(&self) {
+        self.inner
+            .write()
+            .expect("ERV state lock poisoned")
+            .next_read_retry_at = None;
+    }
 
-        let active_interval = config.poll_interval_seconds.max(5);
-        let idle_interval = config.idle_poll_interval_seconds.max(active_interval);
-        let status_known_idle = inner
-            .latest_status
-            .as_ref()
-            .is_some_and(|status| !status.power);
-
-        Duration::from_secs(if status_known_idle {
-            idle_interval
-        } else {
-            active_interval
-        })
+    /// Whether a local status read is out of backoff.
+    pub fn read_retry_allowed(&self, now: f64) -> bool {
+        self.inner
+            .read()
+            .expect("ERV state lock poisoned")
+            .next_read_retry_at
+            .is_none_or(|retry_at| now >= retry_at)
     }
 
     pub async fn smoke_status_with<W>(
@@ -449,10 +939,7 @@ impl ErvState {
         W: ErvSpeedWriter + ?Sized,
     {
         if !config.is_configured() {
-            bail!("ERV local Tuya config is incomplete");
-        }
-        if self.snapshot().local_key_invalid {
-            bail!("ERV local Tuya key is invalid");
+            bail!("ERV control config is incomplete");
         }
 
         let _local_io_guard = self.local_io_lock.lock().await;
@@ -469,14 +956,16 @@ impl ErvState {
     {
         match writer.smoke_status(config).await {
             Ok(status) => {
-                if self.record_local_success(status.clone()) {
+                if self.record_status_success(status.clone(), ErvStatusSource::Local) {
                     self.notify_status();
                 }
                 Ok(status)
             }
             Err(error) => {
+                // A failed *read* backs off reads only. Letting it back off the
+                // write path is what coupled speed readback to control.
                 let message = format!("{error:#}");
-                if self.record_local_failure(&message) {
+                if self.record_read_only_local_failure(config, &message) {
                     self.notify_status();
                 }
                 Err(error)
@@ -660,7 +1149,7 @@ impl ErvState {
         let timestamp = local_iso_now();
         {
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
-            inner.next_local_retry_at = Some(at + LOCAL_WRITE_BURST_WINDOW_SECONDS);
+            inner.next_write_retry_at = Some(at + LOCAL_WRITE_BURST_WINDOW_SECONDS);
             push_local_activity_locked(
                 &mut inner,
                 ErvLocalActivity {
@@ -697,6 +1186,7 @@ impl ErvState {
     fn record_write_success(
         &self,
         device_status: ErvDeviceStatus,
+        report: ErvWriteReport,
         speed: ErvFanSpeed,
         reason: &str,
         co2_ppm: Option<i64>,
@@ -729,6 +1219,8 @@ impl ErvState {
                 "target_speed": speed.as_str(),
                 "reason": reason,
                 "co2_ppm": co2_ppm,
+                "transport": transport_label(report.transport),
+                "status_source": report.source.as_str(),
                 "device_status": device_status_json(&device_status),
                 "recent_write_attempts_5m": attempt.recent_write_attempts_5m,
                 "attempted_at": attempt.timestamp.clone(),
@@ -740,6 +1232,7 @@ impl ErvState {
 
     fn record_write_failure(
         &self,
+        report: ErvWriteReport,
         speed: ErvFanSpeed,
         reason: &str,
         co2_ppm: Option<i64>,
@@ -779,9 +1272,37 @@ impl ErvState {
                 "target_speed": speed.as_str(),
                 "reason": reason,
                 "co2_ppm": co2_ppm,
+                "transport": transport_label(report.transport),
                 "error": sanitized_message,
                 "recent_write_attempts_5m": recent_write_attempts_5m,
                 "recent_local_activity": recent_activity,
+            }),
+        );
+    }
+
+    /// A `(speed, pressure)` pair with no configured scene is a configuration
+    /// hole, not a transient failure: surface it instead of letting it look
+    /// like an ordinary cloud error.
+    fn record_missing_scene(&self, error: &anyhow::Error) {
+        let Some(missing) = error.downcast_ref::<MissingSceneError>() else {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            inner.control.missing_scene = None;
+            return;
+        };
+
+        let now = local_iso_now();
+        {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            inner.control.missing_scene = Some(missing.preset.clone());
+            inner.notification = Some(missing_scene_notification(&missing.preset, &now));
+        }
+
+        self.log_health_event(
+            "scene_missing",
+            json!({
+                "type": "erv_scene_missing",
+                "at": now,
+                "preset": missing.preset,
             }),
         );
     }
@@ -794,15 +1315,20 @@ impl ErvState {
     fn record_speed_success(
         &self,
         device_status: ErvDeviceStatus,
+        report: ErvWriteReport,
         speed: ErvFanSpeed,
         reason: &str,
         co2_ppm: Option<i64>,
     ) {
-        self.record_local_success(device_status);
-        self.inner
-            .write()
-            .expect("ERV state lock poisoned")
-            .last_speed_changed_at = Some(unix_timestamp_now());
+        self.record_status_success(device_status, report.source);
+        {
+            // Only a landed write clears the write-path backoff. A successful
+            // read says nothing about whether the transport recovered.
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            inner.last_speed_changed_at = Some(unix_timestamp_now());
+            inner.consecutive_scene_failures = 0;
+            inner.next_write_retry_at = None;
+        }
 
         if let Err(error) = db::log_climate_action(
             &self.database_path,
@@ -816,25 +1342,38 @@ impl ErvState {
         }
     }
 
-    fn record_local_success(&self, device_status: ErvDeviceStatus) -> bool {
+    /// Record a status we believe in, tagged with where it came from. Only a
+    /// local observation clears the local-key state — an assumed or cloud
+    /// status says nothing about whether local reads work.
+    fn record_status_success(
+        &self,
+        device_status: ErvDeviceStatus,
+        source: ErvStatusSource,
+    ) -> bool {
         let now = local_iso_now();
+        let observed_locally = source == ErvStatusSource::Local;
         let (status_changed, was_invalid, invalid_since) = {
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
-            let status_changed = inner.latest_status.as_ref() != Some(&device_status);
-            let was_invalid = inner.control.local_key_invalid;
+            let status_changed = inner.latest_status.as_ref() != Some(&device_status)
+                || inner.control.status_source != source;
+            let was_invalid = observed_locally && inner.control.local_key_invalid;
             let invalid_since = inner.control.local_key_invalid_since.clone();
 
             inner.latest_status = Some(device_status);
+            inner.control.status_source = source;
             inner.control.last_ok_at = Some(now.clone());
-            inner.control.last_local_ok_at = Some(now.clone());
             inner.control.last_error = None;
-            inner.control.using_cloud = false;
-            inner.control.local_key_invalid = false;
-            inner.control.local_key_invalid_since = None;
-            inner.consecutive_local_failures = 0;
-            inner.control.consecutive_local_key_errors = 0;
-            inner.next_local_retry_at = None;
-            inner.next_status_poll_retry_at = None;
+            inner.control.missing_scene = None;
+            inner.control.using_cloud = source == ErvStatusSource::Cloud;
+
+            if observed_locally {
+                inner.control.last_local_ok_at = Some(now.clone());
+                inner.control.local_key_invalid = false;
+                inner.control.local_key_invalid_since = None;
+                inner.consecutive_local_failures = 0;
+                inner.control.consecutive_local_key_errors = 0;
+                inner.next_read_retry_at = None;
+            }
 
             if was_invalid {
                 inner.notification = Some(recovered_notification(&now));
@@ -857,15 +1396,52 @@ impl ErvState {
         status_changed || was_invalid
     }
 
-    fn record_local_failure(&self, message: &str) -> bool {
-        self.record_local_failure_with_retry(message, true)
+    fn record_local_failure(&self, config: &ErvConfig, message: &str) -> bool {
+        self.record_local_failure_with_retry(config, message, true)
     }
 
-    fn record_read_only_local_failure(&self, message: &str) -> bool {
-        self.record_local_failure_with_retry(message, false)
+    fn record_read_only_local_failure(&self, config: &ErvConfig, message: &str) -> bool {
+        self.record_local_failure_with_retry(config, message, false)
     }
 
-    fn record_local_failure_with_retry(&self, message: &str, active_retry: bool) -> bool {
+    /// A scene trigger failed. This says nothing about the local key, so the
+    /// local-key counters must not move; it only backs off the write path.
+    fn record_scene_failure(&self, message: &str) {
+        let at = unix_timestamp_now();
+        let now = local_iso_now();
+        let sanitized_message = sanitize_erv_error(message);
+        let mut inner = self.inner.write().expect("ERV state lock poisoned");
+
+        inner.control.last_error = Some(format!("Scene trigger failed: {sanitized_message}"));
+        inner.control.last_error_at = Some(now.clone());
+        inner.control.using_cloud = false;
+        inner.consecutive_scene_failures = inner.consecutive_scene_failures.saturating_add(1);
+        inner.next_write_retry_at =
+            Some(at + local_failure_retry_delay_seconds(inner.consecutive_scene_failures));
+        let recent_write_attempts_5m =
+            recent_write_attempts_locked(&inner, at, LOCAL_WRITE_BURST_WINDOW_SECONDS);
+
+        push_local_activity_locked(
+            &mut inner,
+            ErvLocalActivity {
+                at,
+                timestamp: now,
+                event: "scene_write_failed",
+                target_speed: None,
+                reason: None,
+                co2_ppm: None,
+                message: Some(sanitized_message),
+                recent_write_attempts_5m: Some(recent_write_attempts_5m),
+            },
+        );
+    }
+
+    fn record_local_failure_with_retry(
+        &self,
+        config: &ErvConfig,
+        message: &str,
+        active_retry: bool,
+    ) -> bool {
         let now = local_iso_now();
         let at = unix_timestamp_now();
         let mut invalid_event = None;
@@ -879,10 +1455,9 @@ impl ErvState {
             inner.consecutive_local_failures = inner.consecutive_local_failures.saturating_add(1);
             let retry_at = unix_timestamp_now()
                 + local_failure_retry_delay_seconds(inner.consecutive_local_failures);
+            inner.next_read_retry_at = Some(retry_at);
             if active_retry {
-                inner.next_local_retry_at = Some(retry_at);
-            } else {
-                inner.next_status_poll_retry_at = Some(retry_at);
+                inner.next_write_retry_at = Some(retry_at);
             }
             let recent_write_attempts_5m =
                 recent_write_attempts_locked(&inner, at, LOCAL_WRITE_BURST_WINDOW_SECONDS);
@@ -920,7 +1495,10 @@ impl ErvState {
                 {
                     inner.control.local_key_invalid = true;
                     inner.control.local_key_invalid_since = Some(now.clone());
-                    inner.notification = Some(invalid_key_notification(&now));
+                    inner.notification = Some(invalid_key_notification(
+                        &now,
+                        config.scene_control_active(),
+                    ));
                     invalid_event = Some(json!({
                         "type": "erv_local_key_invalid",
                         "started_at": now,
@@ -1025,6 +1603,13 @@ fn runtime_snapshot_json(snapshot: ErvRuntimeSnapshot) -> Value {
     })
 }
 
+fn transport_label(transport: ErvTransport) -> &'static str {
+    match transport {
+        ErvTransport::Local => "local",
+        ErvTransport::Scene => "scene",
+    }
+}
+
 fn device_status_json(status: &ErvDeviceStatus) -> Value {
     json!({
         "power": status.power,
@@ -1056,26 +1641,94 @@ fn sanitize_erv_error(message: &str) -> String {
     truncated
 }
 
-pub fn start_erv_status_poll(config: &AppConfig, erv: ErvState) -> Option<JoinHandle<()>> {
-    if !config.erv.is_configured() {
-        tracing::info!("ERV local Tuya config is incomplete; read-only ERV polling disabled");
-        return None;
+/// Establish true state once at startup, replacing the status poll loop.
+///
+/// The loop it replaces issued 288-1440 local reads a day and its failures were
+/// the trigger for the Err 914 lockout. Everything after boot is read-after-write.
+/// If the boot read fails and scenes can control the unit, force a known state
+/// by triggering the off scene rather than running blind.
+pub async fn run_erv_boot_read(config: &AppConfig, erv: &ErvState) {
+    let off_writer = config
+        .erv
+        .scene_control_active()
+        .then(|| build_erv_writer(config));
+    run_erv_boot_read_with(config, erv, &RustuyaErvStatusReader, off_writer.as_deref()).await;
+}
+
+pub(crate) async fn run_erv_boot_read_with<R, W>(
+    config: &AppConfig,
+    erv: &ErvState,
+    reader: &R,
+    off_writer: Option<&W>,
+) where
+    R: ErvStatusReader + ?Sized,
+    W: ErvSpeedWriter + ?Sized,
+{
+    if config.erv.local_readback_active() {
+        match erv.refresh_with(&config.erv, reader).await {
+            Ok(status) => {
+                tracing::info!(
+                    "ERV boot read: running={} speed={}",
+                    status.power,
+                    status
+                        .fan_speed
+                        .map(ErvFanSpeed::as_str)
+                        .unwrap_or("unknown")
+                );
+                return;
+            }
+            Err(error) => tracing::warn!("ERV boot read failed: {error:#}"),
+        }
+    } else {
+        tracing::info!("ERV local readback is not configured; skipping the boot read");
     }
 
-    let config = config.erv.clone();
-    Some(tokio::spawn(async move {
-        let reader = RustuyaErvStatusReader;
-        loop {
-            if !erv.local_retry_allowed(unix_timestamp_now()) {
-                time::sleep(erv.status_poll_delay(&config, unix_timestamp_now())).await;
-                continue;
-            }
-            if let Err(error) = erv.refresh_with(&config, &reader).await {
-                tracing::warn!("ERV read-only status poll failed: {error:#}");
-            }
-            time::sleep(erv.status_poll_delay(&config, unix_timestamp_now())).await;
-        }
-    }))
+    let Some(off_writer) = off_writer else { return };
+    if !config.erv.active_control_enabled {
+        return;
+    }
+
+    match erv
+        .set_speed_with(
+            &config.erv,
+            off_writer,
+            ErvFanSpeed::Off,
+            false,
+            "boot_unknown_state",
+            None,
+        )
+        .await
+    {
+        Ok(_) => tracing::info!("ERV boot state unknown; forced off via the Smart Life off scene"),
+        Err(error) => tracing::warn!("ERV boot off-scene trigger failed: {error:#}"),
+    }
+}
+
+/// Assemble the ERV writer for a configuration.
+///
+/// The default is `SplitErvWriter { writer: SceneErvSpeedWriter, reader:
+/// RustuyaErvStatusReader }`: writes go out as scene triggers, reads come back
+/// over local Tuya. `control_mode: local` keeps the pre-#154 all-local path.
+pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
+    if !config.erv.scene_control_active() {
+        return Arc::new(RustuyaErvSpeedWriter);
+    }
+
+    let cloud: Arc<dyn ErvCloudClient> = Arc::new(SmartLifeErvCloud::new(
+        config.smart_life.client_id.clone(),
+        &config.erv,
+    ));
+    let mut writer = SplitErvWriter::new(
+        Arc::new(SceneErvSpeedWriter::new(cloud.clone())),
+        Arc::new(RustuyaErvStatusReader),
+    )
+    .with_cloud_verifier(cloud);
+
+    if config.erv.local_write_fallback_enabled && config.erv.local_tuya_configured() {
+        writer = writer.with_local_write_fallback(Arc::new(RustuyaErvSpeedWriter));
+    }
+
+    Arc::new(writer)
 }
 
 pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {
@@ -1290,15 +1943,29 @@ fn looks_like_tuya_error(message: &str) -> bool {
     message.contains("\"Error\"") || message.contains("\"Err\"") || message.contains("Error:")
 }
 
-fn invalid_key_notification(created_at: &str) -> AppNotification {
+fn invalid_key_notification(created_at: &str, scene_control_active: bool) -> AppNotification {
+    // With scene control this is a degraded-observability notice, not an
+    // outage: writes never touch the local key.
+    let (severity, title, message) = if scene_control_active {
+        (
+            "warning",
+            "ERV speed readback degraded",
+            "Local Tuya reads are failing with Err 914, so reported fan speed may be assumed rather than observed. Control is unaffected — writes go through Smart Life scenes. Run docs/tuya-local-key.md to restore readback.",
+        )
+    } else {
+        (
+            "critical",
+            "ERV local key rotated",
+            "Local Tuya control is failing with Err 914. Run docs/tuya-local-key.md to recover it.",
+        )
+    };
+
     AppNotification {
         id: format!("erv_local_key_invalid:{created_at}"),
         notification_type: "erv_local_key_invalid".to_string(),
-        severity: "critical".to_string(),
-        title: "ERV local key rotated".to_string(),
-        message:
-            "Local Tuya control is failing with Err 914. Run docs/tuya-local-key.md to recover it."
-                .to_string(),
+        severity: severity.to_string(),
+        title: title.to_string(),
+        message: message.to_string(),
         created_at: Some(created_at.to_string()),
         active: true,
         runbook_path: Some("docs/tuya-local-key.md".to_string()),
@@ -1310,11 +1977,26 @@ fn recovered_notification(created_at: &str) -> AppNotification {
         id: format!("erv_local_key_recovered:{created_at}"),
         notification_type: "erv_local_key_recovered".to_string(),
         severity: "info".to_string(),
-        title: "ERV local control recovered".to_string(),
-        message: "Local Tuya control is working again.".to_string(),
+        title: "ERV local readback recovered".to_string(),
+        message: "Local Tuya reads are working again; reported fan speed is observed.".to_string(),
         created_at: Some(created_at.to_string()),
         active: true,
         runbook_path: Some("docs/tuya-local-key.md".to_string()),
+    }
+}
+
+fn missing_scene_notification(preset: &str, created_at: &str) -> AppNotification {
+    AppNotification {
+        id: format!("erv_scene_missing:{preset}:{created_at}"),
+        notification_type: "erv_scene_missing".to_string(),
+        severity: "critical".to_string(),
+        title: "ERV scene missing".to_string(),
+        message: format!(
+            "No Smart Life scene is configured for {preset}, so that mode cannot be delivered. Scenes are hand-built in the Smart Life app; the API cannot create them."
+        ),
+        created_at: Some(created_at.to_string()),
+        active: true,
+        runbook_path: Some("docs/working/154_erv_scene_fallback.md".to_string()),
     }
 }
 
@@ -1381,6 +2063,7 @@ mod tests {
         write_results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
         smoke_calls: AtomicUsize,
         write_speeds: Mutex<Vec<ErvFanSpeed>>,
+        report: ErvWriteReport,
     }
 
     impl FakeErvWriter {
@@ -1393,7 +2076,17 @@ mod tests {
                 write_results: Mutex::new(write_results.into()),
                 smoke_calls: AtomicUsize::new(0),
                 write_speeds: Mutex::new(Vec::new()),
+                report: ErvWriteReport::default(),
             }
+        }
+
+        /// Model a scene write whose result nothing could observe.
+        fn with_scene_report(mut self) -> Self {
+            self.report = ErvWriteReport {
+                transport: ErvTransport::Scene,
+                source: ErvStatusSource::Assumed,
+            };
+            self
         }
 
         fn smoke_calls(&self) -> usize {
@@ -1441,6 +2134,10 @@ mod tests {
                 .unwrap_or_else(|| bail!("no fake ERV write result configured"));
             Box::pin(async move { result })
         }
+
+        fn last_write_report(&self) -> ErvWriteReport {
+            self.report
+        }
     }
 
     fn test_config() -> ErvConfig {
@@ -1460,6 +2157,18 @@ mod tests {
         }
     }
 
+    /// A fully configured scene write path on top of the local read path.
+    fn scene_config() -> ErvConfig {
+        ErvConfig {
+            smart_life_home_id: Some("home-id".to_string()),
+            off_scene_id: Some("off-scene".to_string()),
+            quiet_scene_id: Some("quiet-scene".to_string()),
+            medium_scene_id: Some("medium-scene".to_string()),
+            turbo_scene_id: Some("turbo-scene".to_string()),
+            ..active_config()
+        }
+    }
+
     fn app_config(erv: ErvConfig) -> AppConfig {
         AppConfig {
             orchestrator: OrchestratorConfig::default(),
@@ -1471,6 +2180,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv,
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),
@@ -1667,7 +2377,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_status_failure_backs_off_polling_without_blocking_writes() {
+    async fn local_read_failure_backs_off_reads_without_blocking_writes() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
@@ -1680,53 +2390,37 @@ mod tests {
         assert!(state.refresh_with(&test_config(), &reader).await.is_err());
 
         let now = unix_timestamp_now();
-        assert!(state.local_retry_allowed(now));
-        let delay = state.status_poll_delay(&test_config(), now);
-        assert!(delay >= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64 - 1));
-        assert!(delay <= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64));
+        assert!(state.write_retry_allowed(now));
+        assert!(!state.read_retry_allowed(now));
+        assert!(state.read_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
 
         assert!(state.refresh_with(&test_config(), &reader).await.is_err());
         let now = unix_timestamp_now();
-        assert!(state.local_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
-        let delay = state.status_poll_delay(&test_config(), now);
-        assert!(delay >= Duration::from_secs((LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) as u64 - 1));
-        assert!(delay <= Duration::from_secs((LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0) as u64));
+        assert!(state.write_retry_allowed(now));
+        assert!(!state.read_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS + 1.0));
+        assert!(state.read_retry_allowed(now + LOCAL_FAILURE_BASE_RETRY_SECONDS * 2.0 + 1.0));
     }
 
     #[tokio::test]
-    async fn status_poll_delay_uses_idle_interval_and_failure_backoff() {
+    async fn successful_local_read_clears_the_read_backoff() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
         let state = ErvState::new(database_path);
         let reader = FakeErvReader::new(vec![
-            Ok(parse_erv_status_payload(r#"{"dps":{"1":false}}"#).expect("status")),
             Err(anyhow!("Connection reset by peer")),
+            Ok(medium_status()),
         ]);
-        let config = ErvConfig {
-            poll_interval_seconds: 11,
-            idle_poll_interval_seconds: 97,
-            ..test_config()
-        };
 
-        assert_eq!(
-            state.status_poll_delay(&config, unix_timestamp_now()),
-            Duration::from_secs(11)
-        );
+        assert!(state.refresh_with(&test_config(), &reader).await.is_err());
+        assert!(!state.read_retry_allowed(unix_timestamp_now()));
 
         state
-            .refresh_with(&config, &reader)
+            .refresh_with(&test_config(), &reader)
             .await
-            .expect("idle status poll succeeds");
-        assert_eq!(
-            state.status_poll_delay(&config, unix_timestamp_now()),
-            Duration::from_secs(97)
-        );
+            .expect("read succeeds");
 
-        assert!(state.refresh_with(&config, &reader).await.is_err());
-        let delay = state.status_poll_delay(&config, unix_timestamp_now());
-        assert!(delay >= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64 - 1));
-        assert!(delay <= Duration::from_secs(LOCAL_FAILURE_BASE_RETRY_SECONDS as u64));
+        assert!(state.read_retry_allowed(unix_timestamp_now()));
     }
 
     #[tokio::test]
@@ -1928,7 +2622,7 @@ mod tests {
             writer.write_speeds(),
             vec![ErvFanSpeed::Turbo, ErvFanSpeed::Turbo, ErvFanSpeed::Turbo]
         );
-        assert!(!state.local_retry_allowed(unix_timestamp_now()));
+        assert!(!state.write_retry_allowed(unix_timestamp_now()));
 
         let history = db::read_history(&database_path, 1, 20).expect("history");
         let suppressed = history
@@ -1991,7 +2685,7 @@ mod tests {
 
         assert!(error.to_string().contains("burst guard"));
         assert_eq!(writer.write_speeds().len(), LOCAL_WRITE_BURST_ATTEMPT_LIMIT);
-        assert!(!state.local_retry_allowed(unix_timestamp_now()));
+        assert!(!state.write_retry_allowed(unix_timestamp_now()));
     }
 
     #[tokio::test]
@@ -2041,8 +2735,10 @@ mod tests {
         assert_eq!(writer.write_speeds().len(), LOCAL_WRITE_BURST_ATTEMPT_LIMIT);
     }
 
+    /// The regression this whole change exists for: repeated Err 914 reads mark
+    /// the local key invalid, and control keeps working through all of it.
     #[tokio::test]
-    async fn smoke_local_key_failures_close_active_write_gate() {
+    async fn local_key_failures_degrade_readback_without_closing_the_write_gate() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
@@ -2051,34 +2747,47 @@ mod tests {
             (0..LOCAL_KEY_ERROR_THRESHOLD)
                 .map(|_| bail!("Check device key or version (Error 914)"))
                 .collect(),
-            vec![Ok(turbo_status())],
-        );
+            (0..LOCAL_KEY_ERROR_THRESHOLD + 1)
+                .map(|_| Ok(turbo_status()))
+                .collect(),
+        )
+        .with_scene_report();
 
+        // Reads keep failing, but every write lands. The read backoff is
+        // stepped over here so each attempt actually tries a read.
         for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
-            assert!(
-                state
-                    .set_speed_with(
-                        &active_config(),
-                        &writer,
-                        ErvFanSpeed::Turbo,
-                        false,
-                        "manual_override",
-                        None,
-                    )
-                    .await
-                    .is_err()
-            );
+            state
+                .set_speed_with(
+                    &scene_config(),
+                    &writer,
+                    ErvFanSpeed::Turbo,
+                    false,
+                    "manual_override",
+                    None,
+                )
+                .await
+                .expect("write succeeds while reads fail");
+            state.clear_read_backoff_for_test();
         }
 
-        let mut status = Status::read_only_default(&app_config(active_config()));
+        let mut status = Status::read_only_default(&app_config(scene_config()));
         state.overlay_status(&mut status);
         assert!(status.erv.control.local_key_invalid);
+        assert_eq!(
+            status.notifications[0].notification_type,
+            "erv_local_key_invalid"
+        );
+        assert_eq!(status.notifications[0].severity, "warning");
         assert_eq!(writer.smoke_calls(), LOCAL_KEY_ERROR_THRESHOLD as usize);
-        assert!(writer.write_speeds().is_empty());
+        assert_eq!(
+            writer.write_speeds().len(),
+            LOCAL_KEY_ERROR_THRESHOLD as usize
+        );
 
-        let error = state
+        // And a write issued once the key is already marked invalid still goes.
+        state
             .set_speed_with(
-                &active_config(),
+                &scene_config(),
                 &writer,
                 ErvFanSpeed::Quiet,
                 false,
@@ -2086,9 +2795,438 @@ mod tests {
                 None,
             )
             .await
-            .expect_err("invalid local key should fail before smoke");
-        assert!(error.to_string().contains("local Tuya key is invalid"));
-        assert_eq!(writer.smoke_calls(), LOCAL_KEY_ERROR_THRESHOLD as usize);
-        assert!(writer.write_speeds().is_empty());
+            .expect("invalid local key must not block control");
+        assert_eq!(
+            writer.write_speeds().len(),
+            LOCAL_KEY_ERROR_THRESHOLD as usize + 1
+        );
+    }
+
+    #[derive(Default)]
+    struct FakeCloud {
+        triggers: Mutex<Vec<(String, String)>>,
+        trigger_results: Mutex<VecDeque<Result<()>>>,
+        power_results: Mutex<VecDeque<Result<Option<bool>>>>,
+        power_reads: AtomicUsize,
+    }
+
+    impl FakeCloud {
+        fn failing(errors: usize) -> Self {
+            Self {
+                trigger_results: Mutex::new(
+                    (0..errors)
+                        .map(|_| Err(anyhow!("Smart Life API error code=1106")))
+                        .collect(),
+                ),
+                ..Self::default()
+            }
+        }
+
+        fn with_power_reads(self, results: Vec<Result<Option<bool>>>) -> Self {
+            *self.power_results.lock().expect("power lock") = results.into();
+            self
+        }
+
+        fn triggered_scenes(&self) -> Vec<String> {
+            self.triggers
+                .lock()
+                .expect("trigger lock")
+                .iter()
+                .map(|(_, scene_id)| scene_id.clone())
+                .collect()
+        }
+
+        fn power_reads(&self) -> usize {
+            self.power_reads.load(Ordering::SeqCst)
+        }
+    }
+
+    impl ErvCloudClient for FakeCloud {
+        fn trigger_scene<'a>(
+            &'a self,
+            home_id: &'a str,
+            scene_id: &'a str,
+        ) -> BoxFutureResult<'a, ()> {
+            self.triggers
+                .lock()
+                .expect("trigger lock")
+                .push((home_id.to_string(), scene_id.to_string()));
+            let result = self
+                .trigger_results
+                .lock()
+                .expect("trigger results lock")
+                .pop_front()
+                .unwrap_or(Ok(()));
+            Box::pin(async move { result })
+        }
+
+        fn read_power<'a>(&'a self, _device_id: &'a str) -> BoxFutureResult<'a, Option<bool>> {
+            self.power_reads.fetch_add(1, Ordering::SeqCst);
+            let result = self
+                .power_results
+                .lock()
+                .expect("power lock")
+                .pop_front()
+                .unwrap_or(Ok(None));
+            Box::pin(async move { result })
+        }
+    }
+
+    fn split_writer(
+        cloud: Arc<FakeCloud>,
+        reader: Arc<FakeErvReader>,
+        fallback: Option<Arc<FakeErvWriter>>,
+    ) -> SplitErvWriter {
+        let mut writer =
+            SplitErvWriter::new(Arc::new(SceneErvSpeedWriter::new(cloud.clone())), reader)
+                .with_cloud_verifier(cloud);
+        if let Some(fallback) = fallback {
+            writer = writer.with_local_write_fallback(fallback);
+        }
+        writer
+    }
+
+    /// The property the whole design rests on: in the default configuration a
+    /// write reaches the device as a scene trigger and never as a local
+    /// command, because local commands are what trigger the Err 914 lockout.
+    #[tokio::test]
+    async fn default_write_path_triggers_a_scene_and_issues_no_local_command() {
+        let cloud = Arc::new(FakeCloud::default());
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), Vec::new()));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![Ok(turbo_status())])),
+            Some(local.clone()),
+        );
+
+        let status = writer
+            .set_speed(&scene_config(), ErvFanSpeed::Turbo, false)
+            .await
+            .expect("scene write succeeds");
+
+        assert_eq!(cloud.triggered_scenes(), vec!["turbo-scene".to_string()]);
+        assert!(
+            local.write_speeds().is_empty(),
+            "no local command may be issued on the scene path"
+        );
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+    }
+
+    #[tokio::test]
+    async fn scene_write_verified_by_a_local_read_reports_observed_speeds() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                Ok(medium_status()),
+                Ok(turbo_status()),
+            ])),
+            None,
+        );
+
+        let status = state
+            .set_speed_with(
+                &scene_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect("scene write succeeds");
+
+        assert_eq!(status.supply_speed, Some(8));
+        assert_eq!(status.exhaust_speed, Some(8));
+
+        let mut app_status = Status::read_only_default(&app_config(scene_config()));
+        state.overlay_status(&mut app_status);
+        assert_eq!(app_status.erv.control.status_source, ErvStatusSource::Local);
+        assert_eq!(app_status.erv.speed, "turbo");
+    }
+
+    #[tokio::test]
+    async fn scene_write_survives_a_failed_readback_and_reports_assumed_state() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                Err(anyhow!("Check device key or version (Error 914)")),
+                Err(anyhow!("Check device key or version (Error 914)")),
+            ])),
+            None,
+        );
+
+        let status = state
+            .set_speed_with(
+                &scene_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect("a failed readback must not fail the write");
+
+        assert_eq!(cloud.triggered_scenes(), vec!["turbo-scene".to_string()]);
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+
+        let mut app_status = Status::read_only_default(&app_config(scene_config()));
+        state.overlay_status(&mut app_status);
+        assert_eq!(
+            app_status.erv.control.status_source,
+            ErvStatusSource::Assumed
+        );
+    }
+
+    /// The cloud only exposes the `switch` bit, so it is worth a call when the
+    /// power state changes and pure noise when only the speed does.
+    #[tokio::test]
+    async fn cloud_verification_runs_on_power_transitions_only() {
+        let cloud =
+            Arc::new(FakeCloud::default().with_power_reads(vec![Ok(Some(true)), Ok(Some(true))]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                Err(anyhow!("Check device key or version (Error 914)")),
+                Err(anyhow!("Check device key or version (Error 914)")),
+            ])),
+            None,
+        );
+        let config = scene_config();
+
+        // Power state is unknown, so off -> turbo is a transition.
+        writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect("scene write succeeds");
+        assert_eq!(cloud.power_reads(), 1);
+        assert_eq!(
+            writer.last_write_report().source,
+            ErvStatusSource::Cloud,
+            "a confirmed power bit is better than an assumption"
+        );
+
+        // Turbo -> medium leaves the switch on, so there is nothing to learn.
+        writer
+            .set_speed(&config, ErvFanSpeed::Medium, false)
+            .await
+            .expect("scene write succeeds");
+        assert_eq!(cloud.power_reads(), 1);
+        assert_eq!(writer.last_write_report().source, ErvStatusSource::Assumed);
+    }
+
+    #[tokio::test]
+    async fn failed_scene_trigger_falls_back_to_a_local_write() {
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            Some(local.clone()),
+        );
+
+        let status = writer
+            .set_speed(&scene_config(), ErvFanSpeed::Turbo, false)
+            .await
+            .expect("local fallback keeps the ERV controllable");
+
+        assert_eq!(local.write_speeds(), vec![ErvFanSpeed::Turbo]);
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+        assert_eq!(writer.last_write_report().transport, ErvTransport::Local);
+        assert_eq!(writer.last_write_report().source, ErvStatusSource::Local);
+    }
+
+    #[tokio::test]
+    async fn failed_scene_trigger_surfaces_an_error_when_local_is_unhealthy() {
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Check device key or version (Error 914)"
+            ))])),
+            Some(local.clone()),
+        );
+        let config = scene_config();
+
+        // A failed read is what marks local unhealthy.
+        assert!(writer.smoke_status(&config).await.is_err());
+
+        let error = writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect_err("no usable transport should surface an error");
+
+        assert!(format!("{error:#}").contains("Smart Life API error"));
+        assert!(
+            local.write_speeds().is_empty(),
+            "an unhealthy local path must not be used as a fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_scene_fails_loudly_instead_of_substituting() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+
+        // Negative-pressure turbo has no configured scene here.
+        let error = state
+            .set_speed_with(
+                &scene_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                true,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect_err("a missing scene must not fall back to another preset");
+
+        assert!(error.downcast_ref::<MissingSceneError>().is_some());
+        assert!(
+            cloud.triggered_scenes().is_empty(),
+            "the normal-pressure scene must not be substituted"
+        );
+
+        let mut app_status = Status::read_only_default(&app_config(scene_config()));
+        state.overlay_status(&mut app_status);
+        assert_eq!(
+            app_status.erv.control.missing_scene.as_deref(),
+            Some("turbo (negative pressure)")
+        );
+        assert_eq!(
+            app_status.notifications[0].notification_type,
+            "erv_scene_missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_read_forces_a_known_state_when_the_local_read_fails() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let reader = FakeErvReader::new(vec![Err(anyhow!("Connection reset by peer"))]);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+
+        run_erv_boot_read_with(&app_config(scene_config()), &state, &reader, Some(&writer)).await;
+
+        assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
+        assert!(!state.snapshot().running);
+    }
+
+    #[tokio::test]
+    async fn boot_read_establishes_state_without_touching_the_cloud() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let reader = FakeErvReader::new(vec![Ok(medium_status())]);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+
+        run_erv_boot_read_with(&app_config(scene_config()), &state, &reader, Some(&writer)).await;
+
+        assert!(cloud.triggered_scenes().is_empty());
+        assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+    }
+
+    /// A cloud failure backs off the write path and says nothing about the
+    /// local key, which is a different subsystem entirely.
+    #[tokio::test]
+    async fn scene_failure_backs_off_writes_without_blaming_the_local_key() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let writer = split_writer(cloud, Arc::new(FakeErvReader::new(Vec::new())), None);
+        let config = ErvConfig {
+            local_readback_enabled: false,
+            ..scene_config()
+        };
+
+        state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect_err("scene trigger failed with no fallback");
+
+        let now = unix_timestamp_now();
+        assert!(!state.write_retry_allowed(now));
+        assert!(state.read_retry_allowed(now));
+
+        let mut app_status = Status::read_only_default(&app_config(config));
+        state.overlay_status(&mut app_status);
+        assert!(!app_status.erv.control.local_key_invalid);
+        assert_eq!(app_status.erv.control.consecutive_local_key_errors, 0);
+        assert!(
+            app_status
+                .erv
+                .control
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.starts_with("Scene trigger failed:"))
+        );
+    }
+
+    #[test]
+    fn scene_ids_cover_the_full_speed_by_pressure_matrix() {
+        let config = ErvConfig {
+            quiet_negative_pressure_scene_id: Some("quiet-np".to_string()),
+            medium_negative_pressure_scene_id: Some("medium-np".to_string()),
+            turbo_negative_pressure_scene_id: Some("turbo-np".to_string()),
+            ..scene_config()
+        };
+
+        for (speed, negative_pressure, expected) in [
+            (ErvFanSpeed::Off, false, "off-scene"),
+            (ErvFanSpeed::Off, true, "off-scene"),
+            (ErvFanSpeed::Quiet, false, "quiet-scene"),
+            (ErvFanSpeed::Medium, false, "medium-scene"),
+            (ErvFanSpeed::Turbo, false, "turbo-scene"),
+            (ErvFanSpeed::Quiet, true, "quiet-np"),
+            (ErvFanSpeed::Medium, true, "medium-np"),
+            (ErvFanSpeed::Turbo, true, "turbo-np"),
+        ] {
+            assert_eq!(
+                scene_id_for(&config, speed, negative_pressure),
+                Ok(expected),
+                "wrong scene for {speed:?} negative_pressure={negative_pressure}"
+            );
+        }
     }
 }

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -856,19 +856,31 @@ impl ErvState {
             }
         }
 
-        // The pre-write read is an optimisation that skips redundant writes, not
-        // a gate. Requiring it to succeed is what let one dead local key take
-        // out every control path for a month.
+        // On the scene path the pre-write read is an optimisation that skips
+        // redundant writes, not a gate: requiring it to succeed is what let one
+        // dead local key take out every control path for a month.
+        //
+        // In local control mode it is still a gate, because there the local key
+        // *is* the control path. Writing through credentials a read just
+        // rejected is the command pattern that produces the lockout.
+        let local_control = config.control_mode == ErvControlMode::Local;
         if self.pre_write_read_allowed(config) {
             match self.smoke_status_with_locked(config, writer).await {
                 Ok(status) if device_status_matches_target(&status, speed, negative_pressure) => {
                     return Ok(status);
                 }
                 Ok(_) => {}
+                Err(error) if local_control => {
+                    return Err(error.context("ERV read before a local write failed"));
+                }
                 Err(error) => {
                     tracing::warn!("ERV read before write failed, writing anyway: {error:#}");
                 }
             }
+        } else if local_control && config.local_readback_active() {
+            // The read was skipped because reads are in failure backoff, which
+            // in local mode means the write would fail the same way.
+            bail!("ERV local reads are in failure backoff; refusing to issue a local command");
         }
 
         self.write_speed_after_gate_locked(
@@ -1937,6 +1949,41 @@ pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
     }
 
     Arc::new(writer)
+}
+
+/// Read-only check of the Smart Life scene transport.
+///
+/// Scene ids being non-empty strings proves nothing: the auth cache can be
+/// missing, unreadable, or holding a dead refresh token, and every ERV command
+/// would fail. This exercises the credentials without commanding the device.
+pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
+    if !config.erv.scene_control_active() {
+        bail!("ERV scene control is not configured");
+    }
+
+    let client = SmartLifeClient::new(
+        config.smart_life.client_id.clone(),
+        auth_file_or_default(config.erv.smart_life_auth_file.as_ref()),
+    );
+    let endpoint = client
+        .check_credentials()
+        .await
+        .context("Smart Life credentials are not usable")?;
+
+    let device_id = config.erv.device_id.trim();
+    if device_id.is_empty() {
+        return Ok(format!("Smart Life auth OK at {endpoint}"));
+    }
+
+    let status = client
+        .device_status(device_id)
+        .await
+        .context("Smart Life device read failed")?;
+    let power = status_code_value(&status, "switch")
+        .and_then(value_as_bool)
+        .map(|power| power.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    Ok(format!("Smart Life auth OK at {endpoint}; switch={power}"))
 }
 
 pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {
@@ -3863,6 +3910,87 @@ mod tests {
         run_erv_boot_read(&config, &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
+    }
+
+    /// §6 scopes "a failed read must not block control" to the scene path. In
+    /// local control mode the local key *is* control, so writing through
+    /// credentials a read just rejected is the command pattern that produces
+    /// the lockout.
+    #[tokio::test]
+    async fn local_control_mode_keeps_the_failed_read_gate() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let writer = FakeErvWriter::new(
+            vec![Err(anyhow!("Check device key or version (Error 914)"))],
+            vec![Ok(turbo_status())],
+        );
+        let config = ErvConfig {
+            control_mode: ErvControlMode::Local,
+            ..active_config()
+        };
+
+        let error = state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("a rejected read must not be followed by a local command");
+
+        assert!(format!("{error:#}").contains("read before a local write failed"));
+        assert!(writer.write_speeds().is_empty());
+
+        // And once reads are in backoff, the write is refused without even
+        // attempting one.
+        let error = state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("local writes stay gated while reads are backing off");
+
+        assert!(error.to_string().contains("failure backoff"));
+        assert_eq!(writer.smoke_calls(), 1);
+        assert!(writer.write_speeds().is_empty());
+    }
+
+    /// The same failure on the scene path must not block control.
+    #[tokio::test]
+    async fn scene_control_mode_writes_through_a_failed_read() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let writer = FakeErvWriter::new(
+            vec![Err(anyhow!("Check device key or version (Error 914)"))],
+            vec![Ok(turbo_status())],
+        )
+        .with_scene_report();
+
+        state
+            .set_speed_with(
+                &scene_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect("a failed read must not block a scene write");
+
+        assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
     }
 
     /// A fallback write that lands proves local works, so the failure count

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -18,7 +18,7 @@ use tokio::{
 };
 
 use crate::{
-    config::{AppConfig, ErvConfig},
+    config::{AppConfig, ErvConfig, ErvControlMode},
     db,
     smart_life::{SmartLifeClient, auth_file_or_default, status_code_value},
     status::{AppNotification, ErvControlStatus, ErvStatusSource, Status},
@@ -300,8 +300,11 @@ impl ErvSpeedWriter for SceneErvSpeedWriter {
 struct SplitWriterState {
     report: ErvWriteReport,
     last_known_power: Option<bool>,
-    consecutive_read_failures: u64,
-    read_retry_at: Option<f64>,
+    /// Health of the local path, fed by both failed readbacks and failed
+    /// fallback writes. It gates readback *and* whether local is healthy
+    /// enough to be used as a write fallback.
+    consecutive_local_failures: u64,
+    local_retry_at: Option<f64>,
 }
 
 /// Splits the two transports by direction: writes go out over `writer` (the
@@ -350,21 +353,21 @@ impl SplitErvWriter {
             return false;
         }
         self.state()
-            .read_retry_at
+            .local_retry_at
             .is_none_or(|retry_at| unix_timestamp_now() >= retry_at)
     }
 
-    fn record_read_outcome(&self, succeeded: bool) {
+    fn record_local_outcome(&self, succeeded: bool) {
         let mut state = self.state();
         if succeeded {
-            state.consecutive_read_failures = 0;
-            state.read_retry_at = None;
+            state.consecutive_local_failures = 0;
+            state.local_retry_at = None;
             return;
         }
-        state.consecutive_read_failures = state.consecutive_read_failures.saturating_add(1);
-        state.read_retry_at = Some(
+        state.consecutive_local_failures = state.consecutive_local_failures.saturating_add(1);
+        state.local_retry_at = Some(
             unix_timestamp_now()
-                + local_failure_retry_delay_seconds(state.consecutive_read_failures),
+                + local_failure_retry_delay_seconds(state.consecutive_local_failures),
         );
     }
 
@@ -386,7 +389,7 @@ impl SplitErvWriter {
 
     async fn read_local(&self, config: &ErvConfig) -> Result<ErvDeviceStatus> {
         let result = self.reader.read_status(config).await;
-        self.record_read_outcome(result.is_ok());
+        self.record_local_outcome(result.is_ok());
         if let Ok(status) = &result {
             self.state().last_known_power = Some(status.power);
         }
@@ -407,7 +410,7 @@ impl SplitErvWriter {
         // has been failing is not going to accept a command either.
         if self
             .state()
-            .read_retry_at
+            .local_retry_at
             .is_some_and(|retry_at| unix_timestamp_now() < retry_at)
         {
             return None;
@@ -508,6 +511,13 @@ impl ErvSpeedWriter for SplitErvWriter {
                 Ok(status) => (self.writer.last_write_report(), status),
                 Err(error) => {
                     let primary_report = self.writer.last_write_report();
+                    // A hole in the scene matrix is a configuration error, not
+                    // an outage. Writing it locally would deliver the speed
+                    // while hiding the hole, so it has to propagate.
+                    if error.downcast_ref::<MissingSceneError>().is_some() {
+                        self.finish(primary_report, None);
+                        return Err(error);
+                    }
                     match self.write_fallback(config, speed, negative_pressure).await {
                         Some(Ok(status)) => {
                             tracing::warn!(
@@ -521,6 +531,11 @@ impl ErvSpeedWriter for SplitErvWriter {
                             (report, status)
                         }
                         Some(Err(fallback_error)) => {
+                            // Mark local unhealthy, or the next cloud failure
+                            // fires another command at a known-bad local key —
+                            // exactly the command pattern that causes the
+                            // Err 914 lockout.
+                            self.record_local_outcome(false);
                             self.finish(primary_report, None);
                             return Err(error.context(format!(
                                 "ERV local write fallback also failed: {fallback_error:#}"
@@ -1709,8 +1724,12 @@ pub(crate) async fn run_erv_boot_read_with<R, W>(
 /// The default is `SplitErvWriter { writer: SceneErvSpeedWriter, reader:
 /// RustuyaErvStatusReader }`: writes go out as scene triggers, reads come back
 /// over local Tuya. `control_mode: local` keeps the pre-#154 all-local path.
+///
+/// Selection follows `control_mode` alone. An incomplete scene set must fail
+/// per write with a missing-scene diagnostic, never quietly demote the whole
+/// deployment to the local transport this change exists to stop using.
 pub fn build_erv_writer(config: &AppConfig) -> Arc<dyn ErvSpeedWriter> {
-    if !config.erv.scene_control_active() {
+    if config.erv.control_mode == ErvControlMode::Local {
         return Arc::new(RustuyaErvSpeedWriter);
     }
 
@@ -3081,10 +3100,14 @@ mod tests {
         db::migrate_database(&database_path).expect("migration");
         let state = ErvState::new(database_path);
         let cloud = Arc::new(FakeCloud::default());
+        // The fallback is configured and healthy, as it is by default. A hole
+        // in the scene matrix must still surface instead of being papered over
+        // by a local write that happens to be able to deliver the speed.
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
         let writer = split_writer(
             cloud.clone(),
             Arc::new(FakeErvReader::new(Vec::new())),
-            None,
+            Some(local.clone()),
         );
 
         // Negative-pressure turbo has no configured scene here.
@@ -3104,6 +3127,10 @@ mod tests {
         assert!(
             cloud.triggered_scenes().is_empty(),
             "the normal-pressure scene must not be substituted"
+        );
+        assert!(
+            local.write_speeds().is_empty(),
+            "a configuration hole must not be written away by the local fallback"
         );
 
         let mut app_status = Status::read_only_default(&app_config(scene_config()));
@@ -3156,6 +3183,115 @@ mod tests {
 
         assert!(cloud.triggered_scenes().is_empty());
         assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+    }
+
+    /// A failed fallback write means local is not usable either. Leaving it
+    /// marked healthy would fire another command at a known-bad local key on
+    /// the next cloud failure, which is the command pattern that causes the
+    /// Err 914 lockout in the first place.
+    #[tokio::test]
+    async fn failed_fallback_write_marks_the_local_path_unhealthy() {
+        let cloud = Arc::new(FakeCloud::failing(2));
+        let local = Arc::new(FakeErvWriter::new(
+            Vec::new(),
+            vec![Err(anyhow!("Check device key or version (Error 914)"))],
+        ));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            Some(local.clone()),
+        );
+        let config = scene_config();
+
+        writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect_err("both transports failed");
+        assert_eq!(local.write_speeds().len(), 1);
+
+        // Second cloud failure must not reach for local again.
+        writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect_err("both transports still failing");
+        assert_eq!(
+            local.write_speeds().len(),
+            1,
+            "local was retried while still in failure backoff"
+        );
+    }
+
+    /// Writer selection follows `control_mode`. An incomplete scene set fails
+    /// per write with a missing-scene diagnostic; it must never quietly demote
+    /// the deployment to the local transport.
+    #[tokio::test]
+    async fn incomplete_scene_config_does_not_silently_select_the_local_writer() {
+        let config = app_config(ErvConfig {
+            turbo_scene_id: None,
+            status_timeout_seconds: 1,
+            ..scene_config()
+        });
+        assert!(
+            !config.erv.scene_configured(),
+            "the scene set is deliberately incomplete"
+        );
+        assert!(
+            config.erv.local_tuya_configured(),
+            "local credentials are present, as they are pre-upgrade"
+        );
+
+        let error = build_erv_writer(&config)
+            .set_speed(&config.erv, ErvFanSpeed::Turbo, false)
+            .await
+            .expect_err("an incomplete scene set must fail, not fall back to local");
+
+        assert!(
+            error.downcast_ref::<MissingSceneError>().is_some(),
+            "expected a missing-scene diagnostic, got: {error:#}"
+        );
+    }
+
+    /// `control_mode` picks the writer in both directions. The two writers are
+    /// told apart by how they refuse a read with no local credentials, which
+    /// needs no network.
+    #[tokio::test]
+    async fn control_mode_selects_the_writer_in_both_directions() {
+        let without_local_credentials = ErvConfig {
+            ip: String::new(),
+            device_id: String::new(),
+            local_key: String::new(),
+            ..scene_config()
+        };
+
+        let local_mode = app_config(ErvConfig {
+            control_mode: ErvControlMode::Local,
+            ..without_local_credentials.clone()
+        });
+        let error = build_erv_writer(&local_mode)
+            .smoke_status(&local_mode.erv)
+            .await
+            .expect_err("no local credentials");
+        assert!(
+            error
+                .to_string()
+                .contains("local Tuya config is incomplete"),
+            "expected the local writer, got: {error:#}"
+        );
+
+        let scene_mode = app_config(ErvConfig {
+            control_mode: ErvControlMode::Scene,
+            ..without_local_credentials
+        });
+        let error = build_erv_writer(&scene_mode)
+            .smoke_status(&scene_mode.erv)
+            .await
+            .expect_err("no local credentials");
+        assert!(
+            error
+                .to_string()
+                .contains("local readback is not configured"),
+            "expected the split writer, got: {error:#}"
+        );
     }
 
     /// A cloud failure backs off the write path and says nothing about the

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1995,6 +1995,12 @@ pub fn check_erv_scene_config(config: &AppConfig) -> Result<usize> {
         bail!("ERV scene control is not the selected transport");
     }
 
+    // Without a home id no scene can be triggered at all, however complete the
+    // matrix looks.
+    if config.erv.smart_life_home_id().is_none() {
+        bail!("{}", SceneConfigError::MissingHomeId);
+    }
+
     // The matrix this deployment will command, not the one that happens to be
     // filled in. An incomplete set does not demote anything to local control --
     // the affected writes just fail -- so this has to reject it rather than
@@ -4316,6 +4322,28 @@ mod tests {
                 .as_deref()
                 .is_some_and(|error| error.starts_with("Scene trigger failed:"))
         );
+    }
+
+    /// Without a home id no scene can be triggered at all, so a complete
+    /// matrix must not be mistaken for a working transport.
+    #[test]
+    fn scene_config_check_requires_the_home_id() {
+        let complete = app_config(scene_config());
+        assert_eq!(check_erv_scene_config(&complete).expect("configured"), 4);
+
+        let no_home_id = app_config(ErvConfig {
+            smart_life_home_id: None,
+            ..scene_config()
+        });
+        let error = check_erv_scene_config(&no_home_id).expect_err("no home id");
+        assert!(error.to_string().contains("home id"));
+
+        let no_turbo = app_config(ErvConfig {
+            turbo_scene_id: None,
+            ..scene_config()
+        });
+        let error = check_erv_scene_config(&no_turbo).expect_err("incomplete matrix");
+        assert!(error.to_string().contains("turbo"));
     }
 
     /// While negative pressure is armed, those are the only scenes automation

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -880,8 +880,32 @@ impl ErvState {
         match writer.set_speed(config, speed, negative_pressure).await {
             Ok(status) => {
                 let report = writer.last_write_report();
-                self.record_speed_success(status.clone(), report, speed, reason, co2_ppm);
-                self.record_write_success(status.clone(), report, speed, reason, co2_ppm, &attempt);
+                // An observation that contradicts the target means the command
+                // did not land. Keep the observed status -- it is the truth --
+                // but do not claim the speed changed: that would start the
+                // dwell timer and suppress the corrective command for the
+                // whole dwell window. The burst guard, not dwell, is what
+                // bounds retries here.
+                let landed = !matches!(
+                    report.source,
+                    ErvStatusSource::Local | ErvStatusSource::Cloud
+                ) || device_status_matches_target(&status, speed, negative_pressure);
+
+                if landed {
+                    self.record_speed_success(status.clone(), report, speed, reason, co2_ppm);
+                    self.record_write_success(
+                        status.clone(),
+                        report,
+                        speed,
+                        reason,
+                        co2_ppm,
+                        &attempt,
+                    );
+                } else {
+                    self.record_status_success(status.clone(), report.source);
+                    self.record_write_unverified(status.clone(), report, speed, reason, co2_ppm);
+                    self.notify_status();
+                }
                 Ok(status)
             }
             Err(error) => {
@@ -1250,6 +1274,52 @@ impl ErvState {
                 "recent_write_attempts_5m": attempt.recent_write_attempts_5m,
                 "attempted_at": attempt.timestamp.clone(),
                 "activity_at_attempt": attempt.recent_activity.clone(),
+                "recent_local_activity": self.recent_local_activity_json(),
+            }),
+        );
+    }
+
+    /// The transport accepted the command but the device says otherwise. Not a
+    /// failed write and not a landed one: the status is real, the speed change
+    /// is not, and no climate action is logged for a change that did not happen.
+    fn record_write_unverified(
+        &self,
+        device_status: ErvDeviceStatus,
+        report: ErvWriteReport,
+        speed: ErvFanSpeed,
+        reason: &str,
+        co2_ppm: Option<i64>,
+    ) {
+        let at = unix_timestamp_now();
+        let timestamp = local_iso_now();
+        {
+            let mut inner = self.inner.write().expect("ERV state lock poisoned");
+            push_local_activity_locked(
+                &mut inner,
+                ErvLocalActivity {
+                    at,
+                    timestamp: timestamp.clone(),
+                    event: "write_not_verified",
+                    target_speed: Some(speed),
+                    reason: Some(reason.to_string()),
+                    co2_ppm,
+                    message: Some("device state contradicts the commanded speed".to_string()),
+                    recent_write_attempts_5m: None,
+                },
+            );
+        }
+
+        self.log_health_event(
+            "write_not_verified",
+            json!({
+                "type": "erv_write_not_verified",
+                "at": timestamp,
+                "target_speed": speed.as_str(),
+                "reason": reason,
+                "co2_ppm": co2_ppm,
+                "transport": transport_label(report.transport),
+                "status_source": report.source.as_str(),
+                "device_status": device_status_json(&device_status),
                 "recent_local_activity": self.recent_local_activity_json(),
             }),
         );
@@ -1682,15 +1752,14 @@ fn sanitize_erv_error(message: &str) -> String {
 /// the trigger for the Err 914 lockout. Everything after boot is read-after-write.
 /// If the boot read fails and scenes can control the unit, force a known state
 /// by triggering the off scene rather than running blind.
-pub async fn run_erv_boot_read(config: &AppConfig, erv: &ErvState) {
-    run_erv_boot_read_with(config, erv, build_erv_writer(config).as_ref()).await;
-}
-
 /// The boot read goes through the *writer's* own read path, not a fresh
 /// reader, so a failure lands in that writer's local-health state. Otherwise a
 /// failed boot read followed by a failed off-scene trigger would find a
 /// pristine health gate and fire a local command at the path that just failed.
-pub(crate) async fn run_erv_boot_read_with<W>(config: &AppConfig, erv: &ErvState, writer: &W)
+///
+/// Pass the same writer the policy coordinator uses. A second instance has its
+/// own health state, which puts the pristine-gate hole back one level up.
+pub async fn run_erv_boot_read<W>(config: &AppConfig, erv: &ErvState, writer: &W)
 where
     W: ErvSpeedWriter + ?Sized,
 {
@@ -3216,7 +3285,7 @@ mod tests {
             None,
         );
 
-        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
         assert!(!state.snapshot().running);
@@ -3242,7 +3311,7 @@ mod tests {
             Some(local.clone()),
         );
 
-        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
 
         assert!(
             local.write_speeds().is_empty(),
@@ -3286,7 +3355,7 @@ mod tests {
             .expect("policy write succeeds");
         let triggered = cloud.triggered_scenes();
 
-        run_erv_boot_read_with(&config, &state, &writer).await;
+        run_erv_boot_read(&config, &state, &writer).await;
 
         assert_eq!(
             cloud.triggered_scenes(),
@@ -3309,10 +3378,66 @@ mod tests {
             None,
         );
 
-        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
 
         assert!(cloud.triggered_scenes().is_empty());
         assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+    }
+
+    /// A scene the API accepted but the device ignored must not start the
+    /// dwell timer. Dwell exists to stop thrash between real speed changes; if
+    /// a non-change starts it, the corrective command is suppressed for the
+    /// whole dwell window. The burst guard is what bounds retries here.
+    #[tokio::test]
+    async fn contradicted_write_reports_truth_without_starting_dwell() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path.clone());
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                // Pre-write read: still at medium.
+                Ok(medium_status()),
+                // Read-after-write: the scene was accepted but nothing moved.
+                Ok(medium_status()),
+            ])),
+            None,
+        );
+
+        let status = state
+            .set_speed_with(
+                &scene_config(),
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect("a contradicted verification must not fail the write");
+
+        // The observed state is reported truthfully...
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Medium));
+        assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+        // ...and the speed is not claimed to have changed.
+        assert!(
+            state.snapshot().last_speed_changed_at.is_none(),
+            "a command the device ignored started the dwell timer"
+        );
+
+        let history = db::read_history(&database_path, 1, 20).expect("history");
+        assert!(
+            history.climate_actions.is_empty(),
+            "a change that did not happen was logged as a climate action"
+        );
+        assert!(
+            history
+                .device_events
+                .iter()
+                .any(|event| event["event"] == "write_not_verified")
+        );
     }
 
     /// An unverified write leaves power unknown, so the next command still
@@ -3382,7 +3507,7 @@ mod tests {
             None,
         );
 
-        run_erv_boot_read_with(&config, &state, &writer).await;
+        run_erv_boot_read(&config, &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
     }

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -109,6 +109,16 @@ pub trait ErvSpeedWriter: Send + Sync {
     fn last_write_report(&self) -> ErvWriteReport {
         ErvWriteReport::default()
     }
+
+    /// Error text from the most recent local readback attempt, if it failed.
+    ///
+    /// Nothing polls any more, so a read-after-write is often the only local
+    /// read that happens. Without reporting it, a local key that dies after a
+    /// good boot read would fail every verification while `local_key_invalid`
+    /// and the degraded-readback notification stayed clear forever.
+    fn last_readback_failure(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Which transport issued a write.
@@ -306,6 +316,9 @@ struct SplitWriterState {
     /// enough to be used as a write fallback.
     consecutive_local_failures: u64,
     local_retry_at: Option<f64>,
+    /// Surfaced to the state layer so local-key health stays accurate now
+    /// that nothing polls. Cleared by a successful read.
+    readback_failure: Option<String>,
 }
 
 /// Splits the two transports by direction: writes go out over `writer` (the
@@ -401,8 +414,13 @@ impl SplitErvWriter {
     async fn read_local(&self, config: &ErvConfig) -> Result<ErvDeviceStatus> {
         let result = self.reader.read_status(config).await;
         self.record_local_outcome(result.is_ok());
-        if let Ok(status) = &result {
-            self.state().last_known_power = Some(status.power);
+        match &result {
+            Ok(status) => {
+                let mut state = self.state();
+                state.last_known_power = Some(status.power);
+                state.readback_failure = None;
+            }
+            Err(error) => self.state().readback_failure = Some(format!("{error:#}")),
         }
         result
     }
@@ -601,6 +619,10 @@ impl ErvSpeedWriter for SplitErvWriter {
     fn last_write_report(&self) -> ErvWriteReport {
         self.state().report
     }
+
+    fn last_readback_failure(&self) -> Option<String> {
+        self.state().readback_failure.clone()
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -776,7 +798,7 @@ impl ErvState {
         if !config.active_control_enabled {
             bail!("ERV active control is disabled");
         }
-        if !config.is_configured() {
+        if !config.write_transport_configured() {
             bail!("ERV control config is incomplete");
         }
 
@@ -840,7 +862,7 @@ impl ErvState {
         if !config.active_control_enabled {
             bail!("ERV active control is disabled");
         }
-        if !config.is_configured() {
+        if !config.write_transport_configured() {
             bail!("ERV control config is incomplete");
         }
 
@@ -905,6 +927,15 @@ impl ErvState {
                 } else {
                     self.record_status_success(status.clone(), report.source);
                     self.record_write_unverified(status.clone(), report, speed, reason, co2_ppm);
+                    self.notify_status();
+                }
+
+                // A read-after-write is often the only local read that happens
+                // now that nothing polls, so its failure has to reach the
+                // health counters or a dying local key would never be noticed.
+                if let Some(message) = writer.last_readback_failure()
+                    && self.record_read_only_local_failure(config, &message)
+                {
                     self.notify_status();
                 }
                 Ok(status)
@@ -988,7 +1019,7 @@ impl ErvState {
     where
         W: ErvSpeedWriter + ?Sized,
     {
-        if !config.is_configured() {
+        if !config.write_transport_configured() {
             bail!("ERV control config is incomplete");
         }
 
@@ -1379,10 +1410,12 @@ impl ErvState {
     /// A `(speed, pressure)` pair with no configured scene is a configuration
     /// hole, not a transient failure: surface it instead of letting it look
     /// like an ordinary cloud error.
+    ///
+    /// A hole stays reported until a write actually lands. An unrelated failure
+    /// -- a WAN outage on a configured scene, say -- is no evidence that anyone
+    /// went and built the missing scene, so it must not clear this.
     fn record_missing_scene(&self, error: &anyhow::Error) {
         let Some(missing) = error.downcast_ref::<MissingSceneError>() else {
-            let mut inner = self.inner.write().expect("ERV state lock poisoned");
-            inner.control.missing_scene = None;
             return;
         };
 
@@ -1428,13 +1461,15 @@ impl ErvState {
             inner.consecutive_scene_failures = 0;
             inner.next_write_retry_at = None;
 
-            if inner.control.missing_scene.take().is_some()
-                && inner.notification.as_ref().is_some_and(|notification| {
-                    notification.notification_type == "erv_scene_missing"
-                })
+            // Clear the alert alongside the flag, and independently of it, so
+            // neither piece can be stranded: a stale critical missing-scene
+            // notification would otherwise pin itself on clients forever.
+            inner.control.missing_scene = None;
+            if inner
+                .notification
+                .as_ref()
+                .is_some_and(|notification| notification.notification_type == "erv_scene_missing")
             {
-                // Clear the alert too, or clients keep showing a critical
-                // missing-scene notification after the scene is configured.
                 inner.notification = None;
             }
         }
@@ -3426,6 +3461,147 @@ mod tests {
 
         assert!(cloud.triggered_scenes().is_empty());
         assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+    }
+
+    /// Nothing polls any more, so a failed read-after-write is often the only
+    /// evidence that the local key has died. It has to reach the health
+    /// counters, or `local_key_invalid` and its notification stay clear while
+    /// every local read fails.
+    #[tokio::test]
+    async fn failed_readback_after_write_marks_the_local_key_invalid() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(
+                (0..LOCAL_KEY_ERROR_THRESHOLD * 2)
+                    .map(|_| bail!("Check device key or version (Error 914)"))
+                    .collect(),
+            )),
+            None,
+        );
+        let config = scene_config();
+
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            state
+                .set_speed_with(
+                    &config,
+                    &writer,
+                    ErvFanSpeed::Turbo,
+                    false,
+                    "manual_override",
+                    None,
+                )
+                .await
+                .expect("write succeeds while readback fails");
+            state.clear_read_backoff_for_test();
+        }
+
+        let mut app_status = Status::read_only_default(&app_config(config));
+        state.overlay_status(&mut app_status);
+        assert!(
+            app_status.erv.control.local_key_invalid,
+            "a local key failing every readback was never reported"
+        );
+        assert_eq!(
+            app_status.notifications[0].notification_type,
+            "erv_local_key_invalid"
+        );
+    }
+
+    /// A WAN outage on a configured scene is no evidence that anyone built the
+    /// missing one, so it must not clear the hole -- least of all leave the
+    /// flag cleared and the critical alert stranded.
+    #[tokio::test]
+    async fn unrelated_failure_does_not_strand_the_missing_scene_alert() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+        let config = ErvConfig {
+            local_readback_enabled: false,
+            ..scene_config()
+        };
+
+        // A hole in the matrix is reported.
+        state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                true,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("no negative-pressure turbo scene");
+
+        // Then an ordinary cloud failure on a configured scene.
+        state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("cloud is down");
+
+        let mut app_status = Status::read_only_default(&app_config(config));
+        state.overlay_status(&mut app_status);
+        assert_eq!(
+            app_status.erv.control.missing_scene.as_deref(),
+            Some("turbo (negative pressure)"),
+            "an unrelated failure cleared the missing-scene flag"
+        );
+        assert_eq!(
+            app_status.notifications[0].notification_type,
+            "erv_scene_missing"
+        );
+    }
+
+    /// Boot recovery needs the off scene, not the whole matrix. The write gate
+    /// must not reject the configuration the boot path deliberately permits.
+    #[tokio::test]
+    async fn boot_off_scene_survives_the_write_gate_without_local_credentials() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let config = app_config(ErvConfig {
+            // Scene-only deployment with one unrelated scene missing.
+            ip: String::new(),
+            device_id: String::new(),
+            local_key: String::new(),
+            quiet_scene_id: None,
+            ..scene_config()
+        });
+        assert!(
+            !config.erv.is_configured(),
+            "the strict gate would reject this"
+        );
+
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+
+        run_erv_boot_read(&config, &state, &writer).await;
+
+        assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
     }
 
     /// A scene the API accepted but the device ignored must not start the

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -395,6 +395,16 @@ impl SplitErvWriter {
             .is_none_or(|retry_at| unix_timestamp_now() >= retry_at)
     }
 
+    #[cfg(test)]
+    fn clear_local_backoff_for_test(&self) {
+        self.state().local_retry_at = None;
+    }
+
+    #[cfg(test)]
+    fn local_failure_count_for_test(&self) -> u64 {
+        self.state().consecutive_local_failures
+    }
+
     fn record_local_outcome(&self, succeeded: bool) {
         let mut state = self.state();
         if succeeded {
@@ -576,6 +586,13 @@ impl ErvSpeedWriter for SplitErvWriter {
                             tracing::warn!(
                                 "ERV scene trigger failed ({error:#}); wrote locally instead"
                             );
+                            // The local path demonstrably works. Without this
+                            // the old failure count survives, so the next
+                            // intermittent failure resumes the exponential
+                            // backoff where it left off and can disable the
+                            // fallback for an hour despite writes succeeding
+                            // in between.
+                            self.record_local_outcome(true);
                             let report = self
                                 .fallback
                                 .as_ref()
@@ -3846,6 +3863,55 @@ mod tests {
         run_erv_boot_read(&config, &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
+    }
+
+    /// A fallback write that lands proves local works, so the failure count
+    /// behind the backoff curve has to reset. Otherwise the next intermittent
+    /// failure resumes the exponential climb and can disable the fallback for
+    /// an hour despite successful local writes in between.
+    #[tokio::test]
+    async fn successful_fallback_write_resets_local_health() {
+        let cloud = Arc::new(FakeCloud::failing(3));
+        let local = Arc::new(FakeErvWriter::new(
+            Vec::new(),
+            vec![Ok(turbo_status()), Ok(turbo_status())],
+        ));
+        let writer = split_writer(
+            cloud.clone(),
+            // One failed read to put a failure on the books, then successes.
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Connection reset by peer"
+            ))])),
+            Some(local.clone()),
+        );
+        let config = ErvConfig {
+            local_readback_enabled: false,
+            ..scene_config()
+        };
+
+        // Seed a local failure, then let the backoff lapse.
+        assert!(
+            writer
+                .set_speed(&config, ErvFanSpeed::Turbo, false)
+                .await
+                .is_ok()
+        );
+        assert_eq!(local.write_speeds().len(), 1);
+        writer.clear_local_backoff_for_test();
+
+        // A second fallback write after the reset must still be attempted.
+        assert!(
+            writer
+                .set_speed(&config, ErvFanSpeed::Turbo, false)
+                .await
+                .is_ok()
+        );
+        assert_eq!(local.write_speeds().len(), 2);
+        assert_eq!(
+            writer.local_failure_count_for_test(),
+            0,
+            "a landed local write left the old failure count in place"
+        );
     }
 
     /// A failed fallback write means local is not usable either. Leaving it

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -110,13 +110,18 @@ pub trait ErvSpeedWriter: Send + Sync {
         ErvWriteReport::default()
     }
 
-    /// Error text from the most recent local readback attempt, if it failed.
+    /// Take the error from the most recent local readback attempt, if it
+    /// failed, clearing it.
     ///
     /// Nothing polls any more, so a read-after-write is often the only local
     /// read that happens. Without reporting it, a local key that dies after a
     /// good boot read would fail every verification while `local_key_invalid`
     /// and the degraded-readback notification stayed clear forever.
-    fn last_readback_failure(&self) -> Option<String> {
+    ///
+    /// Consuming is the point: while the writer is in read backoff it performs
+    /// no local I/O at all, so a value left in place would let one failure be
+    /// counted once per write and manufacture a key-invalid verdict.
+    fn take_readback_failure(&self) -> Option<String> {
         None
     }
 }
@@ -183,25 +188,44 @@ impl ErvCloudClient for SmartLifeErvCloud {
     }
 }
 
-/// A `(speed, pressure)` pair that resolved to no configured scene. Surfaced
-/// rather than silently substituted: a system that reports a mode it is not
-/// delivering is worse than one that reports an error.
+/// The scene path is not configured for this write.
+///
+/// Deterministic configuration errors, not outages: they are surfaced rather
+/// than silently substituted or written locally. A system that reports a mode
+/// it is not delivering is worse than one that reports an error, and falling
+/// back to a local command here would reintroduce the Err 914 path over a
+/// problem no retry can fix.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MissingSceneError {
-    pub preset: String,
+pub enum SceneConfigError {
+    /// No `smart_life_home_id`, so no scene can be triggered at all.
+    MissingHomeId,
+    /// A `(speed, pressure)` pair that resolved to no configured scene.
+    MissingScene { preset: String },
 }
 
-impl fmt::Display for MissingSceneError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "ERV Smart Life scene id for {} is not configured",
-            self.preset
-        )
+impl SceneConfigError {
+    /// Short label for `erv.control.missing_scene`.
+    fn subject(&self) -> String {
+        match self {
+            Self::MissingHomeId => "smart_life_home_id".to_string(),
+            Self::MissingScene { preset } => preset.clone(),
+        }
     }
 }
 
-impl std::error::Error for MissingSceneError {}
+impl fmt::Display for SceneConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingHomeId => write!(formatter, "ERV Smart Life home id is not configured"),
+            Self::MissingScene { preset } => write!(
+                formatter,
+                "ERV Smart Life scene id for {preset} is not configured"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SceneConfigError {}
 
 fn scene_preset_label(speed: ErvFanSpeed, negative_pressure: bool) -> String {
     if speed == ErvFanSpeed::Off || !negative_pressure {
@@ -215,7 +239,7 @@ fn scene_id_for(
     config: &ErvConfig,
     speed: ErvFanSpeed,
     negative_pressure: bool,
-) -> Result<&str, MissingSceneError> {
+) -> Result<&str, SceneConfigError> {
     let configured = match (speed, negative_pressure) {
         (ErvFanSpeed::Off, _) => &config.off_scene_id,
         (ErvFanSpeed::Quiet, false) => &config.quiet_scene_id,
@@ -230,7 +254,7 @@ fn scene_id_for(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| MissingSceneError {
+        .ok_or_else(|| SceneConfigError::MissingScene {
             preset: scene_preset_label(speed, negative_pressure),
         })
 }
@@ -286,7 +310,7 @@ impl ErvSpeedWriter for SceneErvSpeedWriter {
         Box::pin(async move {
             let home_id = config
                 .smart_life_home_id()
-                .ok_or_else(|| anyhow!("ERV Smart Life home id is missing"))?;
+                .ok_or(SceneConfigError::MissingHomeId)?;
             let preset = scene_preset_label(speed, negative_pressure);
             let scene_id = scene_id_for(config, speed, negative_pressure)?;
 
@@ -543,7 +567,7 @@ impl ErvSpeedWriter for SplitErvWriter {
                     // A hole in the scene matrix is a configuration error, not
                     // an outage. Writing it locally would deliver the speed
                     // while hiding the hole, so it has to propagate.
-                    if error.downcast_ref::<MissingSceneError>().is_some() {
+                    if error.downcast_ref::<SceneConfigError>().is_some() {
                         self.finish(primary_report, None);
                         return Err(error);
                     }
@@ -620,8 +644,8 @@ impl ErvSpeedWriter for SplitErvWriter {
         self.state().report
     }
 
-    fn last_readback_failure(&self) -> Option<String> {
-        self.state().readback_failure.clone()
+    fn take_readback_failure(&self) -> Option<String> {
+        self.state().readback_failure.take()
     }
 }
 
@@ -933,7 +957,7 @@ impl ErvState {
                 // A read-after-write is often the only local read that happens
                 // now that nothing polls, so its failure has to reach the
                 // health counters or a dying local key would never be noticed.
-                if let Some(message) = writer.last_readback_failure()
+                if let Some(message) = writer.take_readback_failure()
                     && self.record_read_only_local_failure(config, &message)
                 {
                     self.notify_status();
@@ -1043,6 +1067,12 @@ impl ErvState {
                 Ok(status)
             }
             Err(error) => {
+                // This failure is being recorded right here, so drain the
+                // writer's slot: it exists to carry failures the state layer
+                // has *not* seen, and leaving this one would let the write
+                // path count the same read a second time.
+                let _ = writer.take_readback_failure();
+
                 // A failed *read* backs off reads only. Letting it back off the
                 // write path is what coupled speed readback to control.
                 let message = format!("{error:#}");
@@ -1407,23 +1437,24 @@ impl ErvState {
         );
     }
 
-    /// A `(speed, pressure)` pair with no configured scene is a configuration
+    /// A scene path that is not configured for this write is a configuration
     /// hole, not a transient failure: surface it instead of letting it look
     /// like an ordinary cloud error.
     ///
     /// A hole stays reported until a write actually lands. An unrelated failure
     /// -- a WAN outage on a configured scene, say -- is no evidence that anyone
-    /// went and built the missing scene, so it must not clear this.
+    /// went and fixed the configuration, so it must not clear this.
     fn record_missing_scene(&self, error: &anyhow::Error) {
-        let Some(missing) = error.downcast_ref::<MissingSceneError>() else {
+        let Some(missing) = error.downcast_ref::<SceneConfigError>() else {
             return;
         };
 
+        let subject = missing.subject();
         let now = local_iso_now();
         {
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
-            inner.control.missing_scene = Some(missing.preset.clone());
-            inner.notification = Some(missing_scene_notification(&missing.preset, &now));
+            inner.control.missing_scene = Some(subject.clone());
+            inner.notification = Some(missing_scene_notification(missing, &now));
         }
 
         self.log_health_event(
@@ -1431,7 +1462,7 @@ impl ErvState {
             json!({
                 "type": "erv_scene_missing",
                 "at": now,
-                "preset": missing.preset,
+                "preset": subject,
             }),
         );
     }
@@ -2145,15 +2176,23 @@ fn recovered_notification(created_at: &str) -> AppNotification {
     }
 }
 
-fn missing_scene_notification(preset: &str, created_at: &str) -> AppNotification {
-    AppNotification {
-        id: format!("erv_scene_missing:{preset}:{created_at}"),
-        notification_type: "erv_scene_missing".to_string(),
-        severity: "critical".to_string(),
-        title: "ERV scene missing".to_string(),
-        message: format!(
+fn missing_scene_notification(error: &SceneConfigError, created_at: &str) -> AppNotification {
+    let subject = error.subject();
+    let message = match error {
+        SceneConfigError::MissingHomeId => {
+            "No Smart Life home id is configured, so no ERV scene can be triggered. Set erv.smart_life_home_id in config.yaml.".to_string()
+        }
+        SceneConfigError::MissingScene { preset } => format!(
             "No Smart Life scene is configured for {preset}, so that mode cannot be delivered. Scenes are hand-built in the Smart Life app; the API cannot create them."
         ),
+    };
+
+    AppNotification {
+        id: format!("erv_scene_missing:{subject}:{created_at}"),
+        notification_type: "erv_scene_missing".to_string(),
+        severity: "critical".to_string(),
+        title: "ERV scene control misconfigured".to_string(),
+        message,
         created_at: Some(created_at.to_string()),
         active: true,
         runbook_path: Some("docs/working/154_erv_scene_fallback.md".to_string()),
@@ -3264,7 +3303,7 @@ mod tests {
             .await
             .expect_err("a missing scene must not fall back to another preset");
 
-        assert!(error.downcast_ref::<MissingSceneError>().is_some());
+        assert!(error.downcast_ref::<SceneConfigError>().is_some());
         assert!(
             cloud.triggered_scenes().is_empty(),
             "the normal-pressure scene must not be substituted"
@@ -3510,6 +3549,83 @@ mod tests {
             app_status.notifications[0].notification_type,
             "erv_local_key_invalid"
         );
+    }
+
+    /// One failed read must be counted once. While the writer is in read
+    /// backoff it performs no local I/O at all, so a failure left in place
+    /// would be re-counted on every write and manufacture a key-invalid
+    /// verdict out of a single Err 914.
+    #[tokio::test]
+    async fn a_single_readback_failure_is_counted_once() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Check device key or version (Error 914)"
+            ))])),
+            None,
+        );
+        let config = scene_config();
+
+        // Both backoffs are left alone after this, so no further read happens.
+        for _ in 0..LOCAL_KEY_ERROR_THRESHOLD {
+            state
+                .set_speed_with(
+                    &config,
+                    &writer,
+                    ErvFanSpeed::Turbo,
+                    false,
+                    "manual_override",
+                    None,
+                )
+                .await
+                .expect("scene writes keep succeeding");
+        }
+
+        let mut app_status = Status::read_only_default(&app_config(config));
+        state.overlay_status(&mut app_status);
+        assert_eq!(
+            app_status.erv.control.consecutive_local_key_errors, 1,
+            "one failed read was counted more than once"
+        );
+        assert!(!app_status.erv.control.local_key_invalid);
+    }
+
+    /// A missing home id is as deterministic as a missing scene id, and just
+    /// as ineligible for a local fallback: no retry fixes configuration, and
+    /// the local command is the thing this design exists to never issue.
+    #[tokio::test]
+    async fn missing_home_id_fails_instead_of_falling_back_to_local() {
+        let cloud = Arc::new(FakeCloud::default());
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            Some(local.clone()),
+        );
+        let config = ErvConfig {
+            smart_life_home_id: None,
+            ..scene_config()
+        };
+
+        let error = writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect_err("no home id means no scene can be triggered");
+
+        assert_eq!(
+            error.downcast_ref::<SceneConfigError>(),
+            Some(&SceneConfigError::MissingHomeId)
+        );
+        assert!(
+            local.write_speeds().is_empty(),
+            "a configuration error must not be written away by the local fallback"
+        );
+        assert!(cloud.triggered_scenes().is_empty());
     }
 
     /// A WAN outage on a configured scene is no evidence that anyone built the
@@ -3793,7 +3909,7 @@ mod tests {
             .expect_err("an incomplete scene set must fail, not fall back to local");
 
         assert!(
-            error.downcast_ref::<MissingSceneError>().is_some(),
+            error.downcast_ref::<SceneConfigError>().is_some(),
             "expected a missing-scene diagnostic, got: {error:#}"
         );
     }

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -374,9 +374,19 @@ impl SplitErvWriter {
     fn finish(&self, report: ErvWriteReport, status: Option<&ErvDeviceStatus>) {
         let mut state = self.state();
         state.report = report;
-        if let Some(status) = status {
-            state.last_known_power = Some(status.power);
-        }
+        let Some(status) = status else {
+            // Nothing was commanded successfully, so power is whatever it was.
+            return;
+        };
+
+        // Only an observation may claim to know the power state. Trusting an
+        // assumed one would classify the next on-to-on command as speed-only
+        // and skip the cloud check, so an ERV that never ran the scene would
+        // keep being reported as ventilating.
+        state.last_known_power = match report.source {
+            ErvStatusSource::Local | ErvStatusSource::Cloud => Some(status.power),
+            ErvStatusSource::Assumed | ErvStatusSource::Unknown => None,
+        };
     }
 
     /// A power transition is the only change the cloud's `switch` bit can
@@ -1663,10 +1673,12 @@ fn sanitize_erv_error(message: &str) -> String {
 /// If the boot read fails and scenes can control the unit, force a known state
 /// by triggering the off scene rather than running blind.
 pub async fn run_erv_boot_read(config: &AppConfig, erv: &ErvState) {
-    let off_writer = config
-        .erv
-        .scene_control_active()
-        .then(|| build_erv_writer(config));
+    // Gate on the selected transport, not on a complete scene matrix: the off
+    // scene is the one this needs, and a hole elsewhere in the matrix is no
+    // reason to leave a possibly-running ERV in an unknown state. A missing
+    // off scene fails loudly on its own.
+    let off_writer =
+        (config.erv.control_mode == ErvControlMode::Scene).then(|| build_erv_writer(config));
     run_erv_boot_read_with(config, erv, &RustuyaErvStatusReader, off_writer.as_deref()).await;
 }
 
@@ -3183,6 +3195,82 @@ mod tests {
 
         assert!(cloud.triggered_scenes().is_empty());
         assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+    }
+
+    /// An unverified write leaves power unknown, so the next command still
+    /// pays for a cloud check. Trusting the assumption would let an ERV that
+    /// never ran the scene be reported as ventilating indefinitely.
+    #[tokio::test]
+    async fn assumed_status_does_not_count_as_known_power() {
+        let cloud = Arc::new(FakeCloud::default().with_power_reads(vec![
+            Err(anyhow!("Smart Life API error code=1106")),
+            Ok(Some(true)),
+        ]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                Err(anyhow!("Check device key or version (Error 914)")),
+                Err(anyhow!("Check device key or version (Error 914)")),
+            ])),
+            None,
+        );
+        let config = scene_config();
+
+        // Neither rung confirms anything, so the result is assumed.
+        writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect("scene write succeeds");
+        assert_eq!(cloud.power_reads(), 1);
+        assert_eq!(writer.last_write_report().source, ErvStatusSource::Assumed);
+
+        // Turbo -> medium is on-to-on, but power was never observed, so this
+        // must still be treated as worth a cloud check.
+        writer
+            .set_speed(&config, ErvFanSpeed::Medium, false)
+            .await
+            .expect("scene write succeeds");
+        assert_eq!(
+            cloud.power_reads(),
+            2,
+            "an assumed power state must not suppress cloud verification"
+        );
+        assert_eq!(writer.last_write_report().source, ErvStatusSource::Cloud);
+    }
+
+    /// The off scene is the only one boot recovery needs. A hole elsewhere in
+    /// the matrix is no reason to leave a possibly-running ERV unknown.
+    #[tokio::test]
+    async fn boot_off_scene_runs_with_a_partial_scene_matrix() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let config = app_config(ErvConfig {
+            quiet_scene_id: None,
+            ..scene_config()
+        });
+        assert!(
+            !config.erv.scene_configured(),
+            "the scene set is deliberately incomplete"
+        );
+
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            None,
+        );
+
+        run_erv_boot_read_with(
+            &config,
+            &state,
+            &FakeErvReader::new(vec![Err(anyhow!("Connection reset by peer"))]),
+            Some(&writer),
+        )
+        .await;
+
+        assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
     }
 
     /// A failed fallback write means local is not usable either. Leaving it

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -121,7 +121,7 @@ pub trait ErvSpeedWriter: Send + Sync {
     /// Consuming is the point: while the writer is in read backoff it performs
     /// no local I/O at all, so a value left in place would let one failure be
     /// counted once per write and manufacture a key-invalid verdict.
-    fn take_readback_failure(&self) -> Option<String> {
+    fn take_local_failure(&self) -> Option<String> {
         None
     }
 }
@@ -342,7 +342,7 @@ struct SplitWriterState {
     local_retry_at: Option<f64>,
     /// Surfaced to the state layer so local-key health stays accurate now
     /// that nothing polls. Cleared by a successful read.
-    readback_failure: Option<String>,
+    unreported_local_failure: Option<String>,
 }
 
 /// Splits the two transports by direction: writes go out over `writer` (the
@@ -452,9 +452,9 @@ impl SplitErvWriter {
             Ok(status) => {
                 let mut state = self.state();
                 state.last_known_power = Some(status.power);
-                state.readback_failure = None;
+                state.unreported_local_failure = None;
             }
-            Err(error) => self.state().readback_failure = Some(format!("{error:#}")),
+            Err(error) => self.state().unreported_local_failure = Some(format!("{error:#}")),
         }
         result
     }
@@ -606,6 +606,13 @@ impl ErvSpeedWriter for SplitErvWriter {
                             // exactly the command pattern that causes the
                             // Err 914 lockout.
                             self.record_local_outcome(false);
+                            // The outer report stays Scene, so without this the
+                            // state layer records a scene failure and the
+                            // local-key counters never move: /status would say
+                            // the local key is fine while the fallback is known
+                            // bad.
+                            self.state().unreported_local_failure =
+                                Some(format!("{fallback_error:#}"));
                             self.finish(primary_report, None);
                             return Err(error.context(format!(
                                 "ERV local write fallback also failed: {fallback_error:#}"
@@ -661,8 +668,8 @@ impl ErvSpeedWriter for SplitErvWriter {
         self.state().report
     }
 
-    fn take_readback_failure(&self) -> Option<String> {
-        self.state().readback_failure.take()
+    fn take_local_failure(&self) -> Option<String> {
+        self.state().unreported_local_failure.take()
     }
 }
 
@@ -983,14 +990,7 @@ impl ErvState {
                     self.notify_status();
                 }
 
-                // A read-after-write is often the only local read that happens
-                // now that nothing polls, so its failure has to reach the
-                // health counters or a dying local key would never be noticed.
-                if let Some(message) = writer.take_readback_failure()
-                    && self.record_read_only_local_failure(config, &message)
-                {
-                    self.notify_status();
-                }
+                self.record_unreported_local_failure(config, writer);
                 Ok(status)
             }
             Err(error) => {
@@ -1004,9 +1004,27 @@ impl ErvState {
                     }
                     ErvTransport::Scene => self.record_scene_failure(&message),
                 }
+                // A scene report can still hide a local failure underneath it:
+                // a fallback write that was attempted and failed.
+                self.record_unreported_local_failure(config, writer);
                 self.notify_status();
                 Err(error)
             }
+        }
+    }
+
+    /// Drain any local failure the writer saw that the state layer has not
+    /// recorded yet: a failed read-after-write, or a failed fallback write
+    /// hidden under a scene report. Nothing polls any more, so these are often
+    /// the only evidence that the local path has gone bad.
+    fn record_unreported_local_failure<W>(&self, config: &ErvConfig, writer: &W)
+    where
+        W: ErvSpeedWriter + ?Sized,
+    {
+        if let Some(message) = writer.take_local_failure()
+            && self.record_read_only_local_failure(config, &message)
+        {
+            self.notify_status();
         }
     }
 
@@ -1100,7 +1118,7 @@ impl ErvState {
                 // writer's slot: it exists to carry failures the state layer
                 // has *not* seen, and leaving this one would let the write
                 // path count the same read a second time.
-                let _ = writer.take_readback_failure();
+                let _ = writer.take_local_failure();
 
                 // A failed *read* backs off reads only. Letting it back off the
                 // write path is what coupled speed readback to control.
@@ -1970,9 +1988,36 @@ pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
         .await
         .context("Smart Life credentials are not usable")?;
 
+    // Every configured scene id must actually exist. A stale, deleted, or
+    // mistyped id otherwise passes validation and fails at the first
+    // ventilation request. Existence only -- what a scene *does* cannot be read
+    // back, which is why the ids are hand-built and verified physically.
+    let home_id = config
+        .erv
+        .smart_life_home_id()
+        .ok_or(SceneConfigError::MissingHomeId)?;
+    let present = client
+        .list_scene_ids(home_id)
+        .await
+        .context("Smart Life scene list failed")?;
+    let missing = configured_scene_ids(&config.erv)
+        .into_iter()
+        .filter(|(_, scene_id)| !present.iter().any(|found| found == scene_id))
+        .map(|(label, scene_id)| format!("{label}={scene_id}"))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!(
+            "configured ERV scene ids are not present in Smart Life home {home_id}: {}",
+            missing.join(", ")
+        );
+    }
+    let scene_count = configured_scene_ids(&config.erv).len();
+
     let device_id = config.erv.device_id.trim();
     if device_id.is_empty() {
-        return Ok(format!("Smart Life auth OK at {endpoint}"));
+        return Ok(format!(
+            "Smart Life auth OK at {endpoint}; {scene_count} scene ids present"
+        ));
     }
 
     let status = client
@@ -1983,7 +2028,40 @@ pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
         .and_then(value_as_bool)
         .map(|power| power.to_string())
         .unwrap_or_else(|| "unknown".to_string());
-    Ok(format!("Smart Life auth OK at {endpoint}; switch={power}"))
+    Ok(format!(
+        "Smart Life auth OK at {endpoint}; {scene_count} scene ids present; switch={power}"
+    ))
+}
+
+/// Every scene id the configuration actually sets, labelled by preset.
+fn configured_scene_ids(config: &ErvConfig) -> Vec<(&'static str, &str)> {
+    [
+        ("off", &config.off_scene_id),
+        ("quiet", &config.quiet_scene_id),
+        ("medium", &config.medium_scene_id),
+        ("turbo", &config.turbo_scene_id),
+        (
+            "quiet_negative_pressure",
+            &config.quiet_negative_pressure_scene_id,
+        ),
+        (
+            "medium_negative_pressure",
+            &config.medium_negative_pressure_scene_id,
+        ),
+        (
+            "turbo_negative_pressure",
+            &config.turbo_negative_pressure_scene_id,
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(label, configured)| {
+        configured
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|scene_id| (label, scene_id))
+    })
+    .collect()
 }
 
 pub async fn smoke_erv(config: &AppConfig) -> Result<ErvDeviceStatus> {
@@ -3991,6 +4069,51 @@ mod tests {
             .expect("a failed read must not block a scene write");
 
         assert_eq!(writer.write_speeds(), vec![ErvFanSpeed::Turbo]);
+    }
+
+    /// A failed fallback write is hidden under a Scene write report, so
+    /// without draining it the state layer records a scene failure and the
+    /// local-key counters never move -- `/status` would report the local key
+    /// as fine while the fallback path is known bad.
+    #[tokio::test]
+    async fn failed_fallback_write_reaches_the_local_key_counters() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let local = Arc::new(FakeErvWriter::new(
+            Vec::new(),
+            vec![Err(anyhow!("Check device key or version (Error 914)"))],
+        ));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(Vec::new())),
+            Some(local.clone()),
+        );
+        let config = ErvConfig {
+            local_readback_enabled: false,
+            ..scene_config()
+        };
+
+        state
+            .set_speed_with(
+                &config,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "manual_override",
+                None,
+            )
+            .await
+            .expect_err("both transports failed");
+
+        let mut app_status = Status::read_only_default(&app_config(config));
+        state.overlay_status(&mut app_status);
+        assert_eq!(
+            app_status.erv.control.consecutive_local_key_errors, 1,
+            "a failed local fallback never reached the local-key counters"
+        );
     }
 
     /// A fallback write that lands proves local works, so the failure count

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -1347,12 +1347,23 @@ impl ErvState {
     ) {
         self.record_status_success(device_status, report.source);
         {
-            // Only a landed write clears the write-path backoff. A successful
-            // read says nothing about whether the transport recovered.
+            // Only a landed write clears the write-path backoff and the
+            // missing-scene state. A successful read says nothing about
+            // whether the transport recovered or the scene hole was filled.
             let mut inner = self.inner.write().expect("ERV state lock poisoned");
             inner.last_speed_changed_at = Some(unix_timestamp_now());
             inner.consecutive_scene_failures = 0;
             inner.next_write_retry_at = None;
+
+            if inner.control.missing_scene.take().is_some()
+                && inner.notification.as_ref().is_some_and(|notification| {
+                    notification.notification_type == "erv_scene_missing"
+                })
+            {
+                // Clear the alert too, or clients keep showing a critical
+                // missing-scene notification after the scene is configured.
+                inner.notification = None;
+            }
         }
 
         if let Err(error) = db::log_climate_action(
@@ -1388,7 +1399,6 @@ impl ErvState {
             inner.control.status_source = source;
             inner.control.last_ok_at = Some(now.clone());
             inner.control.last_error = None;
-            inner.control.missing_scene = None;
             inner.control.using_cloud = source == ErvStatusSource::Cloud;
 
             if observed_locally {
@@ -1673,26 +1683,19 @@ fn sanitize_erv_error(message: &str) -> String {
 /// If the boot read fails and scenes can control the unit, force a known state
 /// by triggering the off scene rather than running blind.
 pub async fn run_erv_boot_read(config: &AppConfig, erv: &ErvState) {
-    // Gate on the selected transport, not on a complete scene matrix: the off
-    // scene is the one this needs, and a hole elsewhere in the matrix is no
-    // reason to leave a possibly-running ERV in an unknown state. A missing
-    // off scene fails loudly on its own.
-    let off_writer =
-        (config.erv.control_mode == ErvControlMode::Scene).then(|| build_erv_writer(config));
-    run_erv_boot_read_with(config, erv, &RustuyaErvStatusReader, off_writer.as_deref()).await;
+    run_erv_boot_read_with(config, erv, build_erv_writer(config).as_ref()).await;
 }
 
-pub(crate) async fn run_erv_boot_read_with<R, W>(
-    config: &AppConfig,
-    erv: &ErvState,
-    reader: &R,
-    off_writer: Option<&W>,
-) where
-    R: ErvStatusReader + ?Sized,
+/// The boot read goes through the *writer's* own read path, not a fresh
+/// reader, so a failure lands in that writer's local-health state. Otherwise a
+/// failed boot read followed by a failed off-scene trigger would find a
+/// pristine health gate and fire a local command at the path that just failed.
+pub(crate) async fn run_erv_boot_read_with<W>(config: &AppConfig, erv: &ErvState, writer: &W)
+where
     W: ErvSpeedWriter + ?Sized,
 {
     if config.erv.local_readback_active() {
-        match erv.refresh_with(&config.erv, reader).await {
+        match erv.smoke_status_with(&config.erv, writer).await {
             Ok(status) => {
                 tracing::info!(
                     "ERV boot read: running={} speed={}",
@@ -1710,15 +1713,26 @@ pub(crate) async fn run_erv_boot_read_with<R, W>(
         tracing::info!("ERV local readback is not configured; skipping the boot read");
     }
 
-    let Some(off_writer) = off_writer else { return };
-    if !config.erv.active_control_enabled {
+    // Gate on the selected transport, not on a complete scene matrix: the off
+    // scene is the one this needs, and a hole elsewhere in the matrix is no
+    // reason to leave a possibly-running ERV in an unknown state. A missing
+    // off scene fails loudly on its own.
+    if config.erv.control_mode != ErvControlMode::Scene || !config.erv.active_control_enabled {
+        return;
+    }
+
+    // Never overwrite a decision that has already been made. Callers are
+    // expected to run this before any policy input can arrive, but a forced
+    // off would be the wrong answer if one slipped through.
+    if erv.snapshot().last_speed_changed_at.is_some() {
+        tracing::info!("ERV boot recovery skipped; a speed was already commanded");
         return;
     }
 
     match erv
         .set_speed_with(
             &config.erv,
-            off_writer,
+            writer,
             ErvFanSpeed::Off,
             false,
             "boot_unknown_state",
@@ -3155,6 +3169,36 @@ mod tests {
             app_status.notifications[0].notification_type,
             "erv_scene_missing"
         );
+
+        // Once the scene is configured and a write lands, the critical alert
+        // has to go with it -- clearing only `missing_scene` would leave
+        // clients showing the alert forever.
+        let repaired = ErvConfig {
+            turbo_negative_pressure_scene_id: Some("turbo-np-scene".to_string()),
+            ..scene_config()
+        };
+        state
+            .set_speed_with(
+                &repaired,
+                &writer,
+                ErvFanSpeed::Turbo,
+                true,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect("write succeeds once the scene exists");
+
+        let mut app_status = Status::read_only_default(&app_config(repaired));
+        state.overlay_status(&mut app_status);
+        assert!(app_status.erv.control.missing_scene.is_none());
+        assert!(
+            app_status
+                .notifications
+                .iter()
+                .all(|notification| notification.notification_type != "erv_scene_missing"),
+            "a stale missing-scene alert survived recovery"
+        );
     }
 
     #[tokio::test]
@@ -3163,18 +3207,93 @@ mod tests {
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
         let state = ErvState::new(database_path);
-        let reader = FakeErvReader::new(vec![Err(anyhow!("Connection reset by peer"))]);
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(Vec::new())),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Connection reset by peer"
+            ))])),
             None,
         );
 
-        run_erv_boot_read_with(&app_config(scene_config()), &state, &reader, Some(&writer)).await;
+        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
         assert!(!state.snapshot().running);
+    }
+
+    /// The boot read must feed the writer's own local health. Otherwise a
+    /// failed boot read plus a failed off-scene trigger finds a pristine
+    /// health gate and fires a local command at the path that just failed --
+    /// the exact WAN-outage-plus-Err-914 case the gate exists for.
+    #[tokio::test]
+    async fn failed_boot_read_marks_local_unhealthy_for_the_fallback() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::failing(1));
+        let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Check device key or version (Error 914)"
+            ))])),
+            Some(local.clone()),
+        );
+
+        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
+
+        assert!(
+            local.write_speeds().is_empty(),
+            "a local path that just failed its read must not be used as a fallback"
+        );
+    }
+
+    /// Boot recovery must never overwrite a decision that has already landed.
+    #[tokio::test]
+    async fn boot_recovery_yields_to_an_already_commanded_speed() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let writer = split_writer(
+            cloud.clone(),
+            Arc::new(FakeErvReader::new(vec![
+                // Pre-write read: not at target, so the write actually goes.
+                Ok(medium_status()),
+                // Read-after-write.
+                Ok(turbo_status()),
+                // Boot read, which fails and would otherwise force off.
+                Err(anyhow!("Connection reset by peer")),
+            ])),
+            None,
+        );
+        let config = app_config(scene_config());
+
+        // A policy decision lands first.
+        state
+            .set_speed_with(
+                &config.erv,
+                &writer,
+                ErvFanSpeed::Turbo,
+                false,
+                "away_refresh",
+                None,
+            )
+            .await
+            .expect("policy write succeeds");
+        let triggered = cloud.triggered_scenes();
+
+        run_erv_boot_read_with(&config, &state, &writer).await;
+
+        assert_eq!(
+            cloud.triggered_scenes(),
+            triggered,
+            "boot recovery overwrote a newer policy decision"
+        );
+        assert_eq!(state.snapshot().speed, ErvFanSpeed::Turbo);
     }
 
     #[tokio::test]
@@ -3183,15 +3302,14 @@ mod tests {
         let database_path = temp_dir.path().join("office_climate.db");
         db::migrate_database(&database_path).expect("migration");
         let state = ErvState::new(database_path);
-        let reader = FakeErvReader::new(vec![Ok(medium_status())]);
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(Vec::new())),
+            Arc::new(FakeErvReader::new(vec![Ok(medium_status())])),
             None,
         );
 
-        run_erv_boot_read_with(&app_config(scene_config()), &state, &reader, Some(&writer)).await;
+        run_erv_boot_read_with(&app_config(scene_config()), &state, &writer).await;
 
         assert!(cloud.triggered_scenes().is_empty());
         assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
@@ -3258,17 +3376,13 @@ mod tests {
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(Vec::new())),
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Connection reset by peer"
+            ))])),
             None,
         );
 
-        run_erv_boot_read_with(
-            &config,
-            &state,
-            &FakeErvReader::new(vec![Err(anyhow!("Connection reset by peer"))]),
-            Some(&writer),
-        )
-        .await;
+        run_erv_boot_read_with(&config, &state, &writer).await;
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
     }

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -47,9 +47,7 @@ use crate::{
     blinds::{BlindsCommand, set_blinds},
     config::{AppConfig, ThresholdsConfig},
     db,
-    erv::{
-        ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, RustuyaErvSpeedWriter,
-    },
+    erv::{ERV_MANUAL_OVERRIDE_SECONDS, ErvFanSpeed, ErvSpeedWriter, ErvState, build_erv_writer},
     hvac::{
         HvacControlMode, HvacModeCommand, HvacModeWriter, HvacRuntimeSnapshot, HvacState,
         KumoHvacModeWriter,
@@ -293,6 +291,7 @@ fn try_app_with_state(
     erv_state: ErvState,
     hvac_state: HvacState,
 ) -> Result<Router> {
+    let erv_writer = build_erv_writer(&config);
     try_app_with_erv_writer(
         config,
         qingping,
@@ -300,7 +299,7 @@ fn try_app_with_state(
         yolink,
         erv_state,
         hvac_state,
-        Arc::new(RustuyaErvSpeedWriter),
+        erv_writer,
         Arc::new(KumoHvacModeWriter),
     )
 }
@@ -551,7 +550,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         yolink.clone(),
         erv_state.clone(),
         hvac_state.clone(),
-        Arc::new(RustuyaErvSpeedWriter),
+        build_erv_writer(&config),
         Arc::new(KumoHvacModeWriter),
     )
     .context("failed to build HTTP app state")?;
@@ -589,7 +588,12 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         Some(yolink_hvac_trigger),
     );
     let _door_grace_task = start_door_grace_policy_poll(app_state.clone(), erv_automation);
-    let _erv_task = crate::erv::start_erv_status_poll(&config, erv_state);
+    // One read at boot establishes true state; everything after is
+    // read-after-write. There is no status poll loop.
+    let _erv_boot_read = tokio::spawn({
+        let config = config.clone();
+        async move { crate::erv::run_erv_boot_read(&config, &erv_state).await }
+    });
     let _hvac_task = crate::hvac::start_hvac_status_poll(&config, hvac_state);
     let _presence_task = start_presence_poll(app_state);
 
@@ -1505,7 +1509,7 @@ async fn blinds(State(state): State<AppState>, Json(payload): Json<BlindsRequest
             .into_response();
     };
 
-    match set_blinds(&state.config.blinds, command).await {
+    match set_blinds(&state.config, command).await {
         Ok(()) => Json(json!({
             "ok": true,
             "blinds": {
@@ -3097,6 +3101,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -543,6 +543,9 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     let yolink = YoLinkState::new(state_machine.clone(), config.runtime.database_path.clone());
     let erv_state = ErvState::new(config.runtime.database_path.clone());
     let hvac_state = HvacState::new(config.runtime.database_path.clone());
+    // One writer for the whole process. A second instance carries its own
+    // local-health state, so a failure seen by one would not gate the other.
+    let erv_writer = build_erv_writer(&config);
     let (app_state, erv_automation) = build_app_state(
         config.clone(),
         qingping.clone(),
@@ -550,7 +553,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         yolink.clone(),
         erv_state.clone(),
         hvac_state.clone(),
-        build_erv_writer(&config),
+        erv_writer.clone(),
         Arc::new(KumoHvacModeWriter),
     )
     .context("failed to build HTTP app state")?;
@@ -561,7 +564,7 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     // its client starts, and boot recovery would then overwrite that newer
     // decision with the off scene and start the dwell timer from it -- leaving
     // an away office unventilated until the dwell expires.
-    crate::erv::run_erv_boot_read(&config, &erv_state).await;
+    crate::erv::run_erv_boot_read(&config, &erv_state, erv_writer.as_ref()).await;
 
     let runtime_handle = tokio::runtime::Handle::current();
     let qingping_policy_trigger: mqtt::SensorIngressHook = Arc::new({

--- a/rust/office-automate-server/src/http.rs
+++ b/rust/office-automate-server/src/http.rs
@@ -555,6 +555,14 @@ pub async fn serve(config: AppConfig) -> Result<()> {
     )
     .context("failed to build HTTP app state")?;
     let app = router_from_state(app_state.clone());
+
+    // Establish ERV state before anything that can produce a policy decision.
+    // A retained MQTT reading or a YoLink event can command a speed the moment
+    // its client starts, and boot recovery would then overwrite that newer
+    // decision with the off scene and start the dwell timer from it -- leaving
+    // an away office unventilated until the dwell expires.
+    crate::erv::run_erv_boot_read(&config, &erv_state).await;
+
     let runtime_handle = tokio::runtime::Handle::current();
     let qingping_policy_trigger: mqtt::SensorIngressHook = Arc::new({
         let erv_automation = erv_automation.clone();
@@ -588,12 +596,6 @@ pub async fn serve(config: AppConfig) -> Result<()> {
         Some(yolink_hvac_trigger),
     );
     let _door_grace_task = start_door_grace_policy_poll(app_state.clone(), erv_automation);
-    // One read at boot establishes true state; everything after is
-    // read-after-write. There is no status poll loop.
-    let _erv_boot_read = tokio::spawn({
-        let config = config.clone();
-        async move { crate::erv::run_erv_boot_read(&config, &erv_state).await }
-    });
     let _hvac_task = crate::hvac::start_hvac_status_poll(&config, hvac_state);
     let _presence_task = start_presence_poll(app_state);
 

--- a/rust/office-automate-server/src/hvac.rs
+++ b/rust/office-automate-server/src/hvac.rs
@@ -915,6 +915,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: crate::config::ErvConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: crate::config::MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),

--- a/rust/office-automate-server/src/lib.rs
+++ b/rust/office-automate-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod mqtt;
 pub mod policy;
 pub mod presence;
 pub mod qingping;
+pub mod smart_life;
 pub mod state;
 pub mod status;
 pub mod telemetry;

--- a/rust/office-automate-server/src/migration.rs
+++ b/rust/office-automate-server/src/migration.rs
@@ -909,6 +909,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: TelemetryConfig::default(),

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -106,6 +106,17 @@ impl SmartLifeClient {
             .ok_or_else(|| anyhow!("Smart Life returned no status for device {device_id}"))
     }
 
+    /// Read-only credential check: the cache is present, parseable, and its
+    /// refresh token is usable. Issues no device command.
+    pub async fn check_credentials(&self) -> Result<String> {
+        let _auth_guard = AUTH_CACHE_LOCK.lock().await;
+        let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
+        if self.refresh_auth_if_needed(&mut auth).await? {
+            auth.save(&self.auth_file)?;
+        }
+        Ok(auth.endpoint.clone())
+    }
+
     async fn call(
         &self,
         method: &str,

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -1,0 +1,543 @@
+//! Shared Smart Life (Tuya sharing API) client.
+//!
+//! The auth cache, token refresh, signing, and AES-GCM payload crypto are all
+//! device-agnostic, so blinds and the ERV share this module. Token refresh
+//! *rotates the refresh token*, which means two devices refreshing concurrently
+//! against the same cache file can clobber each other and lose cloud auth for
+//! both. Every load/refresh/save cycle therefore runs under `AUTH_CACHE_LOCK`.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+use aes_gcm::{
+    Aes128Gcm, Nonce,
+    aead::{Aead, KeyInit},
+};
+use anyhow::{Context, Result, anyhow, bail};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use hmac::{Hmac, Mac};
+use rand::Rng;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use tokio::sync::Mutex as AsyncMutex;
+use uuid::Uuid;
+
+/// Shared Home Assistant Tuya integration identifier. Not a secret, but a
+/// third-party constant that has changed before, so it lives in config with
+/// this value as the default.
+pub const DEFAULT_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
+
+const DEFAULT_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
+const SCENE_TRIGGER_PATH: &str = "/v1.0/m/scene/ha/trigger";
+const DEVICE_DETAIL_PATH: &str = "/v1.0/m/life/ha/devices/detail";
+
+/// Serializes the whole load -> refresh -> save cycle across every caller in
+/// the process. See the module docs for why this is not optional.
+static AUTH_CACHE_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub fn default_auth_file() -> PathBuf {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(DEFAULT_AUTH_FILE)
+}
+
+/// Resolve a configured auth-file override against the shared default path.
+pub fn auth_file_or_default(configured: Option<&PathBuf>) -> PathBuf {
+    configured.cloned().unwrap_or_else(default_auth_file)
+}
+
+pub struct SmartLifeClient {
+    http: Client,
+    client_id: String,
+    auth_file: PathBuf,
+}
+
+impl SmartLifeClient {
+    pub fn new(client_id: impl Into<String>, auth_file: PathBuf) -> Self {
+        Self {
+            http: Client::new(),
+            client_id: client_id.into(),
+            auth_file,
+        }
+    }
+
+    pub async fn get(&self, path: &str, params: Option<Value>) -> Result<Value> {
+        self.call("GET", path, params, None).await
+    }
+
+    pub async fn post(
+        &self,
+        path: &str,
+        params: Option<Value>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        self.call("POST", path, params, body).await
+    }
+
+    /// Run a tap-to-run scene. The trigger endpoint only names the scene; what
+    /// the scene does is stored server-side and is not constrained by what the
+    /// (lossy) scene read view can display.
+    pub async fn trigger_scene(&self, home_id: &str, scene_id: &str) -> Result<()> {
+        self.post(
+            SCENE_TRIGGER_PATH,
+            None,
+            Some(json!({"homeId": home_id, "sceneId": scene_id})),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Read a device's cloud status codes. The sharing API exposes only the
+    /// standard codes (`switch`, `mode`, air-quality values); private data
+    /// points such as the ERV speed DPs are never returned.
+    pub async fn device_status(&self, device_id: &str) -> Result<Value> {
+        let result = self
+            .get(DEVICE_DETAIL_PATH, Some(json!({"devIds": device_id})))
+            .await?;
+        device_status_codes(&result, device_id)
+            .ok_or_else(|| anyhow!("Smart Life returned no status for device {device_id}"))
+    }
+
+    async fn call(
+        &self,
+        method: &str,
+        path: &str,
+        params: Option<Value>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let _auth_guard = AUTH_CACHE_LOCK.lock().await;
+        let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
+        if self.refresh_auth_if_needed(&mut auth).await? {
+            auth.save(&self.auth_file)?;
+        }
+        self.request(&auth, method, path, params, body).await
+    }
+
+    /// Returns true when the cache was rotated and needs persisting.
+    async fn refresh_auth_if_needed(&self, auth: &mut SmartLifeAuthCache) -> Result<bool> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let expires_at = auth.token_info.t + auth.token_info.expire_time * 1_000;
+        if expires_at - 60_000 > now_ms {
+            return Ok(false);
+        }
+
+        let path = format!("/v1.0/m/token/{}", auth.token_info.refresh_token);
+        let result = self
+            .request(auth, "GET", &path, None, None)
+            .await
+            .context("failed to refresh Smart Life access token")?;
+        auth.token_info = SmartLifeTokenInfo {
+            t: chrono::Utc::now().timestamp_millis(),
+            expire_time: result
+                .get("expireTime")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing expireTime"))?,
+            uid: result
+                .get("uid")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing uid"))?
+                .to_string(),
+            access_token: result
+                .get("accessToken")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing accessToken"))?
+                .to_string(),
+            refresh_token: result
+                .get("refreshToken")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Smart Life token refresh missing refreshToken"))?
+                .to_string(),
+        };
+        Ok(true)
+    }
+
+    async fn request(
+        &self,
+        auth: &SmartLifeAuthCache,
+        method: &str,
+        path: &str,
+        params: Option<Value>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let request_id = Uuid::new_v4().to_string();
+        let hash_key = format!(
+            "{:x}",
+            md5::compute(format!("{}{}", request_id, auth.token_info.refresh_token))
+        );
+        let secret = smart_life_secret(&request_id, "", &hash_key)?;
+
+        let query_encdata = match params {
+            Some(params) => Some(encrypt_json(&params, &secret)?),
+            None => None,
+        };
+        let body_encdata = match body {
+            Some(body) => Some(encrypt_json(&body, &secret)?),
+            None => None,
+        };
+        let now_ms = chrono::Utc::now().timestamp_millis().to_string();
+        let sign = smart_life_sign(
+            &self.client_id,
+            &hash_key,
+            query_encdata.as_deref().unwrap_or_default(),
+            body_encdata.as_deref().unwrap_or_default(),
+            &auth.token_info.access_token,
+            &request_id,
+            &now_ms,
+        )?;
+
+        let url = format!("{}{}", auth.endpoint, path);
+        let mut request = match method {
+            "GET" => self.http.get(url),
+            "POST" => self.http.post(url),
+            _ => bail!("unsupported Smart Life method {method}"),
+        }
+        .header("X-appKey", &self.client_id)
+        .header("X-requestId", request_id)
+        .header("X-sid", "")
+        .header("X-time", now_ms)
+        .header("X-token", &auth.token_info.access_token)
+        .header("X-sign", sign);
+
+        if let Some(query_encdata) = query_encdata {
+            request = request.query(&[("encdata", query_encdata)]);
+        }
+        if let Some(body_encdata) = body_encdata {
+            request = request.json(&json!({ "encdata": body_encdata }));
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("Smart Life request failed")?
+            .error_for_status()
+            .context("Smart Life HTTP error")?;
+        let envelope: SmartLifeApiEnvelope = response
+            .json()
+            .await
+            .context("failed to parse Smart Life response")?;
+        if !envelope.success {
+            bail!(
+                "Smart Life API error code={} msg={}",
+                envelope
+                    .code
+                    .as_ref()
+                    .map(Value::to_string)
+                    .unwrap_or_else(|| "unknown".to_string()),
+                envelope
+                    .msg
+                    .as_ref()
+                    .map(Value::to_string)
+                    .unwrap_or_else(|| "unknown".to_string())
+            );
+        }
+
+        match envelope.result {
+            Some(Value::String(encrypted)) => decrypt_result(&encrypted, &secret),
+            Some(value) => Ok(value),
+            None => Ok(Value::Null),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct SmartLifeAuthCache {
+    user_code: String,
+    terminal_id: String,
+    endpoint: String,
+    token_info: SmartLifeTokenInfo,
+}
+
+impl SmartLifeAuthCache {
+    fn load(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read Smart Life auth cache {}", path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse Smart Life auth cache {}", path.display()))
+    }
+
+    fn save(&self, path: &Path) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)
+            .context("failed to serialize Smart Life auth cache")?;
+        fs::write(path, format!("{content}\n"))
+            .with_context(|| format!("failed to write Smart Life auth cache {}", path.display()))
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct SmartLifeTokenInfo {
+    t: i64,
+    expire_time: i64,
+    uid: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SmartLifeApiEnvelope {
+    success: bool,
+    result: Option<Value>,
+    code: Option<Value>,
+    msg: Option<Value>,
+}
+
+/// Pull the status codes for one device out of a `devices/detail` result. The
+/// endpoint answers with a bare list, or a wrapper object, depending on how
+/// many devices were asked for, so both shapes are accepted.
+fn device_status_codes(result: &Value, device_id: &str) -> Option<Value> {
+    let devices = match result {
+        Value::Array(devices) => devices.clone(),
+        Value::Object(object) => ["devices", "list", "data"]
+            .iter()
+            .find_map(|key| object.get(*key).and_then(Value::as_array).cloned())
+            .unwrap_or_else(|| vec![result.clone()]),
+        _ => return None,
+    };
+
+    devices
+        .into_iter()
+        .find(|device| {
+            ["id", "devId", "device_id"]
+                .iter()
+                .filter_map(|key| device.get(*key).and_then(Value::as_str))
+                .any(|value| value == device_id)
+        })
+        .and_then(|device| device.get("status").cloned())
+}
+
+/// Read one status code out of the `status` payload. It arrives either as a
+/// `{code, value}` list or as a flat code -> value map.
+pub fn status_code_value<'a>(status: &'a Value, code: &str) -> Option<&'a Value> {
+    if let Some(entries) = status.as_array() {
+        return entries
+            .iter()
+            .find(|entry| entry.get("code").and_then(Value::as_str) == Some(code))
+            .and_then(|entry| entry.get("value"));
+    }
+    status.get(code)
+}
+
+fn encrypt_json(value: &Value, secret: &str) -> Result<String> {
+    let raw = serde_json::to_string(value).context("failed to encode Smart Life payload")?;
+    let nonce = random_nonce();
+    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(nonce.as_bytes()), raw.as_bytes())
+        .map_err(|error| anyhow!("failed to encrypt Smart Life payload: {error}"))?;
+    Ok(format!(
+        "{}{}",
+        BASE64.encode(nonce.as_bytes()),
+        BASE64.encode(ciphertext)
+    ))
+}
+
+fn decrypt_result(encrypted: &str, secret: &str) -> Result<Value> {
+    let bytes = BASE64
+        .decode(encrypted)
+        .context("failed to decode Smart Life response")?;
+    if bytes.len() < 12 {
+        bail!("Smart Life response is too short");
+    }
+    let (nonce, ciphertext) = bytes.split_at(12);
+    let cipher = Aes128Gcm::new_from_slice(secret.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life AES key: {error}"))?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(nonce), ciphertext)
+        .map_err(|error| anyhow!("failed to decrypt Smart Life response: {error}"))?;
+    let text = String::from_utf8(plaintext).context("Smart Life response is not valid UTF-8")?;
+    serde_json::from_str(&text).or_else(|_| Ok(Value::String(text)))
+}
+
+fn random_nonce() -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
+    let mut rng = rand::thread_rng();
+    (0..12)
+        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+        .collect()
+}
+
+fn smart_life_secret(request_id: &str, sid: &str, hash_key: &str) -> Result<String> {
+    let mut message = hash_key.to_string();
+    if !sid.is_empty() {
+        let mut ecode = String::new();
+        for character in sid.chars().take(16) {
+            let index = character as usize % 16;
+            let selected = sid
+                .chars()
+                .nth(index)
+                .ok_or_else(|| anyhow!("invalid Smart Life sid"))?;
+            ecode.push(selected);
+        }
+        message.push('_');
+        message.push_str(&ecode);
+    }
+
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(request_id.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life HMAC key: {error}"))?;
+    mac.update(message.as_bytes());
+    let digest = mac.finalize().into_bytes();
+    Ok(to_lower_hex(&digest)[..16].to_string())
+}
+
+fn smart_life_sign(
+    client_id: &str,
+    hash_key: &str,
+    query_encdata: &str,
+    body_encdata: &str,
+    access_token: &str,
+    request_id: &str,
+    timestamp_ms: &str,
+) -> Result<String> {
+    let mut sign = format!(
+        "X-appKey={client_id}||X-requestId={request_id}||X-time={timestamp_ms}||X-token={access_token}"
+    );
+    sign.push_str(query_encdata);
+    sign.push_str(body_encdata);
+
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(hash_key.as_bytes())
+        .map_err(|error| anyhow!("invalid Smart Life sign key: {error}"))?;
+    mac.update(sign.as_bytes());
+    Ok(to_lower_hex(&mac.finalize().into_bytes()))
+}
+
+fn to_lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smart_life_crypto_matches_sdk_vectors() {
+        let secret = smart_life_secret(
+            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
+            "",
+            "4b7d14dca2d3df16b3a12219a47a7e56",
+        )
+        .expect("secret");
+        assert_eq!(secret, "60437f64b09370c5");
+
+        let sign = smart_life_sign(
+            DEFAULT_CLIENT_ID,
+            "4b7d14dca2d3df16b3a12219a47a7e56",
+            "",
+            "body-encdata",
+            "access-token",
+            "7aeb69e7-0132-4553-9eaf-8df515d7e6de",
+            "1783144312258",
+        )
+        .expect("sign");
+        assert_eq!(
+            sign,
+            "0b01f17ddcba9cd54e0305cdd53607ae3b877d88f84690fc406ee719fae94871"
+        );
+    }
+
+    #[test]
+    fn signs_with_the_configured_client_id() {
+        let default_sign = smart_life_sign(
+            DEFAULT_CLIENT_ID,
+            "hash-key",
+            "",
+            "",
+            "access-token",
+            "request-id",
+            "1783144312258",
+        )
+        .expect("sign");
+        let custom_sign = smart_life_sign(
+            "HA_other_client",
+            "hash-key",
+            "",
+            "",
+            "access-token",
+            "request-id",
+            "1783144312258",
+        )
+        .expect("sign");
+
+        assert_ne!(default_sign, custom_sign);
+    }
+
+    #[test]
+    fn reads_device_status_from_both_response_shapes() {
+        let listed = json!([
+            {"id": "other-device", "status": [{"code": "switch", "value": false}]},
+            {"id": "erv-device", "status": [{"code": "switch", "value": true}]},
+        ]);
+        let status = device_status_codes(&listed, "erv-device").expect("status");
+        assert_eq!(status_code_value(&status, "switch"), Some(&json!(true)));
+
+        let wrapped = json!({"devices": [{"devId": "erv-device", "status": {"switch": false}}]});
+        let status = device_status_codes(&wrapped, "erv-device").expect("status");
+        assert_eq!(status_code_value(&status, "switch"), Some(&json!(false)));
+
+        assert!(device_status_codes(&listed, "missing-device").is_none());
+    }
+
+    /// Token refresh rotates the refresh token. Two devices sharing the cache
+    /// file must not interleave load/save, or one rotation is lost and cloud
+    /// auth dies for both.
+    #[tokio::test]
+    async fn auth_cache_lock_serializes_concurrent_rotations() {
+        async fn rotate(path: PathBuf) {
+            let _auth_guard = AUTH_CACHE_LOCK.lock().await;
+            let mut auth = SmartLifeAuthCache::load(&path).expect("load");
+            // Stand in for the round trip a real refresh makes between reading
+            // the cache and writing the rotated token back.
+            tokio::task::yield_now().await;
+            auth.token_info.refresh_token.push('+');
+            auth.save(&path).expect("save");
+        }
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("tuya-sharing-auth.json");
+        let auth = SmartLifeAuthCache {
+            user_code: "user".to_string(),
+            terminal_id: "terminal".to_string(),
+            endpoint: "https://apigw.example".to_string(),
+            token_info: SmartLifeTokenInfo {
+                t: 0,
+                expire_time: 7200,
+                uid: "uid".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: "refresh".to_string(),
+            },
+        };
+        auth.save(&path).expect("seed");
+
+        let rotations = 8;
+        let handles = (0..rotations)
+            .map(|_| tokio::spawn(rotate(path.clone())))
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.await.expect("rotation task");
+        }
+
+        let final_auth = SmartLifeAuthCache::load(&path).expect("load");
+        assert_eq!(
+            final_auth.token_info.refresh_token,
+            format!("refresh{}", "+".repeat(rotations)),
+            "a concurrent refresh clobbered another rotation"
+        );
+    }
+
+    #[test]
+    fn auth_file_falls_back_to_the_shared_default() {
+        let configured = PathBuf::from("/tmp/office/auth.json");
+        assert_eq!(
+            auth_file_or_default(Some(&configured)),
+            PathBuf::from("/tmp/office/auth.json")
+        );
+        assert_eq!(auth_file_or_default(None), default_auth_file());
+    }
+}

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -34,7 +34,6 @@ pub const DEFAULT_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
 
 const DEFAULT_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
 const SCENE_TRIGGER_PATH: &str = "/v1.0/m/scene/ha/trigger";
-const SCENE_LIST_PATH: &str = "/v1.0/m/scene/ha/home/scenes";
 const DEVICE_DETAIL_PATH: &str = "/v1.0/m/life/ha/devices/detail";
 
 /// Serializes the whole load -> refresh -> save cycle across every caller in
@@ -96,31 +95,6 @@ impl SmartLifeClient {
         .map(|_| ())
     }
 
-    /// List the scene ids in a home.
-    ///
-    /// Existence only. The rendered *actions* of a scene are lossy -- the
-    /// sharing API hides the private speed data points there exactly as it
-    /// hides them in device status -- so nothing may be concluded from them
-    /// about what a scene does. An id being present is still worth knowing:
-    /// a deleted or mistyped one fails at the first ventilation request.
-    pub async fn list_scene_ids(&self, home_id: &str) -> Result<Vec<String>> {
-        let result = self
-            .get(SCENE_LIST_PATH, Some(json!({"homeId": home_id})))
-            .await?;
-        let scenes = result
-            .as_array()
-            .ok_or_else(|| anyhow!("Smart Life scene list is not an array"))?;
-        Ok(scenes
-            .iter()
-            .filter_map(|scene| {
-                ["scene_id", "sceneId", "id"]
-                    .iter()
-                    .find_map(|key| scene.get(*key).and_then(Value::as_str))
-                    .map(str::to_string)
-            })
-            .collect())
-    }
-
     /// Read a device's cloud status codes. The sharing API exposes only the
     /// standard codes (`switch`, `mode`, air-quality values); private data
     /// points such as the ERV speed DPs are never returned.
@@ -130,17 +104,6 @@ impl SmartLifeClient {
             .await?;
         device_status_codes(&result, device_id)
             .ok_or_else(|| anyhow!("Smart Life returned no status for device {device_id}"))
-    }
-
-    /// Read-only credential check: the cache is present, parseable, and its
-    /// refresh token is usable. Issues no device command.
-    pub async fn check_credentials(&self) -> Result<String> {
-        let _auth_guard = AUTH_CACHE_LOCK.lock().await;
-        let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
-        if self.refresh_auth_if_needed(&mut auth).await? {
-            auth.save(&self.auth_file)?;
-        }
-        Ok(auth.endpoint.clone())
     }
 
     async fn call(

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
 
 const DEFAULT_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
 const SCENE_TRIGGER_PATH: &str = "/v1.0/m/scene/ha/trigger";
+const SCENE_LIST_PATH: &str = "/v1.0/m/scene/ha/home/scenes";
 const DEVICE_DETAIL_PATH: &str = "/v1.0/m/life/ha/devices/detail";
 
 /// Serializes the whole load -> refresh -> save cycle across every caller in
@@ -93,6 +94,31 @@ impl SmartLifeClient {
         )
         .await
         .map(|_| ())
+    }
+
+    /// List the scene ids in a home.
+    ///
+    /// Existence only. The rendered *actions* of a scene are lossy -- the
+    /// sharing API hides the private speed data points there exactly as it
+    /// hides them in device status -- so nothing may be concluded from them
+    /// about what a scene does. An id being present is still worth knowing:
+    /// a deleted or mistyped one fails at the first ventilation request.
+    pub async fn list_scene_ids(&self, home_id: &str) -> Result<Vec<String>> {
+        let result = self
+            .get(SCENE_LIST_PATH, Some(json!({"homeId": home_id})))
+            .await?;
+        let scenes = result
+            .as_array()
+            .ok_or_else(|| anyhow!("Smart Life scene list is not an array"))?;
+        Ok(scenes
+            .iter()
+            .filter_map(|scene| {
+                ["scene_id", "sceneId", "id"]
+                    .iter()
+                    .find_map(|key| scene.get(*key).and_then(Value::as_str))
+                    .map(str::to_string)
+            })
+            .collect())
     }
 
     /// Read a device's cloud status codes. The sharing API exposes only the

--- a/rust/office-automate-server/src/status.rs
+++ b/rust/office-automate-server/src/status.rs
@@ -203,6 +203,34 @@ impl Default for ErvStatus {
     }
 }
 
+/// Where the reported ERV state came from. `Assumed` means the command was
+/// accepted but nothing could confirm it landed — reporting "we told it turbo"
+/// as if it were "the ERV is at turbo" is exactly the failure this marker
+/// exists to prevent.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ErvStatusSource {
+    #[default]
+    Unknown,
+    /// Observed over local Tuya: true supply/exhaust speeds.
+    Local,
+    /// Observed over the Smart Life cloud: power state only.
+    Cloud,
+    /// Not observed at all; the last command is being trusted.
+    Assumed,
+}
+
+impl ErvStatusSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Local => "local",
+            Self::Cloud => "cloud",
+            Self::Assumed => "assumed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ErvControlStatus {
     pub last_ok_at: Option<String>,
@@ -213,6 +241,10 @@ pub struct ErvControlStatus {
     pub local_key_invalid: bool,
     pub local_key_invalid_since: Option<String>,
     pub consecutive_local_key_errors: u64,
+    /// Provenance of `ErvStatus.running` / `ErvStatus.speed`.
+    pub status_source: ErvStatusSource,
+    /// Set when a `(speed, pressure)` pair resolved to no configured scene.
+    pub missing_scene: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -315,6 +347,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             blinds: BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig {
                 hvac_heat_on_temp_f: 70,

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1486,6 +1486,13 @@ async fn validate_live_devices(
         if erv_local_credentials_required(&config.erv) {
             bail!("shadow validation requires a configured ERV control path");
         }
+        // Scene ids being non-empty strings proves nothing about whether the
+        // transport works. This is a cutover gate, so exercise the credentials
+        // that every ERV command depends on.
+        let detail = erv::smoke_erv_scene(config)
+            .await
+            .context("ERV Smart Life scene credential check failed")?;
+        report.push_pass("erv-scene-auth", detail);
         report.push_skip(
             "erv-read",
             "ERV local read credentials are not configured; scene control does not need them",

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1469,23 +1469,32 @@ async fn validate_live_devices(
     config: &AppConfig,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
-    if !config.erv.is_configured() {
-        bail!("shadow validation requires configured ERV read credentials");
+    // Local credentials buy speed readback, not control, so their absence is a
+    // skipped check rather than a failed validation.
+    if !config.erv.local_tuya_configured() {
+        if !config.erv.is_configured() {
+            bail!("shadow validation requires a configured ERV control path");
+        }
+        report.push_skip(
+            "erv-read",
+            "ERV local read credentials are not configured; scene control does not need them",
+        );
+    } else {
+        let erv_status = erv::smoke_erv(config)
+            .await
+            .context("ERV read-only smoke check failed")?;
+        report.push_pass(
+            "erv-read",
+            format!(
+                "read local status: running={} speed={}",
+                erv_status.power,
+                erv_status
+                    .fan_speed
+                    .map(|speed| speed.as_str())
+                    .unwrap_or("unknown")
+            ),
+        );
     }
-    let erv_status = erv::smoke_erv(config)
-        .await
-        .context("ERV read-only smoke check failed")?;
-    report.push_pass(
-        "erv-read",
-        format!(
-            "read local status: running={} speed={}",
-            erv_status.power,
-            erv_status
-                .fan_speed
-                .map(|speed| speed.as_str())
-                .unwrap_or("unknown")
-        ),
-    );
 
     if !config.mitsubishi.is_configured() {
         bail!("shadow validation requires configured HVAC read credentials");
@@ -3413,6 +3422,7 @@ mod tests {
             cloudflare_access: crate::config::CloudflareAccessConfig::default(),
             erv: ErvConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             mitsubishi: MitsubishiConfig::default(),
             thresholds: ThresholdsConfig::default(),
             telemetry: crate::config::TelemetryConfig::default(),

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1482,17 +1482,23 @@ async fn validate_live_devices(
     // Local credentials buy speed readback, not control, so their absence is a
     // skipped check rather than a failed validation -- but only when the
     // selected transport genuinely does not need them.
+    // Validate whichever transport will actually issue writes, independently
+    // of the optional local read below. Scene ids being non-empty strings
+    // proves nothing about whether the transport works, and this is a cutover
+    // gate -- the deployed config has local credentials *and* scene control,
+    // so keying this off the absence of local credentials checked everything
+    // except the path in use.
+    if config.erv.scene_control_active() {
+        let detail = erv::smoke_erv_scene(config)
+            .await
+            .context("ERV Smart Life scene check failed")?;
+        report.push_pass("erv-scene-auth", detail);
+    }
+
     if !config.erv.local_tuya_configured() {
         if erv_local_credentials_required(&config.erv) {
             bail!("shadow validation requires a configured ERV control path");
         }
-        // Scene ids being non-empty strings proves nothing about whether the
-        // transport works. This is a cutover gate, so exercise the credentials
-        // that every ERV command depends on.
-        let detail = erv::smoke_erv_scene(config)
-            .await
-            .context("ERV Smart Life scene credential check failed")?;
-        report.push_pass("erv-scene-auth", detail);
         report.push_skip(
             "erv-read",
             "ERV local read credentials are not configured; scene control does not need them",

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1479,20 +1479,20 @@ async fn validate_live_devices(
     config: &AppConfig,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
-    // Local credentials buy speed readback, not control, so their absence is a
-    // skipped check rather than a failed validation -- but only when the
-    // selected transport genuinely does not need them.
-    // Validate whichever transport will actually issue writes, independently
-    // of the optional local read below. Scene ids being non-empty strings
-    // proves nothing about whether the transport works, and this is a cutover
-    // gate -- the deployed config has local credentials *and* scene control,
-    // so keying this off the absence of local credentials checked everything
-    // except the path in use.
+    // Check whichever transport will actually issue writes, independently of
+    // the optional local read below: the deployed config has local credentials
+    // *and* scene control, so keying this off the absence of local credentials
+    // would check everything except the path in use.
+    //
+    // Configuration only. Whether the credentials work and the scene ids still
+    // exist needs a live Smart Life call, which is tracked separately.
     if config.erv.scene_control_selected() {
-        let detail = erv::smoke_erv_scene(config)
-            .await
-            .context("ERV Smart Life scene check failed")?;
-        report.push_pass("erv-scene-auth", detail);
+        let checked =
+            erv::check_erv_scene_config(config).context("ERV scene configuration is incomplete")?;
+        report.push_pass(
+            "erv-scene-config",
+            format!("{checked} required scene ids configured (not verified live)"),
+        );
     }
 
     if !config.erv.local_tuya_configured() {

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -33,7 +33,7 @@ use tokio_tungstenite::{
 use crate::{
     artifacts::{is_valid_artifact_hash, is_valid_sha256_digest, normalize_cert_digest},
     auth::AuthManager,
-    config::{AppConfig, OrchestratorConfig},
+    config::{AppConfig, ErvConfig, OrchestratorConfig},
     db, edge, erv, http, hvac,
     state::StateMachine,
     yolink::{self, YoLinkCloudClient, YoLinkState},
@@ -1465,14 +1465,25 @@ fn validate_sqlite_quick_check(path: &Path, label: &str) -> Result<()> {
     Ok(())
 }
 
+/// Whether missing local ERV credentials should fail validation.
+///
+/// Only a fully configured scene transport can do without them. In
+/// `control_mode: local` they are the control path, and a complete scene set
+/// does not substitute for them -- the selected writer would reject every
+/// command as incomplete local configuration.
+fn erv_local_credentials_required(config: &ErvConfig) -> bool {
+    !config.scene_control_active()
+}
+
 async fn validate_live_devices(
     config: &AppConfig,
     report: &mut ShadowValidationReport,
 ) -> Result<()> {
     // Local credentials buy speed readback, not control, so their absence is a
-    // skipped check rather than a failed validation.
+    // skipped check rather than a failed validation -- but only when the
+    // selected transport genuinely does not need them.
     if !config.erv.local_tuya_configured() {
-        if !config.erv.is_configured() {
+        if erv_local_credentials_required(&config.erv) {
             bail!("shadow validation requires a configured ERV control path");
         }
         report.push_skip(
@@ -3406,6 +3417,37 @@ mod tests {
     };
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    /// Missing local credentials are only acceptable when a complete scene
+    /// transport is what will actually issue the writes.
+    #[test]
+    fn erv_local_credentials_are_required_unless_scene_control_is_complete() {
+        use crate::config::ErvControlMode;
+
+        let scenes = ErvConfig {
+            smart_life_home_id: Some("home-id".to_string()),
+            off_scene_id: Some("off-scene".to_string()),
+            quiet_scene_id: Some("quiet-scene".to_string()),
+            medium_scene_id: Some("medium-scene".to_string()),
+            turbo_scene_id: Some("turbo-scene".to_string()),
+            ..ErvConfig::default()
+        };
+
+        assert!(!erv_local_credentials_required(&scenes));
+
+        // A complete scene set does not substitute for local credentials when
+        // local is the selected transport.
+        assert!(erv_local_credentials_required(&ErvConfig {
+            control_mode: ErvControlMode::Local,
+            ..scenes.clone()
+        }));
+
+        // Nor does an incomplete one in scene mode.
+        assert!(erv_local_credentials_required(&ErvConfig {
+            turbo_scene_id: None,
+            ..scenes
+        }));
+    }
 
     fn test_config(database_path: &Path) -> AppConfig {
         let root = database_path

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1472,7 +1472,7 @@ fn validate_sqlite_quick_check(path: &Path, label: &str) -> Result<()> {
 /// does not substitute for them -- the selected writer would reject every
 /// command as incomplete local configuration.
 fn erv_local_credentials_required(config: &ErvConfig) -> bool {
-    !config.scene_control_active()
+    !config.scene_control_selected()
 }
 
 async fn validate_live_devices(
@@ -1488,7 +1488,7 @@ async fn validate_live_devices(
     // gate -- the deployed config has local credentials *and* scene control,
     // so keying this off the absence of local credentials checked everything
     // except the path in use.
-    if config.erv.scene_control_active() {
+    if config.erv.scene_control_selected() {
         let detail = erv::smoke_erv_scene(config)
             .await
             .context("ERV Smart Life scene check failed")?;
@@ -3431,10 +3431,12 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
-    /// Missing local credentials are only acceptable when a complete scene
-    /// transport is what will actually issue the writes.
+    /// Missing local credentials are acceptable exactly when scene control is
+    /// the selected transport. An incomplete scene matrix is not this check's
+    /// problem -- local credentials would not fix it, and `smoke_erv_scene`
+    /// rejects it directly -- so this must not demand them as a substitute.
     #[test]
-    fn erv_local_credentials_are_required_unless_scene_control_is_complete() {
+    fn erv_local_credentials_are_required_unless_scene_control_is_selected() {
         use crate::config::ErvControlMode;
 
         let scenes = ErvConfig {
@@ -3455,8 +3457,9 @@ mod tests {
             ..scenes.clone()
         }));
 
-        // Nor does an incomplete one in scene mode.
-        assert!(erv_local_credentials_required(&ErvConfig {
+        // An incomplete matrix in scene mode is rejected by the scene check
+        // itself, so this must not ask for local credentials instead.
+        assert!(!erv_local_credentials_required(&ErvConfig {
             turbo_scene_id: None,
             ..scenes
         }));

--- a/rust/office-automate-server/src/yolink.rs
+++ b/rust/office-automate-server/src/yolink.rs
@@ -1014,6 +1014,7 @@ mod tests {
             },
             mitsubishi: MitsubishiConfig::default(),
             blinds: crate::config::BlindsConfig::default(),
+            smart_life: crate::config::SmartLifeConfig::default(),
             thresholds: ThresholdsConfig {
                 erv_min_dwell_seconds: 0,
                 ..ThresholdsConfig::default()

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -116,9 +116,18 @@ def read_erv_config(config_file: Path) -> tuple[str, str | None]:
 def read_client_id(config_file: Path) -> str:
     """Resolve the Smart Life client id, falling back when config is unreadable.
 
+    Environment beats YAML, matching the server's precedence. Otherwise a
+    deployment configured through OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID would
+    have this script mint credentials for one app key while the server signed
+    with another -- the drift this shared key exists to prevent.
+
     --init-auth runs before there is necessarily a usable config, so a missing
     or malformed file must not block authorization.
     """
+    env_client_id = os.environ.get("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID")
+    if env_client_id and env_client_id.strip():
+        return env_client_id.strip()
+
     try:
         _, data = load_config_data(config_file)
     except RefreshError:

--- a/scripts/refresh-erv-key.py
+++ b/scripts/refresh-erv-key.py
@@ -24,7 +24,11 @@ except ImportError:  # pragma: no cover - exercised by users without deps instal
     SharingTokenListener = object
 
 
-CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
+# Shared Home Assistant Tuya integration identifier. Not a secret, but it has
+# changed before, so config.yaml wins over this fallback -- the server reads the
+# same `smart_life.client_id` key, and the two copies must not drift.
+DEFAULT_CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
+CLIENT_ID = DEFAULT_CLIENT_ID
 SCHEMA = "haauthorize"
 DEFAULT_AUTH_FILE = Path.home() / ".office-automate" / "tuya-sharing-auth.json"
 DEFAULT_CONFIG_FILE = Path("config.yaml")
@@ -107,6 +111,25 @@ def read_device_config(config_file: Path, section: str) -> tuple[str, str | None
 
 def read_erv_config(config_file: Path) -> tuple[str, str | None]:
     return read_device_config(config_file, "erv")
+
+
+def read_client_id(config_file: Path) -> str:
+    """Resolve the Smart Life client id, falling back when config is unreadable.
+
+    --init-auth runs before there is necessarily a usable config, so a missing
+    or malformed file must not block authorization.
+    """
+    try:
+        _, data = load_config_data(config_file)
+    except RefreshError:
+        return DEFAULT_CLIENT_ID
+
+    section = data.get("smart_life")
+    if isinstance(section, dict):
+        client_id = section.get("client_id")
+        if isinstance(client_id, str) and client_id.strip():
+            return client_id.strip()
+    return DEFAULT_CLIENT_ID
 
 
 def update_config_local_key(config_file: Path, section: str, new_local_key: str) -> None:
@@ -648,6 +671,9 @@ def main(
         parser.error("--restart requires --update-config")
     if args.init_auth and not args.user_code:
         parser.error("--init-auth requires --user-code")
+
+    global CLIENT_ID
+    CLIENT_ID = read_client_id(args.config)
 
     try:
         if args.init_auth:

--- a/tests/test_refresh_erv_key.py
+++ b/tests/test_refresh_erv_key.py
@@ -443,3 +443,28 @@ def test_restart_uses_current_launchd_server_label(monkeypatch):
             True,
         )
     ]
+
+
+def test_client_id_precedence_matches_the_server(tmp_path, monkeypatch):
+    """Environment beats YAML beats the built-in default.
+
+    The server applies the same precedence. If this script disagreed, it would
+    mint credentials for one app key while the server signed requests with
+    another -- the drift the shared config key exists to prevent.
+    """
+    module = load_script_module()
+    config_file = tmp_path / "config.yaml"
+
+    # No config file at all: --init-auth must still work off the default.
+    monkeypatch.delenv("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID", raising=False)
+    assert module.read_client_id(config_file) == module.DEFAULT_CLIENT_ID
+
+    config_file.write_text('smart_life:\n  client_id: "HA_from_yaml"\n', encoding="utf-8")
+    assert module.read_client_id(config_file) == "HA_from_yaml"
+
+    monkeypatch.setenv("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID", "HA_from_env")
+    assert module.read_client_id(config_file) == "HA_from_env"
+
+    # Blank env is not an override.
+    monkeypatch.setenv("OFFICE_AUTOMATE_SMART_LIFE_CLIENT_ID", "   ")
+    assert module.read_client_id(config_file) == "HA_from_yaml"


### PR DESCRIPTION
## Summary

Moves ERV writes onto Smart Life tap-to-run scenes and makes local Tuya read-only, so a stale local key costs speed readback instead of all control. Also removes the status poll loop that aggravated the Err 914 failure mode.

The two transports are split by **direction**, not preference order:

| Trait method | Transport | Effect |
|---|---|---|
| `set_speed` | Smart Life scene trigger | no local command is ever issued |
| `smoke_status` | local Tuya read | read-only; the only view of DP 101/102 |

## Spec Reference

`docs/working/154_erv_scene_fallback.md` (the spec commit rides along on this branch — it was never merged separately).

## What changed

1. **`src/smart_life.rs`** — extracted from `blinds.rs`: auth cache, token refresh, request signing, AES-GCM payload crypto. The whole load → refresh → save cycle runs under a process-wide async mutex, because token refresh *rotates the refresh token* and two devices sharing one cache file would clobber each other. The Smart Life client id moved into config (`smart_life.client_id`), read by both the server and `scripts/refresh-erv-key.py` so the two copies cannot drift.
2. **`SceneErvSpeedWriter`** triggers a scene and nothing else. **`SplitErvWriter`** runs the verification ladder afterwards: local read → cloud `switch` bit (power transitions only; it is uninformative on speed-only changes) → assumed. A failed verification never fails the write.
3. **Automatic local-write fallback** when a scene trigger fails and the local path is healthy. No prompt, no toggle.
4. **Gates re-scoped** (§6): a failed local *read* now backs off reads only, `local_key_invalid` bails no write path, and the pre-write read became an optimisation instead of a prerequisite. The same coupling is fixed in `ErvPolicyCoordinator`, where a failed smoke read used to abort policy evaluation entirely.
5. **Poll loop removed**, replaced by a boot read plus read-after-write: 288–1440 local reads/day down to roughly the number of writes. If the boot read fails, the off scene forces a known state.
6. **Status and notifications**: `erv.control.status_source` (`local` | `cloud` | `assumed` | `unknown`) and `erv.control.missing_scene`. `erv_local_key_invalid` is now a warning about degraded readback when scene control is active, still critical in `control_mode: local`.

## Deviations from the spec (flagged, not silent)

- **`config.yaml` on the host had `local_write_fallback_enabled: false`** while the spec calls for `true`. I encoded `true` in `ErvConfig::default()` per spec §Config and set the host file to match. Worth a second look if the `false` was deliberate.
- **`smoke_local_key_failures_close_active_write_gate` was rewritten**, not kept. It asserted exactly the behaviour §6 removes (an invalid local key closing the write gate). It is now `local_key_failures_degrade_readback_without_closing_the_write_gate` and asserts the opposite. Same for `automated_policy_write_respects_local_failure_backoff` in `automation.rs`.
- **`erv.poll_interval_seconds` / `erv.idle_poll_interval_seconds` were removed** along with their env overrides. Nothing read them once the poll loop was gone, and leaving dead knobs in config invites someone to tune them and wonder why nothing happens.
- **Provenance rides on one new *defaulted* trait method** (`last_write_report`), not on a changed signature or a new field on `ErvDeviceStatus`. Both required methods are unchanged and every existing `FakeErvWriter` compiles untouched, which is what §1 was protecting.

## Test Plan

- [x] `cargo test --all-targets` — 361 passed, 0 failed
- [x] `cargo fmt`, `cargo clippy --all-targets` (45 warnings vs 46 on `main`; no new ones)
- [x] `python -m pytest tests/test_refresh_erv_key.py` — 12 passed
- [x] Every case in the spec Testing section is covered:
  - default config issues a scene trigger and **no local command** (asserts the local writer is never invoked)
  - scene write + local read → source `Local`, real supply/exhaust
  - scene write + failed read → write succeeds, source `Assumed`
  - `local_key_invalid` does not block a scene write
  - scene fails + local healthy → automatic local write
  - scene fails + local unhealthy → error surfaced
  - cloud verification used on power transitions, skipped on speed-only changes
  - missing `(speed, pressure)` scene fails loudly and lands in status
  - concurrent auth-cache rotation does not lose the refresh token
  - boot read establishes state; forces the off scene when it fails
- [ ] **Manual, still outstanding:** trigger each speed and confirm supply/exhaust on the unit's display. No automated check can observe speed through the cloud, and I have not run this against the live device.

Fixes #154