### PR TITLE
ERV: retry a cold local contact before declaring boot state unknown

### DIFF
--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -475,14 +475,19 @@ impl SplitErvWriter {
     /// only an exhausted budget does, which is what keeps this from fighting
     /// the backoff that already gates how often a dead path gets tried.
     ///
-    /// Returns the *first* error, not the last: it is the one that actually
-    /// describes the device, and downstream health accounting classifies on
-    /// its message (e.g. an Err 914 local-key diagnosis).
+    /// Returns the first *local-key-classified* error if any attempt saw one,
+    /// else the first error overall. A cold-radio attempt fails before ever
+    /// reaching the device, so it can precede a later attempt that actually
+    /// gets far enough to receive a real Err 914 rejection; preferring the
+    /// earliest transient error in that case would discard the one diagnosis
+    /// downstream health accounting (`is_local_key_error`) can act on, and
+    /// could mask a genuinely invalid key behind cold-radio noise forever.
     async fn read_local_with_cold_contact_retry(
         &self,
         config: &ErvConfig,
     ) -> Result<ErvDeviceStatus> {
         let mut first_error = None;
+        let mut first_key_error = None;
         for attempt in 1..=LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
             match self.reader.read_status(config).await {
                 Ok(status) => return Ok(status),
@@ -494,11 +499,17 @@ impl SplitErvWriter {
                         );
                         time::sleep(LOCAL_COLD_CONTACT_RETRY_DELAY).await;
                     }
-                    first_error.get_or_insert(error);
+                    if first_key_error.is_none() && is_local_key_error(&format!("{error:#}")) {
+                        first_key_error = Some(error);
+                    } else {
+                        first_error.get_or_insert(error);
+                    }
                 }
             }
         }
-        Err(first_error.expect("loop runs at least once so an error was recorded"))
+        Err(first_key_error
+            .or(first_error)
+            .expect("loop runs at least once so an error was recorded"))
     }
 
     async fn write_fallback(
@@ -3730,6 +3741,33 @@ mod tests {
             "a genuinely dead local path retried past its bounded budget"
         );
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
+    }
+
+    /// A cold-radio attempt fails before ever reaching the device, so it can
+    /// precede a later attempt that gets far enough to receive a real Err 914
+    /// rejection. The retry must surface that diagnosis, not the earlier
+    /// transient one, or a genuinely invalid key hides behind cold-radio
+    /// noise indefinitely -- `local_key_invalid` classifies on this message.
+    #[tokio::test]
+    async fn cold_contact_retry_prefers_a_later_local_key_diagnosis() {
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(vec![
+            Err(anyhow!("No route to host (os error 65)")),
+            Err(anyhow!("Check device key or version (Error 914)")),
+            Err(anyhow!("Check device key or version (Error 914)")),
+        ]));
+        let writer = split_writer(cloud, reader.clone(), None);
+
+        let error = writer
+            .smoke_status(&scene_config())
+            .await
+            .expect_err("every attempt failed");
+
+        assert!(
+            format!("{error:#}").contains("Check device key or version"),
+            "a later local-key diagnosis was discarded for an earlier transient error"
+        );
+        assert_eq!(reader.call_count(), 3);
     }
 
     /// The boot read must feed the writer's own local health. Otherwise a

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -455,7 +455,7 @@ impl SplitErvWriter {
     }
 
     async fn read_local(&self, config: &ErvConfig) -> Result<ErvDeviceStatus> {
-        let result = self.read_local_with_cold_contact_retry(config).await;
+        let result = read_status_with_cold_contact_retry(self.reader.as_ref(), config).await;
         self.record_local_outcome(result.is_ok());
         match &result {
             Ok(status) => {
@@ -466,50 +466,6 @@ impl SplitErvWriter {
             Err(error) => self.state().unreported_local_failure = Some(format!("{error:#}")),
         }
         result
-    }
-
-    /// The first packet to a sleeping Wi-Fi radio drops while it wakes; retry
-    /// a bounded handful of times, a second or so apart, before treating a
-    /// local read as a real failure. Callers see one aggregate outcome, so a
-    /// cold contact that recovers on retry never touches `local_retry_at` --
-    /// only an exhausted budget does, which is what keeps this from fighting
-    /// the backoff that already gates how often a dead path gets tried.
-    ///
-    /// Returns the first *local-key-classified* error if any attempt saw one,
-    /// else the first error overall. A cold-radio attempt fails before ever
-    /// reaching the device, so it can precede a later attempt that actually
-    /// gets far enough to receive a real Err 914 rejection; preferring the
-    /// earliest transient error in that case would discard the one diagnosis
-    /// downstream health accounting (`is_local_key_error`) can act on, and
-    /// could mask a genuinely invalid key behind cold-radio noise forever.
-    async fn read_local_with_cold_contact_retry(
-        &self,
-        config: &ErvConfig,
-    ) -> Result<ErvDeviceStatus> {
-        let mut first_error = None;
-        let mut first_key_error = None;
-        for attempt in 1..=LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
-            match self.reader.read_status(config).await {
-                Ok(status) => return Ok(status),
-                Err(error) => {
-                    if attempt < LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
-                        tracing::debug!(
-                            "ERV local read attempt {attempt}/{LOCAL_COLD_CONTACT_RETRY_ATTEMPTS} \
-                             failed, retrying for a cold radio: {error:#}"
-                        );
-                        time::sleep(LOCAL_COLD_CONTACT_RETRY_DELAY).await;
-                    }
-                    if first_key_error.is_none() && is_local_key_error(&format!("{error:#}")) {
-                        first_key_error = Some(error);
-                    } else {
-                        first_error.get_or_insert(error);
-                    }
-                }
-            }
-        }
-        Err(first_key_error
-            .or(first_error)
-            .expect("loop runs at least once so an error was recorded"))
     }
 
     async fn write_fallback(
@@ -726,6 +682,52 @@ impl ErvSpeedWriter for SplitErvWriter {
     }
 }
 
