### PR TITLE
ERV: restore live verification of the Smart Life scene transport

### DIFF
--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -2021,6 +2021,104 @@ pub fn check_erv_scene_config(config: &AppConfig) -> Result<usize> {
     Ok(required.len())
 }
 
+/// Live check of the Smart Life scene transport: credentials, scene id
+/// existence, and (if a device id is configured) a device read.
+///
+/// `check_erv_scene_config` proves the matrix is filled in; it proves nothing
+/// about whether any of it works. The auth cache can be missing, unreadable,
+/// or holding a dead refresh token, and a configured scene id can be stale,
+/// deleted, or mistyped -- none of that shows up until the first ventilation
+/// request. This exercises the credentials and confirms every configured
+/// scene id still exists in Smart Life, without commanding the device.
+///
+/// Existence only, per the Hard Constraints in the ERV design doc: the scene
+/// read view renders every ERV speed scene's action identically, so nothing
+/// may be concluded from it about what a scene *does*. That is verifiable
+/// only physically, at the unit.
+pub async fn smoke_erv_scene(config: &AppConfig) -> Result<String> {
+    let scene_count = check_erv_scene_config(config)?;
+
+    let client = SmartLifeClient::new(
+        config.smart_life.client_id.clone(),
+        auth_file_or_default(config.erv.smart_life_auth_file.as_ref()),
+    );
+    let endpoint = client
+        .check_credentials()
+        .await
+        .context("Smart Life credentials are not usable")?;
+
+    // check_erv_scene_config already confirmed a home id is configured.
+    let home_id = config
+        .erv
+        .smart_life_home_id()
+        .ok_or(SceneConfigError::MissingHomeId)?;
+    let present = client
+        .list_scene_ids(home_id)
+        .await
+        .context("Smart Life scene list failed")?;
+    let missing = configured_scene_ids(&config.erv)
+        .into_iter()
+        .filter(|(_, scene_id)| !present.iter().any(|found| found == scene_id))
+        .map(|(label, scene_id)| format!("{label}={scene_id}"))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!(
+            "configured ERV scene ids are not present in Smart Life home {home_id}: {}",
+            missing.join(", ")
+        );
+    }
+
+    let device_id = config.erv.device_id.trim();
+    if device_id.is_empty() {
+        return Ok(format!(
+            "Smart Life auth OK at {endpoint}; {scene_count} scene ids present"
+        ));
+    }
+
+    let status = client
+        .device_status(device_id)
+        .await
+        .context("Smart Life device read failed")?;
+    let power = status_code_value(&status, "switch")
+        .and_then(value_as_bool)
+        .map(|power| power.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    Ok(format!(
+        "Smart Life auth OK at {endpoint}; {scene_count} scene ids present; switch={power}"
+    ))
+}
+
+/// Every scene id the configuration actually sets, labelled by preset.
+fn configured_scene_ids(config: &ErvConfig) -> Vec<(&'static str, &str)> {
+    [
+        ("off", &config.off_scene_id),
+        ("quiet", &config.quiet_scene_id),
+        ("medium", &config.medium_scene_id),
+        ("turbo", &config.turbo_scene_id),
+        (
+            "quiet_negative_pressure",
+            &config.quiet_negative_pressure_scene_id,
+        ),
+        (
+            "medium_negative_pressure",
+            &config.medium_negative_pressure_scene_id,
+        ),
+        (
+            "turbo_negative_pressure",
+            &config.turbo_negative_pressure_scene_id,
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(label, configured)| {
+        configured
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|scene_id| (label, scene_id))
+    })
+    .collect()
+}
+
 fn configured_scene_id(value: &Option<String>) -> Option<&str> {
     value
         .as_deref()
@@ -4344,6 +4442,67 @@ mod tests {
         });
         let error = check_erv_scene_config(&no_turbo).expect_err("incomplete matrix");
         assert!(error.to_string().contains("turbo"));