+/// The first packet to a sleeping Wi-Fi radio drops while it wakes; retry a
+/// bounded handful of times, a second or so apart, before treating a local
+/// read as a real failure. Shared by every writer that performs its own
+/// local status reads -- scene control's `SplitErvWriter` and local
+/// control's `RustuyaErvSpeedWriter` -- so a cold contact is tolerated the
+/// same way regardless of which transport mode is selected. Callers see one
+/// aggregate outcome, so a cold contact that recovers on retry never trips
+/// backoff -- only an exhausted budget does.
+///
+/// Returns the first *local-key-classified* error if any attempt saw one,
+/// else the first error overall. A cold-radio attempt fails before ever
+/// reaching the device, so it can precede a later attempt that actually gets
+/// far enough to receive a real Err 914 rejection; preferring the earliest
+/// transient error in that case would discard the one diagnosis downstream
+/// health accounting (`is_local_key_error`) can act on, and could mask a
+/// genuinely invalid key behind cold-radio noise forever.
+async fn read_status_with_cold_contact_retry(
+    reader: &(impl ErvStatusReader + ?Sized),
+    config: &ErvConfig,
+) -> Result<ErvDeviceStatus> {
+    let mut first_error = None;
+    let mut first_key_error = None;
+    for attempt in 1..=LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
+        match reader.read_status(config).await {
+            Ok(status) => return Ok(status),
+            Err(error) => {
+                if attempt < LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
+                    tracing::debug!(
+                        "ERV local read attempt {attempt}/{LOCAL_COLD_CONTACT_RETRY_ATTEMPTS} \
+                         failed, retrying for a cold radio: {error:#}"
+                    );
+                    time::sleep(LOCAL_COLD_CONTACT_RETRY_DELAY).await;
+                }
+                if first_key_error.is_none() && is_local_key_error(&format!("{error:#}")) {
+                    first_key_error = Some(error);
+                } else {
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+    }
+    Err(first_key_error
+        .or(first_error)
+        .expect("loop runs at least once so an error was recorded"))
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RustuyaErvStatusReader;
 
@@ -752,7 +754,10 @@ pub struct RustuyaErvSpeedWriter;
 
 impl ErvSpeedWriter for RustuyaErvSpeedWriter {
     fn smoke_status<'a>(&'a self, config: &'a ErvConfig) -> BoxFutureResult<'a, ErvDeviceStatus> {
-        RustuyaErvStatusReader.read_status(config)
+        Box::pin(read_status_with_cold_contact_retry(
+            &RustuyaErvStatusReader,
+            config,
+        ))
     }
 
     fn set_speed<'a>(
@@ -3768,6 +3773,26 @@ mod tests {
             "a later local-key diagnosis was discarded for an earlier transient error"
         );
         assert_eq!(reader.call_count(), 3);
+    }
+
+    /// Local control mode's `RustuyaErvSpeedWriter::smoke_status` delegates
+    /// to this same function -- it can't be exercised directly without real
+    /// hardware, since it always constructs its own device connection -- so
+    /// this is the coverage for that mode's pre-write read gate recovering
+    /// from a cold contact instead of rejecting a legitimate write.
+    #[tokio::test]
+    async fn read_status_retry_recovers_a_cold_local_contact() {
+        let reader = FakeErvReader::new(vec![
+            Err(anyhow!("No route to host (os error 65)")),
+            Ok(medium_status()),
+        ]);
+
+        let status = read_status_with_cold_contact_retry(&reader, &scene_config())
+            .await
+            .expect("recovers on retry");
+
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Medium));
+        assert_eq!(reader.call_count(), 2);
     }
 
     /// The boot read must feed the writer's own local health. Otherwise a

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -691,16 +691,17 @@ impl ErvSpeedWriter for SplitErvWriter {
 /// aggregate outcome, so a cold contact that recovers on retry never trips
 /// backoff -- only an exhausted budget does.
 ///
-/// A local-key-classified error (e.g. Err 914, or a protocol version
-/// mismatch) stops the retry immediately rather than spending the rest of
-/// the budget: the device responded and rejected the connection, which a
-/// cold radio waking up wouldn't change in the next second. Retrying it
-/// anyway would triple the rejected traffic on every contact and delay a
-/// write or boot recovery without any prospect of success; the existing
-/// cross-call threshold (`LOCAL_KEY_ERROR_THRESHOLD`) is what decides
-/// whether it's really invalid, not this retry. A short-circuit on the
-/// first key-classified error is also, incidentally, always the *earliest*
-/// one seen -- so a cold-radio attempt followed by a later Err 914 still
+/// A non-retryable error (see [`is_non_retryable_local_error`]) stops the
+/// retry immediately rather than spending the rest of the budget: it is
+/// either a static configuration problem that will read identically on
+/// every attempt, or the device responding and rejecting the connection --
+/// neither of which a cold radio waking up in the next second would change.
+/// Retrying anyway would triple the rejected traffic on every contact and
+/// delay a write or boot recovery without any prospect of success; the
+/// existing cross-call threshold (`LOCAL_KEY_ERROR_THRESHOLD`) is what
+/// decides whether a key is really invalid, not this retry. A short-circuit
+/// on the first such error is also, incidentally, always the *earliest* one
+/// seen -- so a cold-radio attempt followed by a later Err 914 still
 /// surfaces that diagnosis instead of the transient error that preceded it.
 async fn read_status_with_cold_contact_retry(
     reader: &(impl ErvStatusReader + ?Sized),
@@ -711,7 +712,7 @@ async fn read_status_with_cold_contact_retry(
         match reader.read_status(config).await {
             Ok(status) => return Ok(status),
             Err(error) => {
-                if is_local_key_error(&format!("{error:#}")) {
+                if is_non_retryable_local_error(&format!("{error:#}")) {
                     return Err(error);
                 }
                 if attempt < LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
@@ -726,6 +727,19 @@ async fn read_status_with_cold_contact_retry(
         }
     }
     Err(first_error.expect("loop runs at least once so an error was recorded"))
+}
+
+/// True for local-read errors that no amount of retrying will change: a
+/// static configuration problem (an unparseable protocol version, incomplete
+/// Tuya credentials) that reads identically on every attempt because no
+/// network I/O ever happens, or a definitive device-level rejection (Err
+/// 914). Used only to decide whether the cold-contact retry should give up
+/// early -- `is_local_key_error` alone still gates the separate
+/// local-key-invalid notification, which must not fire for a config error.
+fn is_non_retryable_local_error(message: &str) -> bool {
+    is_local_key_error(message)
+        || message.contains("invalid ERV Tuya protocol version")
+        || message.contains("ERV local Tuya config is incomplete")
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3799,6 +3813,30 @@ mod tests {
             reader.call_count(),
             1,
             "a definitive local-key error must not be retried"
+        );
+    }
+
+    /// A bad protocol version or incomplete Tuya credentials fail before any
+    /// network I/O happens, so every attempt would read identically -- an
+    /// even more clear-cut case than Err 914 for not spending the retry
+    /// budget on it.
+    #[tokio::test]
+    async fn cold_contact_retry_does_not_retry_a_static_config_error() {
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+            "invalid ERV Tuya protocol version: unsupported version \"9.9\""
+        ))]));
+        let writer = split_writer(cloud, reader.clone(), None);
+
+        writer
+            .smoke_status(&scene_config())
+            .await
+            .expect_err("a static config error is a real failure");
+
+        assert_eq!(
+            reader.call_count(),
+            1,
+            "a static configuration error must not be retried"
         );
     }
 

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -35,6 +35,15 @@ const LOCAL_FAILURE_RCA_THRESHOLD: u64 = 3;
 const LOCAL_WRITE_BURST_WINDOW_SECONDS: f64 = 5.0 * 60.0;
 const LOCAL_WRITE_BURST_ATTEMPT_LIMIT: usize = 3;
 const BOOT_RECOVERY_REASON: &str = "boot_unknown_state";
+/// A local read after any idle period is often the first packet to a sleeping
+/// Wi-Fi radio, which drops while the radio wakes -- nothing keeps it warm any
+/// more now that the status poll loop is gone. Bounded so a genuinely dead
+/// local path still fails fast and falls through to recovery.
+const LOCAL_COLD_CONTACT_RETRY_ATTEMPTS: u32 = 3;
+#[cfg(not(test))]
+const LOCAL_COLD_CONTACT_RETRY_DELAY: Duration = Duration::from_secs(1);
+#[cfg(test)]
+const LOCAL_COLD_CONTACT_RETRY_DELAY: Duration = Duration::from_millis(1);
 pub const ERV_MANUAL_OVERRIDE_SECONDS: i64 = 30 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -446,7 +455,7 @@ impl SplitErvWriter {
     }
 
     async fn read_local(&self, config: &ErvConfig) -> Result<ErvDeviceStatus> {
-        let result = self.reader.read_status(config).await;
+        let result = self.read_local_with_cold_contact_retry(config).await;
         self.record_local_outcome(result.is_ok());
         match &result {
             Ok(status) => {
@@ -457,6 +466,39 @@ impl SplitErvWriter {
             Err(error) => self.state().unreported_local_failure = Some(format!("{error:#}")),
         }
         result
+    }
+
+    /// The first packet to a sleeping Wi-Fi radio drops while it wakes; retry
+    /// a bounded handful of times, a second or so apart, before treating a
+    /// local read as a real failure. Callers see one aggregate outcome, so a
+    /// cold contact that recovers on retry never touches `local_retry_at` --
+    /// only an exhausted budget does, which is what keeps this from fighting
+    /// the backoff that already gates how often a dead path gets tried.
+    ///
+    /// Returns the *first* error, not the last: it is the one that actually
+    /// describes the device, and downstream health accounting classifies on
+    /// its message (e.g. an Err 914 local-key diagnosis).
+    async fn read_local_with_cold_contact_retry(
+        &self,
+        config: &ErvConfig,
+    ) -> Result<ErvDeviceStatus> {
+        let mut first_error = None;
+        for attempt in 1..=LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
+            match self.reader.read_status(config).await {
+                Ok(status) => return Ok(status),
+                Err(error) => {
+                    if attempt < LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
+                        tracing::debug!(
+                            "ERV local read attempt {attempt}/{LOCAL_COLD_CONTACT_RETRY_ATTEMPTS} \
+                             failed, retrying for a cold radio: {error:#}"
+                        );
+                        time::sleep(LOCAL_COLD_CONTACT_RETRY_DELAY).await;
+                    }
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+        Err(first_error.expect("loop runs at least once so an error was recorded"))
     }
 
     async fn write_fallback(
@@ -2477,13 +2519,19 @@ mod tests {
 
     struct FakeErvReader {
         results: Mutex<VecDeque<Result<ErvDeviceStatus>>>,
+        calls: AtomicUsize,
     }
 
     impl FakeErvReader {
         fn new(results: Vec<Result<ErvDeviceStatus>>) -> Self {
             Self {
                 results: Mutex::new(results.into()),
+                calls: AtomicUsize::new(0),
             }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
         }
     }
 
@@ -2492,6 +2540,7 @@ mod tests {
             &'a self,
             _config: &'a ErvConfig,
         ) -> BoxFutureResult<'a, ErvDeviceStatus> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
             let result = self
                 .results
                 .lock()
@@ -2500,6 +2549,16 @@ mod tests {
                 .unwrap_or_else(|| bail!("no fake ERV result configured"));
             Box::pin(async move { result })
         }
+    }
+
+    /// A cold local read is retried [`LOCAL_COLD_CONTACT_RETRY_ATTEMPTS`]
+    /// times before it counts as a real failure, so a fake modelling a
+    /// genuinely dead local path needs that many queued results to fail with
+    /// the message under test instead of the fake's own empty-queue error.
+    fn repeated_local_read_failure(message: &str) -> Vec<Result<ErvDeviceStatus>> {
+        (0..LOCAL_COLD_CONTACT_RETRY_ATTEMPTS)
+            .map(|_| Err(anyhow!(message.to_string())))
+            .collect()
     }
 
     struct FakeErvWriter {
@@ -3496,9 +3555,9 @@ mod tests {
         let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
-                "Check device key or version (Error 914)"
-            ))])),
+            Arc::new(FakeErvReader::new(repeated_local_read_failure(
+                "Check device key or version (Error 914)",
+            ))),
             Some(local.clone()),
         );
         let config = scene_config();