+    }
+
+    /// `smoke_erv_scene` layers live checks on top of `check_erv_scene_config`
+    /// and must not reach the network -- construct a client, read the auth
+    /// cache -- when the configuration gate itself already fails. Live
+    /// credentials cannot be exercised in a unit test; this covers the
+    /// routing that decides whether the live path is even attempted.
+    #[tokio::test]
+    async fn smoke_erv_scene_rejects_incomplete_config_before_touching_the_network() {
+        let no_home_id = app_config(ErvConfig {
+            smart_life_home_id: None,
+            ..scene_config()
+        });
+        let error = smoke_erv_scene(&no_home_id)
+            .await
+            .expect_err("no home id");
+        assert!(error.to_string().contains("home id"));
+
+        let no_turbo = app_config(ErvConfig {
+            turbo_scene_id: None,
+            ..scene_config()
+        });
+        let error = smoke_erv_scene(&no_turbo).await.expect_err("incomplete matrix");
+        assert!(error.to_string().contains("turbo"));
+
+        let local_mode = app_config(ErvConfig {
+            control_mode: ErvControlMode::Local,
+            ..scene_config()
+        });
+        let error = smoke_erv_scene(&local_mode)
+            .await
+            .expect_err("scene control not selected");
+        assert!(error.to_string().contains("not the selected transport"));
+    }
+
+    /// Every scene id the configuration sets is checked for existence, not
+    /// just the ones the current pressure mode requires -- a dormant
+    /// negative-pressure id that has gone stale should still be caught before
+    /// the mode is re-armed, not discovered for the first time after.
+    #[test]
+    fn configured_scene_ids_includes_dormant_negative_pressure_and_skips_blank_entries() {
+        let config = ErvConfig {
+            quiet_negative_pressure_scene_id: Some("  ".to_string()),
+            medium_negative_pressure_scene_id: Some("medium-np".to_string()),
+            turbo_negative_pressure_scene_id: None,
+            ..scene_config()
+        };
+        assert!(!negative_pressure_armed(&app_config(config.clone())));
+
+        let ids = configured_scene_ids(&config);
+        assert_eq!(
+            ids,
+            vec![
+                ("off", "off-scene"),
+                ("quiet", "quiet-scene"),
+                ("medium", "medium-scene"),
+                ("turbo", "turbo-scene"),
+                ("medium_negative_pressure", "medium-np"),
+            ],
+            "blank ids are skipped and dormant negative-pressure ids are still included"
+        );
     }
 
     /// While negative pressure is armed, those are the only scenes automation

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -143,6 +143,8 @@ impl SmartLifeClient {
     pub async fn check_credentials(&self) -> Result<String> {
         let _auth_guard = AUTH_CACHE_LOCK.lock().await;
         let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
+        ensure_cache_directory_is_writable(&self.auth_file)
+            .context("refusing to rotate the Smart Life refresh token")?;
         self.refresh_auth(&mut auth)
             .await
             .context("Smart Life refresh token is not usable")?;
@@ -316,12 +318,50 @@ impl SmartLifeAuthCache {
             .with_context(|| format!("failed to parse Smart Life auth cache {}", path.display()))
     }
 
+    /// Write via a sibling temp file and rename over the target, so a reader
+    /// racing this write -- another process attached to the same cache file,
+    /// which the in-process `AUTH_CACHE_LOCK` cannot see -- gets either the
+    /// old complete file or the new one, never a half-written one.
     fn save(&self, path: &Path) -> Result<()> {
         let content = serde_json::to_string_pretty(self)
             .context("failed to serialize Smart Life auth cache")?;
-        fs::write(path, format!("{content}\n"))
-            .with_context(|| format!("failed to write Smart Life auth cache {}", path.display()))
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow!("Smart Life auth cache path has no file name"))?
+            .to_string_lossy();
+        let tmp_path = path.with_file_name(format!("{file_name}.tmp-{}", Uuid::new_v4()));
+        fs::write(&tmp_path, format!("{content}\n")).with_context(|| {
+            format!(
+                "failed to write Smart Life auth cache temp file {}",
+                tmp_path.display()
+            )
+        })?;
+        fs::rename(&tmp_path, path)
+            .with_context(|| format!("failed to finalize Smart Life auth cache {}", path.display()))
     }
+}
+
+/// Prove the cache's directory can be written to before consuming a refresh
+/// token there is no way to un-consume: a forced rotation invalidates the old
+/// refresh token at Smart Life regardless of whether the new one can be
+/// persisted locally, so a save failure after a successful refresh strands
+/// the credential rather than merely failing the check. A cheap probe write
+/// catches the common causes -- permissions, a full disk -- before the
+/// network call, not after.
+fn ensure_cache_directory_is_writable(path: &Path) -> Result<()> {
+    let dir = match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => dir,
+        _ => Path::new("."),
+    };
+    let probe = dir.join(format!(".smart-life-write-probe-{}", Uuid::new_v4()));
+    fs::write(&probe, b"").with_context(|| {
+        format!(
+            "Smart Life auth cache directory {} is not writable",
+            dir.display()
+        )
+    })?;
+    let _ = fs::remove_file(&probe);
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -592,5 +632,59 @@ mod tests {
             PathBuf::from("/tmp/office/auth.json")
         );
         assert_eq!(auth_file_or_default(None), default_auth_file());