@@ -3609,9 +3668,9 @@ mod tests {
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
-                "Connection reset by peer"
-            ))])),
+            Arc::new(FakeErvReader::new(repeated_local_read_failure(
+                "Connection reset by peer",
+            ))),
             None,
         );
 
@@ -3619,6 +3678,58 @@ mod tests {
 
         assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
         assert!(!state.snapshot().running);
+    }
+
+    /// Issue #163: a boot read that fails once and succeeds immediately after
+    /// is the actual failure mode observed live -- the first packet to a
+    /// sleeping Wi-Fi radio dropping while it wakes, not a genuinely
+    /// unreachable device. The retry must recover it without forcing off.
+    #[tokio::test]
+    async fn boot_read_retries_a_cold_local_contact_and_skips_recovery() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(vec![
+            Err(anyhow!("No route to host (os error 65)")),
+            Ok(medium_status()),
+        ]));
+        let writer = split_writer(cloud.clone(), reader.clone(), None);
+
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
+
+        assert!(
+            cloud.triggered_scenes().is_empty(),
+            "a cold contact that recovered on retry must not force the off scene"
+        );
+        assert_eq!(state.snapshot().speed, ErvFanSpeed::Medium);
+        assert_eq!(reader.call_count(), 2);
+    }
+
+    /// The other direction: a local path that is actually dead must not
+    /// retry forever. It has to exhaust the bounded budget and still fall
+    /// through to boot recovery, exactly as before this change.
+    #[tokio::test]
+    async fn boot_read_cold_contact_retry_is_bounded() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let database_path = temp_dir.path().join("office_climate.db");
+        db::migrate_database(&database_path).expect("migration");
+        let state = ErvState::new(database_path);
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(repeated_local_read_failure(
+            "No route to host (os error 65)",
+        )));
+        let writer = split_writer(cloud.clone(), reader.clone(), None);
+
+        run_erv_boot_read(&app_config(scene_config()), &state, &writer).await;
+
+        assert_eq!(
+            reader.call_count(),
+            LOCAL_COLD_CONTACT_RETRY_ATTEMPTS as usize,
+            "a genuinely dead local path retried past its bounded budget"
+        );
+        assert_eq!(cloud.triggered_scenes(), vec!["off-scene".to_string()]);
     }
 
     /// The boot read must feed the writer's own local health. Otherwise a
@@ -3635,9 +3746,9 @@ mod tests {
         let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
-                "Check device key or version (Error 914)"
-            ))])),
+            Arc::new(FakeErvReader::new(repeated_local_read_failure(
+                "Check device key or version (Error 914)",
+            ))),
             Some(local.clone()),
         );
 
@@ -3662,9 +3773,9 @@ mod tests {
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
-                "Connection reset by peer"
-            ))])),
+            Arc::new(FakeErvReader::new(repeated_local_read_failure(
+                "Connection reset by peer",
+            ))),
             None,
         );
 
@@ -3761,7 +3872,11 @@ mod tests {
         let writer = split_writer(
             cloud.clone(),
             Arc::new(FakeErvReader::new(
-                (0..LOCAL_KEY_ERROR_THRESHOLD * 2)
+                // Each write's pre-write read retries a cold contact up to
+                // LOCAL_COLD_CONTACT_RETRY_ATTEMPTS times before giving up, so
+                // a genuinely dead local path drains that many queue entries
+                // per iteration, not one.
+                (0..LOCAL_KEY_ERROR_THRESHOLD * LOCAL_COLD_CONTACT_RETRY_ATTEMPTS as u64)
                     .map(|_| bail!("Check device key or version (Error 914)"))
                     .collect(),
             )),
@@ -4021,6 +4136,30 @@ mod tests {
         );
     }
 
+    /// Issue #163's other exposed path: the read-after-write verification in
+    /// `verify_locally` shares `read_local` with the boot path, so a cold
+    /// contact there must also recover on retry instead of downgrading a
+    /// perfectly good write to an unverified `assumed` status.
+    #[tokio::test]
+    async fn verify_locally_retries_a_cold_readback_after_write() {
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(vec![
+            Err(anyhow!("No route to host (os error 65)")),
+            Ok(turbo_status()),
+        ]));
+        let writer = split_writer(cloud.clone(), reader.clone(), None);
+        let config = scene_config();
+
+        let status = writer
+            .set_speed(&config, ErvFanSpeed::Turbo, false)
+            .await
+            .expect("scene write succeeds");
+
+        assert_eq!(status.fan_speed, Some(ErvFanSpeed::Turbo));
+        assert_eq!(writer.last_write_report().source, ErvStatusSource::Local);
+        assert_eq!(reader.call_count(), 2);
+    }
+
     /// An unverified write leaves power unknown, so the next command still
     /// pays for a cloud check. Trusting the assumption would let an ERV that
     /// never ran the scene be reported as ventilating indefinitely.