+    }
+
+    /// A reader must never observe a half-written cache. `save` proves this
+    /// indirectly: after it returns, the file round-trips and no temp file
+    /// from the write is left behind for a later `load` to trip over.
+    #[test]
+    fn save_leaves_a_clean_file_and_no_temp_debris() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("tuya-sharing-auth.json");
+        let auth = SmartLifeAuthCache {
+            user_code: "user".to_string(),
+            terminal_id: "terminal".to_string(),
+            endpoint: "https://apigw.example".to_string(),
+            token_info: SmartLifeTokenInfo {
+                t: 0,
+                expire_time: 7200,
+                uid: "uid".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: "refresh".to_string(),
+            },
+        };
+
+        auth.save(&path).expect("save");
+        auth.save(&path).expect("re-save over the existing file");
+
+        let loaded = SmartLifeAuthCache::load(&path).expect("load");
+        assert_eq!(loaded.token_info.access_token, "access");
+
+        let leftovers = fs::read_dir(temp_dir.path())
+            .expect("read temp dir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name() != "tuya-sharing-auth.json")
+            .count();
+        assert_eq!(leftovers, 0, "save left a temp file behind");
+    }
+
+    /// `check_credentials` forces a token rotation it cannot undo -- the old
+    /// refresh token is dead at Smart Life the moment the call succeeds, so a
+    /// directory that cannot be written to must be caught before that call,
+    /// not after.
+    #[test]
+    fn writability_probe_rejects_a_missing_directory() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let unwritable = temp_dir.path().join("does-not-exist").join("auth.json");
+        let error = ensure_cache_directory_is_writable(&unwritable)
+            .expect_err("missing directory is not writable");
+        assert!(error.to_string().contains("not writable"));
+    }
+
+    #[test]
+    fn writability_probe_accepts_a_writable_directory() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("auth.json");
+        ensure_cache_directory_is_writable(&path).expect("writable temp dir");
     }
 }

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_CLIENT_ID: &str = "HA_3y9q4ak7g4ephrvke";
 
 const DEFAULT_AUTH_FILE: &str = ".office-automate/tuya-sharing-auth.json";
 const SCENE_TRIGGER_PATH: &str = "/v1.0/m/scene/ha/trigger";
+const SCENE_LIST_PATH: &str = "/v1.0/m/scene/ha/home/scenes";
 const DEVICE_DETAIL_PATH: &str = "/v1.0/m/life/ha/devices/detail";
 
 /// Serializes the whole load -> refresh -> save cycle across every caller in