@@ -4082,9 +4221,9 @@ mod tests {
         let cloud = Arc::new(FakeCloud::default());
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
-                "Connection reset by peer"
-            ))])),
+            Arc::new(FakeErvReader::new(repeated_local_read_failure(
+                "Connection reset by peer",
+            ))),
             None,
         );
 

--- a/rust/office-automate-server/src/erv.rs
+++ b/rust/office-automate-server/src/erv.rs
@@ -691,23 +691,29 @@ impl ErvSpeedWriter for SplitErvWriter {
 /// aggregate outcome, so a cold contact that recovers on retry never trips
 /// backoff -- only an exhausted budget does.
 ///
-/// Returns the first *local-key-classified* error if any attempt saw one,
-/// else the first error overall. A cold-radio attempt fails before ever
-/// reaching the device, so it can precede a later attempt that actually gets
-/// far enough to receive a real Err 914 rejection; preferring the earliest
-/// transient error in that case would discard the one diagnosis downstream
-/// health accounting (`is_local_key_error`) can act on, and could mask a
-/// genuinely invalid key behind cold-radio noise forever.
+/// A local-key-classified error (e.g. Err 914, or a protocol version
+/// mismatch) stops the retry immediately rather than spending the rest of
+/// the budget: the device responded and rejected the connection, which a
+/// cold radio waking up wouldn't change in the next second. Retrying it
+/// anyway would triple the rejected traffic on every contact and delay a
+/// write or boot recovery without any prospect of success; the existing
+/// cross-call threshold (`LOCAL_KEY_ERROR_THRESHOLD`) is what decides
+/// whether it's really invalid, not this retry. A short-circuit on the
+/// first key-classified error is also, incidentally, always the *earliest*
+/// one seen -- so a cold-radio attempt followed by a later Err 914 still
+/// surfaces that diagnosis instead of the transient error that preceded it.
 async fn read_status_with_cold_contact_retry(
     reader: &(impl ErvStatusReader + ?Sized),
     config: &ErvConfig,
 ) -> Result<ErvDeviceStatus> {
     let mut first_error = None;
-    let mut first_key_error = None;
     for attempt in 1..=LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
         match reader.read_status(config).await {
             Ok(status) => return Ok(status),
             Err(error) => {
+                if is_local_key_error(&format!("{error:#}")) {
+                    return Err(error);
+                }
                 if attempt < LOCAL_COLD_CONTACT_RETRY_ATTEMPTS {
                     tracing::debug!(
                         "ERV local read attempt {attempt}/{LOCAL_COLD_CONTACT_RETRY_ATTEMPTS} \
@@ -715,17 +721,11 @@ async fn read_status_with_cold_contact_retry(
                     );
                     time::sleep(LOCAL_COLD_CONTACT_RETRY_DELAY).await;
                 }
-                if first_key_error.is_none() && is_local_key_error(&format!("{error:#}")) {
-                    first_key_error = Some(error);
-                } else {
-                    first_error.get_or_insert(error);
-                }
+                first_error.get_or_insert(error);
             }
         }
     }
-    Err(first_key_error
-        .or(first_error)
-        .expect("loop runs at least once so an error was recorded"))
+    Err(first_error.expect("loop runs at least once so an error was recorded"))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3571,9 +3571,11 @@ mod tests {
         let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(repeated_local_read_failure(
-                "Check device key or version (Error 914)",
-            ))),
+            // A local-key-classified error stops the cold-contact retry
+            // immediately, so a single queued failure is enough here.
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Check device key or version (Error 914)"
+            ))])),
             Some(local.clone()),
         );
         let config = scene_config();
@@ -3759,7 +3761,6 @@ mod tests {
         let reader = Arc::new(FakeErvReader::new(vec![
             Err(anyhow!("No route to host (os error 65)")),
             Err(anyhow!("Check device key or version (Error 914)")),
-            Err(anyhow!("Check device key or version (Error 914)")),
         ]));
         let writer = split_writer(cloud, reader.clone(), None);
 
@@ -3772,7 +3773,33 @@ mod tests {
             format!("{error:#}").contains("Check device key or version"),
             "a later local-key diagnosis was discarded for an earlier transient error"
         );
-        assert_eq!(reader.call_count(), 3);
+        // The key diagnosis also stops the retry immediately -- a third,
+        // pointless attempt at a definitive rejection never happens.
+        assert_eq!(reader.call_count(), 2);
+    }
+
+    /// A definitive rejection isn't a cold radio waking up -- it's the
+    /// device responding and saying no. Retrying it anyway would triple the
+    /// rejected traffic on every contact and add pointless latency to a
+    /// write or boot recovery, so it must stop after the first attempt.
+    #[tokio::test]
+    async fn cold_contact_retry_does_not_retry_a_definitive_local_key_error() {
+        let cloud = Arc::new(FakeCloud::default());
+        let reader = Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+            "Check device key or version (Error 914)"
+        ))]));
+        let writer = split_writer(cloud, reader.clone(), None);
+
+        writer
+            .smoke_status(&scene_config())
+            .await
+            .expect_err("a key rejection is a real failure");
+
+        assert_eq!(
+            reader.call_count(),
+            1,
+            "a definitive local-key error must not be retried"
+        );
     }
 
     /// Local control mode's `RustuyaErvSpeedWriter::smoke_status` delegates