@@ -95,6 +96,31 @@ impl SmartLifeClient {
         .map(|_| ())
     }
 
+    /// List the scene ids in a home.
+    ///
+    /// Existence only. The rendered *actions* of a scene are lossy -- the
+    /// sharing API hides the private speed data points there exactly as it
+    /// hides them in device status -- so nothing may be concluded from them
+    /// about what a scene does. An id being present is still worth knowing:
+    /// a deleted or mistyped one fails at the first ventilation request.
+    pub async fn list_scene_ids(&self, home_id: &str) -> Result<Vec<String>> {
+        let result = self
+            .get(SCENE_LIST_PATH, Some(json!({"homeId": home_id})))
+            .await?;
+        let scenes = result
+            .as_array()
+            .ok_or_else(|| anyhow!("Smart Life scene list is not an array"))?;
+        Ok(scenes
+            .iter()
+            .filter_map(|scene| {
+                ["scene_id", "sceneId", "id"]
+                    .iter()
+                    .find_map(|key| scene.get(*key).and_then(Value::as_str))
+                    .map(str::to_string)
+            })
+            .collect())
+    }
+
     /// Read a device's cloud status codes. The sharing API exposes only the
     /// standard codes (`switch`, `mode`, air-quality values); private data
     /// points such as the ERV speed DPs are never returned.
@@ -104,6 +130,17 @@ impl SmartLifeClient {
             .await?;
         device_status_codes(&result, device_id)
             .ok_or_else(|| anyhow!("Smart Life returned no status for device {device_id}"))
+    }
+
+    /// Read-only credential check: the cache is present, parseable, and its
+    /// refresh token is usable. Issues no device command.
+    pub async fn check_credentials(&self) -> Result<String> {
+        let _auth_guard = AUTH_CACHE_LOCK.lock().await;
+        let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
+        if self.refresh_auth_if_needed(&mut auth).await? {
+            auth.save(&self.auth_file)?;
+        }
+        Ok(auth.endpoint.clone())
     }
 
     async fn call(

--- a/rust/office-automate-server/src/smart_life.rs
+++ b/rust/office-automate-server/src/smart_life.rs
@@ -134,12 +134,19 @@ impl SmartLifeClient {
 
     /// Read-only credential check: the cache is present, parseable, and its
     /// refresh token is usable. Issues no device command.
+    ///
+    /// Unconditionally refreshes rather than deferring to
+    /// `refresh_auth_if_needed`'s expiry check. A cached access token with
+    /// time left on it would otherwise let this pass while the refresh token
+    /// behind it is dead -- exactly the "credentials are fine until the day
+    /// they aren't" gap this check exists to close.
     pub async fn check_credentials(&self) -> Result<String> {
         let _auth_guard = AUTH_CACHE_LOCK.lock().await;
         let mut auth = SmartLifeAuthCache::load(&self.auth_file)?;
-        if self.refresh_auth_if_needed(&mut auth).await? {
-            auth.save(&self.auth_file)?;
-        }
+        self.refresh_auth(&mut auth)
+            .await
+            .context("Smart Life refresh token is not usable")?;
+        auth.save(&self.auth_file)?;
         Ok(auth.endpoint.clone())
     }
 
@@ -165,7 +172,16 @@ impl SmartLifeClient {
         if expires_at - 60_000 > now_ms {
             return Ok(false);
         }
+        self.refresh_auth(auth).await?;
+        Ok(true)
+    }
 
+    /// Unconditionally rotate the access and refresh tokens. Callers that
+    /// only need to avoid an unnecessary round trip should go through
+    /// `refresh_auth_if_needed`; this is for the cases -- like
+    /// `check_credentials` -- where skipping the call because the cached
+    /// access token isn't expired yet would defeat the point.
+    async fn refresh_auth(&self, auth: &mut SmartLifeAuthCache) -> Result<()> {
         let path = format!("/v1.0/m/token/{}", auth.token_info.refresh_token);
         let result = self
             .request(auth, "GET", &path, None, None)
@@ -193,7 +209,7 @@ impl SmartLifeClient {
                 .ok_or_else(|| anyhow!("Smart Life token refresh missing refreshToken"))?
                 .to_string(),
         };
-        Ok(true)
+        Ok(())
     }
 
     async fn request(

--- a/rust/office-automate-server/src/validation.rs
+++ b/rust/office-automate-server/src/validation.rs
@@ -1484,15 +1484,15 @@ async fn validate_live_devices(
     // *and* scene control, so keying this off the absence of local credentials
     // would check everything except the path in use.
     //
-    // Configuration only. Whether the credentials work and the scene ids still
-    // exist needs a live Smart Life call, which is tracked separately.
+    // Live: this exercises the Smart Life credentials and confirms every
+    // configured scene id still exists, not just that the matrix is filled
+    // in. A stale id passes configuration-only validation and fails at the
+    // first ventilation request instead.
     if config.erv.scene_control_selected() {
-        let checked =
-            erv::check_erv_scene_config(config).context("ERV scene configuration is incomplete")?;
-        report.push_pass(
-            "erv-scene-config",
-            format!("{checked} required scene ids configured (not verified live)"),
-        );
+        let detail = erv::smoke_erv_scene(config)
+            .await
+            .context("ERV Smart Life scene check failed")?;
+        report.push_pass("erv-scene-auth", detail);
     }
 
     if !config.erv.local_tuya_configured() {


### PR DESCRIPTION
## Summary

`validate --target shadow|cutover` checked ERV scene control by configuration only: every preset the deployment will command has a scene id, nothing more. That proves the matrix is filled in, not that any of it works.

Restores the live checks from PR #158 (reverted in `efdff44` for scope, not because they were wrong): `SmartLifeClient::check_credentials` and `list_scene_ids`, plus the auth + scene-existence + device-read logic, as `erv::smoke_erv_scene`.

- `smoke_erv_scene` layers on top of the existing `check_erv_scene_config` rather than duplicating it: the config gate runs first (fails fast, no network), then the live checks run against Smart Life.
- `validate_live_devices` now calls the live path (`erv-scene-auth`) instead of the config-only one.
- The config-only `check_erv_scene_config` is unchanged and keeps doing the network-free boot-time log — that split (fast boot check vs. live validation check) was intentional in the design and is preserved.
- Endpoints are the ones already measured against the vendored SDK and already shipped in `smart_life.rs` — no new endpoints invented: `GET /v1.0/m/scene/ha/home/scenes` for scene listing, `GET /v1.0/m/life/ha/devices/detail` (already `device_status`) for the device read.
- Existence only, per the ERV design doc's Hard Constraints (`docs/working/154_erv_scene_fallback.md`): the scene read view renders every ERV speed scene's action identically (`{"switch": true}`), so nothing here concludes what a scene *does* — only that its configured id still exists in Smart Life.

Out of scope, and untouched: the ERV write path, the verification ladder, the local-write fallback, `ErvState`.

## Test Plan

- `cargo test --all-targets` — 386 passed (384 baseline + 2 new), 0 failed.
- `cargo clippy --all-targets` — 45 warnings, same as baseline (no new warnings).
- Live credentials cannot be exercised in a unit test (no live Smart Life account available in CI/dev). What's covered instead:
  - `smoke_erv_scene`'s routing through the config gate (missing home id, incomplete scene matrix, wrong transport selected) never reaches the network — verified directly.
  - `configured_scene_ids`'s filtering (blank/whitespace ids skipped, dormant negative-pressure ids still included even while unarmed) — verified directly.
- **Not verified by this PR**: `check_credentials` against a real or expired auth cache, and `list_scene_ids` / `device_status` against the live Smart Life API. That needs a real deployment run of `validate --target shadow` or `cutover`.

Fixes #159