@@ -3809,9 +3836,11 @@ mod tests {
         let local = Arc::new(FakeErvWriter::new(Vec::new(), vec![Ok(turbo_status())]));
         let writer = split_writer(
             cloud.clone(),
-            Arc::new(FakeErvReader::new(repeated_local_read_failure(
-                "Check device key or version (Error 914)",
-            ))),
+            // A local-key-classified error stops the cold-contact retry
+            // immediately, so a single queued failure is enough here.
+            Arc::new(FakeErvReader::new(vec![Err(anyhow!(
+                "Check device key or version (Error 914)"
+            ))])),
             Some(local.clone()),
         );
 
@@ -3935,11 +3964,10 @@ mod tests {
         let writer = split_writer(
             cloud.clone(),
             Arc::new(FakeErvReader::new(
-                // Each write's pre-write read retries a cold contact up to
-                // LOCAL_COLD_CONTACT_RETRY_ATTEMPTS times before giving up, so
-                // a genuinely dead local path drains that many queue entries
-                // per iteration, not one.
-                (0..LOCAL_KEY_ERROR_THRESHOLD * LOCAL_COLD_CONTACT_RETRY_ATTEMPTS as u64)
+                // A local-key-classified error stops the cold-contact retry
+                // immediately, so each write's pre-write read drains exactly
+                // one queue entry, not the full retry budget.
+                (0..LOCAL_KEY_ERROR_THRESHOLD)
                     .map(|_| bail!("Check device key or version (Error 914)"))
                     .collect(),
             )),


### PR DESCRIPTION
## Summary

#158 removed the ERV status poll loop, which was correct (it was the traffic that caused the Err 914 lockout), but it also incidentally kept the device's Wi-Fi radio awake and its ARP entry warm. Local contact dropped from every 60-300s to roughly 30/day, so nearly every contact is now a cold one against a sleeping radio, and the first packet drops with `No route to host` (errno 65 -- an ARP resolution failure, not a real outage) while the radio wakes. Both boot reads since #158 shipped failed this way; one succeeded two seconds later on its own.

A failed boot read makes boot recovery force the off scene, so a restart while the ERV is ventilating switches it off for no reason. Severity was bounded (boot recovery is dwell-exempt, so the next policy cycle corrects it) but it's still wrong and writes to the device every restart for nothing.

## Fix

`read_status_with_cold_contact_retry` is a shared free function used by every writer that performs its own local status read -- scene control's `SplitErvWriter::read_local` (covering both the boot read and the read-after-write verification) and local control's `RustuyaErvSpeedWriter::smoke_status` -- so a cold contact is tolerated the same way regardless of which transport mode is selected.

- A failed read is retried up to `LOCAL_COLD_CONTACT_RETRY_ATTEMPTS` (3) times, `LOCAL_COLD_CONTACT_RETRY_DELAY` (1s in production) apart, before counting as a real failure.
- A **non-retryable** error -- `is_non_retryable_local_error`: a local-key-classified rejection (Err 914), an invalid protocol version, or incomplete Tuya config -- stops the retry immediately instead of spending the rest of the budget. The device (or local config) has already given a definitive, deterministic answer that a cold radio waking up in the next second can't change; retrying it would just triple the rejected traffic and add pointless latency. `is_local_key_error` itself is unchanged and still exclusively gates the separate `local_key_invalid` notification.
- The retry is internal to a single logical read and only the aggregate outcome is recorded, so it can't fight the existing backoff (`local_retry_at`) -- a genuinely dead transient path still exhausts the budget in ~2s and falls through to recovery exactly as before.

No polling was reintroduced. Read paths only -- no change to the write path, local-write fallback, verification ladder beyond the retry, `ErvState` accounting, dwell, or the burst guard.

## Test plan

- `boot_read_retries_a_cold_local_contact_and_skips_recovery`: fails once, succeeds on retry -- boot recovery must NOT fire the off scene. The actual failure mode from the live evidence (a fake reader that only ever fails deterministically is why 13 rounds of review never caught this).
- `boot_read_cold_contact_retry_is_bounded`: a transient failure on every attempt exhausts the retry budget and still falls through to boot recovery.
- `verify_locally_retries_a_cold_readback_after_write`: the read-after-write path recovers on retry and reports `status_source=local` instead of downgrading to `assumed`.
- `read_status_retry_recovers_a_cold_local_contact`: exercises the shared function directly -- the same coverage for local control mode's `RustuyaErvSpeedWriter`, which can't be unit-tested directly since it always constructs a real device connection.
- `cold_contact_retry_prefers_a_later_local_key_diagnosis` / `cold_contact_retry_does_not_retry_a_definitive_local_key_error`: a cold-radio attempt followed by a real Err 914 surfaces the key diagnosis, and a key rejection stops the retry after one attempt.
- `cold_contact_retry_does_not_retry_a_static_config_error`: an invalid protocol version / incomplete config also stops after one attempt.
- `cargo test --all-targets`: 396 passed, 0 failed (baseline on main: 389 passed).
- `cargo clippy --all-targets`: 45 warnings, unchanged from baseline; no new warnings.

## Live verification

The ERV happened to be having a sustained local connectivity problem while I was testing -- `ping`/ARP/raw TCP connect all succeeded, but every local Tuya read failed with `No route to host`, including after an idle wait. That made it a good adversarial test: rebuilt the release binary from this branch into the production launchd path and restarted the live service, since `office-automate-server smoke ... erv` bypasses the writer entirely and can't exercise this. With `RUST_LOG=debug`, the retry is directly visible doing exactly what it's supposed to, re-confirmed against the final commit on this branch:

```
DEBUG ERV local read attempt 1/3 failed, retrying for a cold radio: ... No route to host (os error 65)
DEBUG ERV local read attempt 2/3 failed, retrying for a cold radio: ... No route to host (os error 65)
WARN  ERV boot read failed: ... No route to host (os error 65)
INFO  ERV boot state unknown; forced off via the Smart Life off scene
```

Two retries, a second apart, then a correct fallthrough to recovery -- confirming both that the transient path still retries as intended and that `is_non_retryable_local_error` does not false-positive on the real, production-wrapped error chain (it only matches key/config errors, not this one). I couldn't observe the "recovers on retry" direction live since the device didn't come back up during testing; that direction is covered by the unit tests above using the same failure signature (`No route to host`) from the ticket's own evidence.

Also observed and unrelated to this change: two `cannot convert float seconds to Duration: value is negative` panics in the server's error log, both during a period where I was rapidly killing/restarting the service while sorting out a `launchctl kickstart` quirk (plain `kickstart` silently no-ops on an already-running job; `-k` then `-p` is what actually restarts it). Didn't reproduce outside that self-inflicted chaos and isn't in code this PR touches, so flagging rather than chasing it here.

Fixes #163