### PR TITLE
Sign the server binary with a stable identity so Local Network survives rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ config.yaml
 
 # Rust
 target/
+target-signing/
 
 # Tuya local key / Smart Life auth material
 tuya-sharing-auth.json

--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -81,7 +81,7 @@ Apply the selected MQTT feed strategy:
 Start the Rust backend and Cloudflare Tunnel services with launchd or the equivalent foreground commands:
 
 ```bash
-./target/release/office-automate-server serve --config "$OFFICE_AUTOMATE_CONFIG"
+"$server_bin" serve --config "$OFFICE_AUTOMATE_CONFIG"
 cloudflared tunnel --config "$CLOUDFLARED_CONFIG" run "$CLOUDFLARED_TUNNEL"
 ```
 
@@ -90,7 +90,7 @@ cloudflared tunnel --config "$CLOUDFLARED_CONFIG" run "$CLOUDFLARED_TUNNEL"
 Run cutover validation after Rust is the only active climate controller:
 
 ```bash
-./target/release/office-automate-server validate \
+"$server_bin" validate \
   --config "$OFFICE_AUTOMATE_CONFIG" \
   cutover \
   --base-url "$OFFICE_AUTOMATE_CUTOVER_BASE_URL" \

--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -44,10 +44,11 @@ Do not run `office-automate-server serve` with those flags while the Python acti
 
 ## Cutover Sequence
 
-Build and run final preflight checks:
+Build and run final preflight checks. Build via `scripts/build-server.sh`, not a
+bare `cargo build --release` — see [code-signing.md](code-signing.md).
 
 ```bash
-cargo build --manifest-path rust/office-automate-server/Cargo.toml --release
+scripts/build-server.sh
 ./target/release/office-automate-server migrate --config "$OFFICE_AUTOMATE_CONFIG"
 ./target/release/office-automate-server smoke --config "$OFFICE_AUTOMATE_CONFIG"
 cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"

--- a/docs/deployment/backend-mqtt-cutover.md
+++ b/docs/deployment/backend-mqtt-cutover.md
@@ -49,8 +49,9 @@ bare `cargo build --release` — see [code-signing.md](code-signing.md).
 
 ```bash
 scripts/build-server.sh
-./target/release/office-automate-server migrate --config "$OFFICE_AUTOMATE_CONFIG"
-./target/release/office-automate-server smoke --config "$OFFICE_AUTOMATE_CONFIG"
+server_bin="${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}"
+"$server_bin" migrate --config "$OFFICE_AUTOMATE_CONFIG"
+"$server_bin" smoke --config "$OFFICE_AUTOMATE_CONFIG"
 cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"
 ```
 

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -118,9 +118,16 @@ $ codesign -d -r- target/release/office-automate-server
 Any incidental cargo invocation that touches the release profile is enough. This
 is why verification is a standing step rather than a build-time one.
 
-The script fails closed: if the signing identity is missing it stops rather than
-deploying a binary that will lose the grant. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1`
-overrides this and warns loudly.
+The script fails closed: if the signing identity is missing it stops **before
+running `cargo build`**, so the deployed binary is left untouched rather than
+overwritten with an ad-hoc artifact that a nonzero exit code would otherwise
+mask. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1` overrides this and warns loudly.
+
+`--target-dir`, `--target`, and a `CARGO_TARGET_DIR` in the environment are
+rejected. Cargo would then write the binary somewhere other than
+`target/release/office-automate-server`, and this script would sign whatever
+stale artifact was already at the expected path instead of the one just built.
+Build and sign such a binary by hand if you need it.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -118,16 +118,40 @@ $ codesign -d -r- target/release/office-automate-server
 Any incidental cargo invocation that touches the release profile is enough. This
 is why verification is a standing step rather than a build-time one.
 
-The script fails closed: if the signing identity is missing it stops **before
-running `cargo build`**, so the deployed binary is left untouched rather than
-overwritten with an ad-hoc artifact that a nonzero exit code would otherwise
-mask. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1` overrides this and warns loudly.
+The script fails closed in two layers:
 
-The script does not assume where cargo writes its output. `--target-dir`,
-`--target`, `--config build.target-dir=...`/`build.target=...`,
-`CARGO_TARGET_DIR`, `CARGO_BUILD_TARGET_DIR`, and `.cargo/config.toml` can all
-relocate it, so the script reads cargo's own `--message-format=json` build
-output to find the actual executable path and deploys that. Requires `jq`.
+1. **Preflight.** If the signing identity is missing, or its certificate root
+   doesn't match the pinned `OFFICE_AUTOMATE_SIGNING_CERT_ROOT` (for example
+   because the certificate was regenerated), it stops before running `cargo
+   build` at all. This is a fast-fail optimization, not the full guarantee —
+   see the next point for why.
+2. **Isolated build, atomic deploy.** `cargo build` is never pointed at the
+   deploy path. By default it builds into `target-signing/`, a separate,
+   persistent directory next to `target/` — persistent so cargo's dependency
+   and incremental cache still speeds up successive builds, separate so a
+   build can fail or produce something unsignable without having touched the
+   binary launchd runs. The script then copies that output to a temp file
+   next to the deploy path, signs and verifies **the temp file**, and only
+   `mv`s it over the deployed binary once both succeed. A `codesign` failure
+   the preflight check can't predict — a locked keychain, or the private
+   key's access control denying a non-interactive request, for instance —
+   leaves the previously deployed, still-working binary untouched.
+
+`OFFICE_AUTOMATE_ALLOW_UNSIGNED=1` skips both of the above and deploys the
+ad-hoc build directly, warning loudly.
+
+An operator's own `CARGO_TARGET_DIR`, `--target-dir`, `--target`, or `--config
+build.target-dir=...`/`build.target=...` is respected untouched; the script
+only supplies its own `target-signing/` default when none of those is set.
+Whichever applies, the script reads cargo's own `--message-format=json` build
+output to find the actual executable path rather than assuming one — enumerating
+every way cargo's output location can be overridden (there is also
+`CARGO_BUILD_TARGET_DIR`/`CARGO_BUILD_TARGET` and `.cargo/config.toml`) is an
+arms race asking cargo directly avoids. Requires `jq`.
+
+`target-signing/` is gitignored and holds full release build artifacts, so
+expect it to roughly double the disk this repo's build output uses. It is
+safe to delete at any time; the next build recreates it, just slower.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -123,11 +123,11 @@ running `cargo build`**, so the deployed binary is left untouched rather than
 overwritten with an ad-hoc artifact that a nonzero exit code would otherwise
 mask. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1` overrides this and warns loudly.
 
-`--target-dir`, `--target`, and a `CARGO_TARGET_DIR` in the environment are
-rejected. Cargo would then write the binary somewhere other than
-`target/release/office-automate-server`, and this script would sign whatever
-stale artifact was already at the expected path instead of the one just built.
-Build and sign such a binary by hand if you need it.
+The script does not assume where cargo writes its output. `--target-dir`,
+`--target`, `--config build.target-dir=...`/`build.target=...`,
+`CARGO_TARGET_DIR`, `CARGO_BUILD_TARGET_DIR`, and `.cargo/config.toml` can all
+relocate it, so the script reads cargo's own `--message-format=json` build
+output to find the actual executable path and deploys that. Requires `jq`.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -1,0 +1,176 @@
+# Code Signing the Server Binary
+
+`office-automate-server` reads the ERV over the LAN. On macOS that is gated by
+the Local Network privacy permission, and the permission is attached to the
+binary's code-signing identity — not to its path. This document explains why the
+binary must be signed with a stable identity, how to set that up once, and how
+to verify it afterwards.
+
+Background: #166 (root cause) and #167 (this fix).
+
+## Why
+
+`cargo build --release` produces an ad-hoc, linker-signed binary with no Team ID.
+For such a binary macOS keys the Local Network grant on the **cdhash**, which is
+derived from the binary's contents. Every rebuild therefore mints a new subject
+with no grant.
+
+The consequence is silent: a denied Local Network connection surfaces as an
+immediate `EHOSTUNREACH` — "No route to host (os error 65)" — 0.4 ms after the
+connect call, with the device pingable and its port open the whole time. It does
+not look like a permissions problem. It cost two tickets and roughly 24 hours of
+dead ERV readback before it was identified.
+
+Signing with a stable certificate replaces the content-derived requirement with
+one based on identifier plus certificate root:
+
+```
+designated => identifier "com.office-automate.server" and certificate root = H"36fc54a8..."
+```
+
+Neither term changes when the code changes, so one Local Network grant survives
+every subsequent rebuild.
+
+## One-time setup
+
+All three steps are required. Each has been observed to be load-bearing.
+
+### 1. Create a self-signed code-signing certificate
+
+An Apple Developer ID is **not** required; a self-signed identity is honoured
+(verified on macOS 26.5.1).
+
+Keychain Access → **Certificate Assistant** → **Create a Certificate…**
+
+| Field | Value |
+| --- | --- |
+| Name | `Office Automate Local Signing` |
+| Identity Type | Self Signed Root |
+| Certificate Type | **Code Signing** |
+| Validity | Tick "Let me override defaults" and set 7300 days, so it does not lapse in a year |
+
+### 2. Trust it for code signing
+
+Double-click the certificate in the **login** keychain → expand **Trust** →
+set **Code Signing** to **Always Trust** → close the window and authenticate.
+
+Without this, `codesign` fails with `CSSMERR_TP_NOT_TRUSTED` and then
+`no identity found`.
+
+Verify:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+The identity must appear here. Note that plain `security find-identity`, which
+uses the X.509 Basic policy, will still report `CSSMERR_TP_NOT_TRUSTED` for this
+certificate. That is expected and harmless — only the codesigning policy matters.
+
+### 3. Allow `codesign` to use the private key
+
+Keychain Access → **Keys** → the **private** key named `Office Automate Local
+Signing` → **Get Info** → **Access Control**. Either select "Allow all
+applications to access this item", or keep "Confirm before allowing access",
+untick "Ask for Keychain password", and add `/usr/bin/codesign` to the list.
+
+Skipping this makes every build prompt for the login keychain password. The
+public key's access control is not consulted and does not need changing.
+
+### 4. Grant Local Network once, after the first signed build
+
+Adopting signing **changes the binary's identity**, so any existing grant does
+not carry over. Build and restart once, then approve the Local Network prompt
+for `office-automate-server` (or enable it under System Settings → Privacy &
+Security → Local Network). After that it is stable across rebuilds.
+
+Do not read anything into a single successful boot read taken immediately after
+signing — the grant state settles a restart later, and a first-restart success
+before any grant exists has been observed. Confirm with a second restart.
+
+## Building
+
+Use the build script. It builds, signs, and verifies in one step:
+
+```bash
+scripts/build-server.sh
+```
+
+Extra arguments are passed through to `cargo build --release`, so
+`scripts/build-server.sh --locked` works.
+
+A bare `cargo build --release` overwrites the signed binary in place with an
+ad-hoc one and silently breaks ERV local readback on the next restart. If you
+do run one, re-sign afterwards by running `scripts/build-server.sh` again.
+
+The script fails closed: if the signing identity is missing it stops rather than
+deploying a binary that will lose the grant. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1`
+overrides this and warns loudly.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OFFICE_AUTOMATE_SIGNING_IDENTITY` | `Office Automate Local Signing` | Keychain identity to sign with |
+| `OFFICE_AUTOMATE_SIGNING_IDENTIFIER` | `com.office-automate.server` | Pinned signing identifier |
+| `OFFICE_AUTOMATE_SIGNING_CERT_ROOT` | `36fc54a8…` | Expected certificate root hash |
+| `OFFICE_AUTOMATE_ALLOW_UNSIGNED` | unset | Build unsigned and accept broken readback |
+
+### Why the identifier is pinned
+
+Cargo's default signing identifier embeds a metadata hash —
+`office_automate_server-652815103961bb17` — that changes on version bumps,
+dependency bumps, and toolchain updates. Signing without `codesign -i` would
+pass a two-rebuild test today and reintroduce this bug on the next `cargo
+update`. `scripts/build-server.sh` pins it and refuses to accept a requirement
+that does not.
+
+## Verifying
+
+Run this after any build, and whenever ERV local readback looks wrong:
+
+```bash
+scripts/build-server.sh --verify-only
+```
+
+It reads the deployed binary's designated requirement and fails if a cdhash term
+is present, if the identifier is not pinned, or if the certificate root is not
+the expected one.
+
+## Restarting
+
+Restart after deploying a new binary:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.office-automate.server
+launchctl kickstart -p gui/$(id -u)/com.office-automate.server
+```
+
+`launchctl kickstart` **without** `-k` does not restart an already-running job —
+it no-ops and leaves the PID unchanged. The two-command sequence above is the
+one verified to work on this host.
+
+Then confirm readback actually recovered:
+
+```bash
+grep "ERV boot read" logs/office-automate-server.out.log | tail -1
+```
+
+A success looks like `ERV boot read: running=false speed=off`. A failure looks
+like `ERV boot read failed: ... No route to host (os error 65)`, which means the
+Local Network grant is missing for the current identity.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `no identity found` from `codesign` | Certificate missing, or not trusted for the Code Signing policy. See steps 1–2. |
+| Keychain password prompt on every build | Private key access control not set. See step 3. |
+| `designated requirement contains a cdhash term` | The binary is ad-hoc signed — something ran a bare `cargo build --release`. Rebuild with `scripts/build-server.sh`. |
+| `not anchored to the expected certificate root` | The certificate was regenerated. It is a new TCC subject: re-grant Local Network and update `OFFICE_AUTOMATE_SIGNING_CERT_ROOT`. |
+| Boot read fails instantly with `os error 65` while `ping` and `nc` to port 6668 succeed | Local Network denial for the current identity, not a network fault. |
+
+## Certificate rotation
+
+The certificate is the anchor for the grant, so replacing it is a re-grant event.
+If it expires or is regenerated: create and trust the new certificate, update
+`OFFICE_AUTOMATE_SIGNING_CERT_ROOT` to the new root hash (visible in
+`codesign -d -r-` output), rebuild, restart, and approve Local Network once more.

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -128,6 +128,7 @@ overrides this and warns loudly.
 | `OFFICE_AUTOMATE_SIGNING_IDENTIFIER` | `com.office-automate.server` | Pinned signing identifier |
 | `OFFICE_AUTOMATE_SIGNING_CERT_ROOT` | `36fc54a8…` | Expected certificate root hash |
 | `OFFICE_AUTOMATE_ALLOW_UNSIGNED` | unset | Build unsigned and accept broken readback |
+| `OFFICE_AUTOMATE_SERVER_BIN` | `target/release/office-automate-server` | Where the built binary is deployed and signed. If set to a path other than cargo's own output, the freshly built binary is copied there before signing. |
 
 ### Why the identifier is pinned
 

--- a/docs/deployment/code-signing.md
+++ b/docs/deployment/code-signing.md
@@ -103,6 +103,21 @@ A bare `cargo build --release` overwrites the signed binary in place with an
 ad-hoc one and silently breaks ERV local readback on the next restart. If you
 do run one, re-sign afterwards by running `scripts/build-server.sh` again.
 
+This happens even when nothing needs recompiling. Cargo keeps the real artifact
+under `target/release/deps/` and copies it to `target/release/`; signing modifies
+the copy, so the next cargo invocation re-copies over it. Verified:
+
+```
+$ scripts/build-server.sh          # signed
+$ cargo build --release
+    Finished `release` profile [optimized] target(s) in 0.11s
+$ codesign -d -r- target/release/office-automate-server
+# designated => cdhash H"..."      # signature gone, nothing was rebuilt
+```
+
+Any incidental cargo invocation that touches the release profile is enough. This
+is why verification is a standing step rather than a build-time one.
+
 The script fails closed: if the signing identity is missing it stops rather than
 deploying a binary that will lose the grant. `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1`
 overrides this and warns loudly.

--- a/docs/deployment/dry-run-migration.md
+++ b/docs/deployment/dry-run-migration.md
@@ -89,8 +89,8 @@ For rollback rehearsal, restore from the snapshot into a temporary directory, so
 
 ```bash
 source /absolute/path/to/restored-snapshot/restore-env.sh
-./target/release/office-automate-server migrate --config "$OFFICE_AUTOMATE_CONFIG"
-./target/release/office-automate-server collect --config "$OFFICE_AUTOMATE_CONFIG" telemetry --dry-run
+"$server_bin" migrate --config "$OFFICE_AUTOMATE_CONFIG"
+"$server_bin" collect --config "$OFFICE_AUTOMATE_CONFIG" telemetry --dry-run
 cloudflared tunnel ingress validate --config "$CLOUDFLARED_CONFIG"
 ```
 

--- a/docs/deployment/dry-run-migration.md
+++ b/docs/deployment/dry-run-migration.md
@@ -31,10 +31,11 @@ Cloudflare Tunnel credentials stay in the `cloudflared` config and credential fi
 
 ## Snapshot Command
 
-Build the Rust binary, then run:
+Build the Rust binary via `scripts/build-server.sh`, not a bare
+`cargo build --release` — see [code-signing.md](code-signing.md) — then run:
 
 ```bash
-cargo build --manifest-path rust/office-automate-server/Cargo.toml --release
+scripts/build-server.sh
 ./target/release/office-automate-server snapshot \
   --config "$OFFICE_AUTOMATE_CONFIG" \
   --output-dir "$OFFICE_AUTOMATE_SNAPSHOT_DIR" \

--- a/docs/deployment/dry-run-migration.md
+++ b/docs/deployment/dry-run-migration.md
@@ -36,7 +36,8 @@ Build the Rust binary via `scripts/build-server.sh`, not a bare
 
 ```bash
 scripts/build-server.sh
-./target/release/office-automate-server snapshot \
+server_bin="${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}"
+"$server_bin" snapshot \
   --config "$OFFICE_AUTOMATE_CONFIG" \
   --output-dir "$OFFICE_AUTOMATE_SNAPSHOT_DIR" \
   --cloudflared-config "$CLOUDFLARED_CONFIG"

--- a/docs/deployment/primary-host-launchd.md
+++ b/docs/deployment/primary-host-launchd.md
@@ -14,6 +14,25 @@ The templates live in `scripts/launchd/primary-host/`:
 
 LocalTunnel is intentionally not represented. Public access is Cloudflare Tunnel only. `cloudflared` should route to `office-automate-server serve-edge`; the edge then calls the controller over the local authenticated IPC token.
 
+## Code Signing
+
+Build the binary these jobs point at with `scripts/build-server.sh`, never a bare
+`cargo build --release`. The server reads the ERV over the LAN, and macOS attaches
+that Local Network permission to the binary's code-signing identity. An ad-hoc
+`cargo` build is keyed on its cdhash, so every rebuild loses the grant and ERV local
+readback fails with an instant `No route to host (os error 65)` while the device is
+perfectly reachable.
+
+After deploying a new binary, verify the signature survived and confirm readback
+recovered:
+
+```bash
+scripts/build-server.sh --verify-only
+grep "ERV boot read" logs/office-automate-server.out.log | tail -1
+```
+
+Full background and the one-time certificate setup: [code-signing.md](code-signing.md).
+
 ## Template Values
 
 Render the templates with deployment-specific absolute paths before loading them:

--- a/docs/deployment/shadow-mode-validation.md
+++ b/docs/deployment/shadow-mode-validation.md
@@ -39,8 +39,13 @@ Do not run this validation with active-control flags enabled.
 Build the Rust binary:
 
 ```bash
-cargo build --manifest-path rust/office-automate-server/Cargo.toml --release
+scripts/build-server.sh
 ```
+
+`scripts/build-server.sh` wraps `cargo build --release` with the code-signing step
+that keeps the binary's macOS Local Network grant alive across rebuilds. A bare
+`cargo build --release` silently breaks ERV local readback — see
+[code-signing.md](code-signing.md).
 
 Start the Rust server on a non-production port:
 

--- a/docs/deployment/shadow-mode-validation.md
+++ b/docs/deployment/shadow-mode-validation.md
@@ -40,6 +40,7 @@ Build the Rust binary:
 
 ```bash
 scripts/build-server.sh
+server_bin="${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}"
 ```
 
 `scripts/build-server.sh` wraps `cargo build --release` with the code-signing step
@@ -50,7 +51,7 @@ that keeps the binary's macOS Local Network grant alive across rebuilds. A bare
 Start the Rust server on a non-production port:
 
 ```bash
-./target/release/office-automate-server serve \
+"$server_bin" serve \
   --config "$OFFICE_AUTOMATE_CONFIG"
 ```
 
@@ -120,7 +121,7 @@ The evidence file must not contain API tokens, service-token secrets, tunnel cre
 Run the Rust validation command:
 
 ```bash
-./target/release/office-automate-server validate \
+"$server_bin" validate \
   --config "$OFFICE_AUTOMATE_CONFIG" \
   shadow \
   --base-url "$OFFICE_AUTOMATE_SHADOW_BASE_URL" \

--- a/docs/deployment/supply-chain.md
+++ b/docs/deployment/supply-chain.md
@@ -38,7 +38,7 @@ cd android
 cd ..
 
 scripts/build-server.sh --locked
-scripts/security/release-provenance.sh target/release/office-automate-server
+scripts/security/release-provenance.sh "${OFFICE_AUTOMATE_SERVER_BIN:-target/release/office-automate-server}"
 ```
 
 The provenance script fails if tracked files are dirty and prints the commit, commit date, artifact size, and SHA-256.

--- a/docs/deployment/supply-chain.md
+++ b/docs/deployment/supply-chain.md
@@ -37,11 +37,16 @@ cd android
 ./gradlew --dependency-verification=strict :app:assembleDebug
 cd ..
 
-cargo build --locked --manifest-path rust/office-automate-server/Cargo.toml --release
+scripts/build-server.sh --locked
 scripts/security/release-provenance.sh target/release/office-automate-server
 ```
 
 The provenance script fails if tracked files are dirty and prints the commit, commit date, artifact size, and SHA-256.
+
+`scripts/build-server.sh` passes its arguments through to `cargo build --release` and
+adds the code-signing step described in [code-signing.md](code-signing.md). Note that
+the recorded SHA-256 covers the signed artifact, so it changes when the signature is
+reapplied even if the compiled code is identical.
 
 ## Rust Dependency Review
 

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -19,7 +19,9 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 manifest="$root/rust/office-automate-server/Cargo.toml"
-binary="${OFFICE_AUTOMATE_SERVER_BIN:-$root/target/release/office-automate-server}"
+# cargo always writes here regardless of any deploy-path override below.
+cargo_bin="$root/target/release/office-automate-server"
+binary="${OFFICE_AUTOMATE_SERVER_BIN:-$cargo_bin}"
 
 # The identity lives in the login keychain and is not in the repo. The
 # identifier and certificate root are pinned because both are load-bearing:
@@ -116,6 +118,14 @@ case "${1:-}" in
 esac
 
 cargo build --release --manifest-path "$manifest" "$@"
+
+# If OFFICE_AUTOMATE_SERVER_BIN points somewhere other than cargo's own output
+# (a deployment path, for example), deploy the binary that was just built
+# before signing it. Otherwise the freshly built code never reaches $binary
+# and a stale file gets a valid signature.
+if [[ "$binary" != "$cargo_bin" ]]; then
+  cp -p "$cargo_bin" "$binary"
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   printf 'build-server: not macOS, skipping code signing\n'

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Build office-automate-server and sign it with a stable code-signing identity.
+#
+# Why this exists: `cargo build --release` produces an ad-hoc, linker-signed
+# binary with no Team ID. macOS keys the Local Network (TCC) grant for such a
+# binary on its cdhash, so every rebuild is a new subject with no grant and ERV
+# local readback silently dies until Local Network is granted again. Signing
+# with a stable identity yields a designated requirement based on identifier
+# plus certificate root instead, which survives rebuilds.
+#
+# One-time certificate setup and the full background: docs/deployment/code-signing.md
+#
+# Usage:
+#   scripts/build-server.sh [cargo args...]   build, sign, verify
+#   scripts/build-server.sh --verify-only     verify the already-deployed binary
+#   scripts/build-server.sh --check-dr        validate a requirement string on stdin
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+manifest="$root/rust/office-automate-server/Cargo.toml"
+binary="${OFFICE_AUTOMATE_SERVER_BIN:-$root/target/release/office-automate-server}"
+
+# The identity lives in the login keychain and is not in the repo. The
+# identifier and certificate root are pinned because both are load-bearing:
+# a change to either produces a different TCC subject and drops the grant.
+identity="${OFFICE_AUTOMATE_SIGNING_IDENTITY:-Office Automate Local Signing}"
+identifier="${OFFICE_AUTOMATE_SIGNING_IDENTIFIER:-com.office-automate.server}"
+cert_root="${OFFICE_AUTOMATE_SIGNING_CERT_ROOT:-36fc54a873d584a34fcfeea7d1f519b19a39de72}"
+
+doc="docs/deployment/code-signing.md"
+
+die() {
+  printf 'build-server: error: %s\n' "$*" >&2
+  exit 1
+}
+
+warn() {
+  printf 'build-server: warning: %s\n' "$*" >&2
+}
+
+# Validate a `codesign -d -r-` designated requirement. Kept free of any
+# keychain or binary access so it can be unit-tested with fixtures.
+check_dr() {
+  local dr
+  dr="$(cat)"
+
+  [[ -n "${dr//[[:space:]]/}" ]] || die "empty designated requirement"
+
+  # A cdhash term means the identity is content-keyed and will not survive a
+  # rebuild. This is the exact failure #167 exists to eliminate.
+  if printf '%s' "$dr" | grep -qi 'cdhash'; then
+    die "designated requirement contains a cdhash term, so it will not survive a rebuild:
+  $dr
+The binary is ad-hoc signed. See $doc"
+  fi
+
+  # Cargo's default identifier embeds a metadata hash (office_automate_server-<hash>)
+  # that changes on version and dependency bumps, so the identifier must be pinned
+  # explicitly with `codesign -i`.
+  if ! printf '%s' "$dr" | grep -qF "identifier \"$identifier\""; then
+    die "designated requirement does not pin identifier \"$identifier\":
+  $dr
+Sign with: codesign -i $identifier. See $doc"
+  fi
+
+  if ! printf '%s' "$dr" | grep -qiF "certificate root = H\"$cert_root\""; then
+    die "designated requirement is not anchored to the expected certificate root $cert_root:
+  $dr
+The signing certificate differs from the one the Local Network grant was issued to.
+Either sign with the original certificate, or set OFFICE_AUTOMATE_SIGNING_CERT_ROOT
+and re-grant Local Network. See $doc"
+  fi
+}
+
+requirement_of() {
+  # An ad-hoc binary's requirement is emitted as a "# designated => ..." comment
+  # rather than a bare line, so match both forms — otherwise the cdhash check
+  # never fires on the exact case it exists to catch.
+  codesign -d -r- "$1" 2>/dev/null | grep -E '^#? *designated' \
+    || die "could not read a designated requirement from $1"
+}
+
+verify() {
+  [[ -x "$binary" ]] || die "no binary at $binary"
+  local dr
+  dr="$(requirement_of "$binary")"
+  printf '%s\n' "$dr" | check_dr
+  printf 'build-server: signature verified\n  %s\n  %s\n' "$binary" "$dr"
+}
+
+sign() {
+  codesign --force --sign "$identity" -i "$identifier" "$binary" \
+    || die "codesign failed. If it reported 'no identity found', the certificate is
+missing or not trusted for the Code Signing policy. See $doc"
+}
+
+case "${1:-}" in
+  --check-dr)
+    check_dr
+    exit 0
+    ;;
+  --verify-only)
+    verify
+    exit 0
+    ;;
+esac
+
+cargo build --release --manifest-path "$manifest" "$@"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  printf 'build-server: not macOS, skipping code signing\n'
+  exit 0
+fi
+
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "\"$identity\""; then
+  if [[ "${OFFICE_AUTOMATE_ALLOW_UNSIGNED:-}" == "1" ]]; then
+    warn "signing identity \"$identity\" not found and OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 is set.
+  The binary is ad-hoc signed. ERV local readback WILL fail after restart until
+  Local Network is granted to this build, and will break again on the next build.
+  See $doc"
+    exit 0
+  fi
+  die "signing identity \"$identity\" not found in the keychain.
+Create and trust it once, per $doc, or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to
+build an unsigned binary and accept broken ERV local readback."
+fi
+
+sign
+verify

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -19,9 +19,20 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 manifest="$root/rust/office-automate-server/Cargo.toml"
-# cargo always writes here regardless of any deploy-path override below.
+# Deploy path — what launchd runs. Independent of where cargo actually builds;
+# see the CARGO_TARGET_DIR default below and why the two must stay decoupled.
 cargo_bin="$root/target/release/office-automate-server"
 binary="${OFFICE_AUTOMATE_SERVER_BIN:-$cargo_bin}"
+
+# Build into a target directory that is never the deploy path, so a build
+# whose signing later fails cannot have already clobbered $binary before we
+# know that. Persistent (not a fresh mktemp -d per run) so cargo's dependency
+# and incremental cache carries over between builds — forcing a clean
+# target-dir every time would turn every build into a full rebuild. Only used
+# as a default: an operator's own CARGO_TARGET_DIR, --target-dir, or --config
+# build.target-dir is respected untouched.
+: "${CARGO_TARGET_DIR:=$root/target-signing}"
+export CARGO_TARGET_DIR
 
 # The identity lives in the login keychain and is not in the repo. The
 # identifier and certificate root are pinned because both are load-bearing:
@@ -83,25 +94,31 @@ requirement_of() {
     || die "could not read a designated requirement from $1"
 }
 
+# Both take an optional path, defaulting to the deploy path $binary. The main
+# build flow passes an explicit temp path so it can sign/verify a candidate
+# before ever touching $binary; --verify-only calls these with no argument to
+# check the binary already deployed there.
 verify() {
-  [[ -x "$binary" ]] || die "no binary at $binary"
+  local target="${1:-$binary}"
+  [[ -x "$target" ]] || die "no binary at $target"
 
   # `codesign -d -r-` only reads the embedded designated requirement; it does
   # not confirm the signature is cryptographically valid over the file's
   # current contents. Without --verify, a binary edited or corrupted after
   # signing could still show a clean DR here and defeat the fail-closed check.
-  codesign --verify --strict "$binary" \
-    || die "signature on $binary does not verify (codesign --verify --strict failed).
+  codesign --verify --strict "$target" \
+    || die "signature on $target does not verify (codesign --verify --strict failed).
 The binary may have been modified after signing. Re-run scripts/build-server.sh."
 
   local dr
-  dr="$(requirement_of "$binary")"
+  dr="$(requirement_of "$target")"
   printf '%s\n' "$dr" | check_dr
-  printf 'build-server: signature verified\n  %s\n  %s\n' "$binary" "$dr"
+  printf 'build-server: signature verified\n  %s\n  %s\n' "$target" "$dr"
 }
 
 sign() {
-  codesign --force --sign "$identity" -i "$identifier" "$binary" \
+  local target="${1:-$binary}"
+  codesign --force --sign "$identity" -i "$identifier" "$target" \
     || die "codesign failed. If it reported 'no identity found', the certificate is
 missing or not trusted for the Code Signing policy. See $doc"
 }
@@ -122,20 +139,19 @@ command -v jq >/dev/null 2>&1 || die "jq is required to locate cargo's build out
 is_darwin=false
 [[ "$(uname -s)" == "Darwin" ]] && is_darwin=true
 
-# Determine signing availability before cargo runs. Otherwise a build that
-# turns out to be unsignable has already overwritten the deployed binary
-# (default path or --verify-only path) with an ad-hoc artifact by the time
-# the identity check fails, leaving Local Network readback broken despite
-# the script exiting nonzero — the exact silent-breakage this PR removes.
+# Fast-fail before invoking cargo at all when we can already tell signing
+# will not work. This is an optimization, not the safety net — cargo building
+# into an isolated target-dir plus the sign-a-temp-copy-then-atomically-move
+# sequence below is what actually guarantees $binary is never touched by a
+# build that turns out to be unsignable, including failure modes this check
+# cannot see in advance (a keychain-locked or ACL-denied private key, for
+# example).
 #
-# Matching on name alone is not enough: a regenerated certificate (or a
-# duplicate-named identity) can share the name while its root differs from
-# the pinned $cert_root, in which case name-only matching says "available"
-# but signing would produce a different TCC subject and fail verify() only
-# after cargo build has already overwritten the deployed binary. For a
-# self-signed identity, the SHA-1 `security find-identity` reports for it is
-# the same hash `codesign -d -r-` reports as its certificate root, so check
-# both before touching anything.
+# Matching on identity name alone is not enough: a regenerated certificate
+# (or a duplicate-named identity) can share the name while its root differs
+# from the pinned $cert_root. For a self-signed identity, the SHA-1
+# `security find-identity` reports for it is the same hash `codesign -d -r-`
+# reports as its certificate root, so check both.
 signing_available=false
 if $is_darwin; then
   identity_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "\"$identity\"" || true)"
@@ -161,9 +177,11 @@ fi
 # CARGO_BUILD_TARGET_DIR/CARGO_BUILD_TARGET, and .cargo/config.toml can all
 # relocate cargo's output — enumerating every such override is an arms race
 # this script keeps losing. Reading cargo's own build-plan output cannot miss
-# a future one.
+# a future one. With our own CARGO_TARGET_DIR default above, this ordinarily
+# resolves under target-signing/, not under $binary's directory.
 json_log="$(mktemp)"
-trap 'rm -f "$json_log"' EXIT
+tmp_binary=""
+trap 'rm -f "$json_log" "${tmp_binary:-}"' EXIT
 
 cargo build --release --manifest-path "$manifest" --message-format=json-render-diagnostics "$@" \
   | tee "$json_log" \
@@ -181,19 +199,16 @@ built_bin="$(jq -r --arg pkg "office-automate-server" '
 [[ -n "$built_bin" && -x "$built_bin" ]] \
   || die "could not determine the built binary's path from cargo's output"
 
-# Deploy the binary cargo actually produced. $binary defaults to $cargo_bin,
-# which built_bin will equal for a plain build with no output override — but
-# never assume that; always deploy from what cargo reported.
-if [[ "$binary" != "$built_bin" ]]; then
-  cp -p "$built_bin" "$binary"
-fi
+mkdir -p "$(dirname "$binary")"
 
 if ! $is_darwin; then
+  cp -p "$built_bin" "$binary"
   printf 'build-server: not macOS, skipping code signing\n'
   exit 0
 fi
 
 if ! $signing_available; then
+  cp -p "$built_bin" "$binary"
   warn "signing identity \"$identity\" not found and OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 is set.
   The binary is ad-hoc signed. ERV local readback WILL fail after restart until
   Local Network is granted to this build, and will break again on the next build.
@@ -201,5 +216,16 @@ if ! $signing_available; then
   exit 0
 fi
 
-sign
-verify
+# Sign and verify a copy, never $binary directly. If codesign fails for any
+# reason — including ones the preflight check above cannot predict, such as
+# the keychain being locked or the private key's access control denying a
+# non-interactive request — $binary is left exactly as it was: the previous,
+# already-signed, working deployment.
+tmp_binary="$(mktemp "$(dirname "$binary")/.office-automate-server.XXXXXX")"
+cp -p "$built_bin" "$tmp_binary"
+sign "$tmp_binary"
+verify "$tmp_binary"
+mv -f "$tmp_binary" "$binary"
+tmp_binary=""
+
+printf 'build-server: deployed\n  %s\n' "$binary"

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -127,15 +127,33 @@ is_darwin=false
 # (default path or --verify-only path) with an ad-hoc artifact by the time
 # the identity check fails, leaving Local Network readback broken despite
 # the script exiting nonzero — the exact silent-breakage this PR removes.
+#
+# Matching on name alone is not enough: a regenerated certificate (or a
+# duplicate-named identity) can share the name while its root differs from
+# the pinned $cert_root, in which case name-only matching says "available"
+# but signing would produce a different TCC subject and fail verify() only
+# after cargo build has already overwritten the deployed binary. For a
+# self-signed identity, the SHA-1 `security find-identity` reports for it is
+# the same hash `codesign -d -r-` reports as its certificate root, so check
+# both before touching anything.
 signing_available=false
-if $is_darwin && security find-identity -v -p codesigning 2>/dev/null | grep -qF "\"$identity\""; then
-  signing_available=true
+if $is_darwin; then
+  identity_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "\"$identity\"" || true)"
+  # grep exits 1 on no match, e.g. when identity_line is empty; that is an
+  # expected outcome here (identity not found), not a script-ending error.
+  identity_hash="$(printf '%s' "$identity_line" | grep -oE '[0-9A-Fa-f]{40}' | tr 'A-F' 'a-f' || true)"
+  if [[ -n "$identity_line" && "$identity_hash" == "$cert_root" ]]; then
+    signing_available=true
+  fi
 fi
 
 if $is_darwin && ! $signing_available && [[ "${OFFICE_AUTOMATE_ALLOW_UNSIGNED:-}" != "1" ]]; then
-  die "signing identity \"$identity\" not found in the keychain.
-Create and trust it once, per $doc, or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to
-build an unsigned binary and accept broken ERV local readback."
+  die "no keychain identity named \"$identity\" with certificate root $cert_root was found.
+Either the identity is missing, or it was regenerated and no longer matches
+OFFICE_AUTOMATE_SIGNING_CERT_ROOT. Create and trust it once per $doc, update
+OFFICE_AUTOMATE_SIGNING_CERT_ROOT to the new root and re-grant Local Network,
+or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to build unsigned and accept broken
+ERV local readback."
 fi
 
 # Ask cargo where it actually put the binary rather than assuming $cargo_bin.

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -40,6 +40,10 @@ export CARGO_TARGET_DIR
 identity="${OFFICE_AUTOMATE_SIGNING_IDENTITY:-Office Automate Local Signing}"
 identifier="${OFFICE_AUTOMATE_SIGNING_IDENTIFIER:-com.office-automate.server}"
 cert_root="${OFFICE_AUTOMATE_SIGNING_CERT_ROOT:-36fc54a873d584a34fcfeea7d1f519b19a39de72}"
+# Normalized once here so every comparison against it (the preflight identity
+# hash, which security find-identity reports uppercase, and check_dr's
+# case-insensitive grep) is comparing like with like.
+cert_root="$(printf '%s' "$cert_root" | tr 'A-F' 'a-f')"
 
 doc="docs/deployment/code-signing.md"
 

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -117,6 +117,44 @@ case "${1:-}" in
     ;;
 esac
 
+# cargo_bin is hard-coded, so any option or env var that moves cargo's own
+# output elsewhere would make this script sign/deploy a stale leftover binary
+# instead of the one just built. Refuse rather than guess.
+for arg in "$@"; do
+  case "$arg" in
+    --target-dir|--target-dir=*|--target|--target=*)
+      die "scripts/build-server.sh does not support $arg: cargo would write the binary
+somewhere other than $cargo_bin, and this script would then sign whatever stale
+artifact was already at that path. Build and sign manually if you need a
+different Cargo output location."
+      ;;
+  esac
+done
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  die "CARGO_TARGET_DIR is set ($CARGO_TARGET_DIR): cargo would write the binary there
+instead of $cargo_bin, and this script would sign a stale artifact. Unset it
+before running scripts/build-server.sh, or build and sign manually."
+fi
+
+is_darwin=false
+[[ "$(uname -s)" == "Darwin" ]] && is_darwin=true
+
+# Determine signing availability before cargo runs. Otherwise a build that
+# turns out to be unsignable has already overwritten the deployed binary
+# (default path or --verify-only path) with an ad-hoc artifact by the time
+# the identity check fails, leaving Local Network readback broken despite
+# the script exiting nonzero — the exact silent-breakage this PR removes.
+signing_available=false
+if $is_darwin && security find-identity -v -p codesigning 2>/dev/null | grep -qF "\"$identity\""; then
+  signing_available=true
+fi
+
+if $is_darwin && ! $signing_available && [[ "${OFFICE_AUTOMATE_ALLOW_UNSIGNED:-}" != "1" ]]; then
+  die "signing identity \"$identity\" not found in the keychain.
+Create and trust it once, per $doc, or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to
+build an unsigned binary and accept broken ERV local readback."
+fi
+
 cargo build --release --manifest-path "$manifest" "$@"
 
 # If OFFICE_AUTOMATE_SERVER_BIN points somewhere other than cargo's own output
@@ -127,22 +165,17 @@ if [[ "$binary" != "$cargo_bin" ]]; then
   cp -p "$cargo_bin" "$binary"
 fi
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
+if ! $is_darwin; then
   printf 'build-server: not macOS, skipping code signing\n'
   exit 0
 fi
 
-if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "\"$identity\""; then
-  if [[ "${OFFICE_AUTOMATE_ALLOW_UNSIGNED:-}" == "1" ]]; then
-    warn "signing identity \"$identity\" not found and OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 is set.
+if ! $signing_available; then
+  warn "signing identity \"$identity\" not found and OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 is set.
   The binary is ad-hoc signed. ERV local readback WILL fail after restart until
   Local Network is granted to this build, and will break again on the next build.
   See $doc"
-    exit 0
-  fi
-  die "signing identity \"$identity\" not found in the keychain.
-Create and trust it once, per $doc, or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to
-build an unsigned binary and accept broken ERV local readback."
+  exit 0
 fi
 
 sign

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -201,14 +201,22 @@ built_bin="$(jq -r --arg pkg "office-automate-server" '
 
 mkdir -p "$(dirname "$binary")"
 
+# built_bin and binary can be the same file (no signing on this platform, or
+# --target-dir/--config pointed cargo straight at the deploy path), in which
+# case cargo already left the right bytes there and `cp` would fail with
+# "are the same file".
+deploy_unsigned() {
+  [[ "$built_bin" -ef "$binary" ]] || cp -p "$built_bin" "$binary"
+}
+
 if ! $is_darwin; then
-  cp -p "$built_bin" "$binary"
+  deploy_unsigned
   printf 'build-server: not macOS, skipping code signing\n'
   exit 0
 fi
 
 if ! $signing_available; then
-  cp -p "$built_bin" "$binary"
+  deploy_unsigned
   warn "signing identity \"$identity\" not found and OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 is set.
   The binary is ad-hoc signed. ERV local readback WILL fail after restart until
   Local Network is granted to this build, and will break again on the next build.

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -117,24 +117,7 @@ case "${1:-}" in
     ;;
 esac
 
-# cargo_bin is hard-coded, so any option or env var that moves cargo's own
-# output elsewhere would make this script sign/deploy a stale leftover binary
-# instead of the one just built. Refuse rather than guess.
-for arg in "$@"; do
-  case "$arg" in
-    --target-dir|--target-dir=*|--target|--target=*)
-      die "scripts/build-server.sh does not support $arg: cargo would write the binary
-somewhere other than $cargo_bin, and this script would then sign whatever stale
-artifact was already at that path. Build and sign manually if you need a
-different Cargo output location."
-      ;;
-  esac
-done
-if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
-  die "CARGO_TARGET_DIR is set ($CARGO_TARGET_DIR): cargo would write the binary there
-instead of $cargo_bin, and this script would sign a stale artifact. Unset it
-before running scripts/build-server.sh, or build and sign manually."
-fi
+command -v jq >/dev/null 2>&1 || die "jq is required to locate cargo's build output reliably"
 
 is_darwin=false
 [[ "$(uname -s)" == "Darwin" ]] && is_darwin=true
@@ -155,14 +138,36 @@ Create and trust it once, per $doc, or set OFFICE_AUTOMATE_ALLOW_UNSIGNED=1 to
 build an unsigned binary and accept broken ERV local readback."
 fi
 
-cargo build --release --manifest-path "$manifest" "$@"
+# Ask cargo where it actually put the binary rather than assuming $cargo_bin.
+# --target-dir/--target, --config overrides of build.target-dir/build.target,
+# CARGO_BUILD_TARGET_DIR/CARGO_BUILD_TARGET, and .cargo/config.toml can all
+# relocate cargo's output — enumerating every such override is an arms race
+# this script keeps losing. Reading cargo's own build-plan output cannot miss
+# a future one.
+json_log="$(mktemp)"
+trap 'rm -f "$json_log"' EXIT
 
-# If OFFICE_AUTOMATE_SERVER_BIN points somewhere other than cargo's own output
-# (a deployment path, for example), deploy the binary that was just built
-# before signing it. Otherwise the freshly built code never reaches $binary
-# and a stale file gets a valid signature.
-if [[ "$binary" != "$cargo_bin" ]]; then
-  cp -p "$cargo_bin" "$binary"
+cargo build --release --manifest-path "$manifest" --message-format=json-render-diagnostics "$@" \
+  | tee "$json_log" \
+  | jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' >&2
+build_status="${PIPESTATUS[0]}"
+[[ "$build_status" -eq 0 ]] || exit "$build_status"
+
+built_bin="$(jq -r --arg pkg "office-automate-server" '
+  select(.reason == "compiler-artifact"
+    and .target.name == $pkg
+    and (.target.kind | index("bin"))
+    and .executable != null) | .executable
+' "$json_log" | tail -n1)"
+
+[[ -n "$built_bin" && -x "$built_bin" ]] \
+  || die "could not determine the built binary's path from cargo's output"
+
+# Deploy the binary cargo actually produced. $binary defaults to $cargo_bin,
+# which built_bin will equal for a plain build with no output override — but
+# never assume that; always deploy from what cargo reported.
+if [[ "$binary" != "$built_bin" ]]; then
+  cp -p "$built_bin" "$binary"
 fi
 
 if ! $is_darwin; then

--- a/scripts/build-server.sh
+++ b/scripts/build-server.sh
@@ -83,6 +83,15 @@ requirement_of() {
 
 verify() {
   [[ -x "$binary" ]] || die "no binary at $binary"
+
+  # `codesign -d -r-` only reads the embedded designated requirement; it does
+  # not confirm the signature is cryptographically valid over the file's
+  # current contents. Without --verify, a binary edited or corrupted after
+  # signing could still show a clean DR here and defeat the fail-closed check.
+  codesign --verify --strict "$binary" \
+    || die "signature on $binary does not verify (codesign --verify --strict failed).
+The binary may have been modified after signing. Re-run scripts/build-server.sh."
+
   local dr
   dr="$(requirement_of "$binary")"
   printf '%s\n' "$dr" | check_dr

--- a/tests/test_build_server_signing.py
+++ b/tests/test_build_server_signing.py
@@ -1,0 +1,82 @@
+"""Tests for the designated-requirement guard in scripts/build-server.sh.
+
+These exercise `--check-dr`, which validates a `codesign -d -r-` requirement
+string read from stdin. That seam needs no keychain, no certificate, and no
+built binary, so the guard that keeps the Local Network grant stable is
+testable on any machine.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "build-server.sh"
+
+IDENTIFIER = "com.office-automate.server"
+CERT_ROOT = "36fc54a873d584a34fcfeea7d1f519b19a39de72"
+
+STABLE_DR = f'designated => identifier "{IDENTIFIER}" and certificate root = H"{CERT_ROOT}"'
+
+
+def check_dr(requirement: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--check-dr"],
+        input=requirement,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_accepts_stable_requirement():
+    result = check_dr(STABLE_DR)
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_cdhash_requirement():
+    """An ad-hoc binary is keyed on content, so its grant dies on every rebuild."""
+    result = check_dr('designated => cdhash H"4032bf3d8b5ba710b7485e855b2a0a4c746d85ad"')
+    assert result.returncode != 0
+    assert "cdhash" in result.stderr
+
+
+def test_rejects_commented_cdhash_requirement():
+    """codesign emits an ad-hoc binary's requirement as a `# designated => ...` comment.
+
+    The extraction must match that form too, or the cdhash check never fires on
+    the very case it exists to catch.
+    """
+    result = check_dr('# designated => cdhash H"9a915dfa23d06a637a27ef789c14387ab92e3db1"')
+    assert result.returncode != 0
+    assert "cdhash" in result.stderr
+
+
+def test_rejects_cargo_default_identifier():
+    """Cargo's identifier embeds a metadata hash that churns on version bumps.
+
+    Signing without `-i` passes a naive two-rebuild test and then breaks
+    readback on the next dependency bump, which is the regression #167 exists
+    to prevent.
+    """
+    result = check_dr(
+        'designated => identifier "office_automate_server-652815103961bb17" '
+        f'and certificate root = H"{CERT_ROOT}"'
+    )
+    assert result.returncode != 0
+    assert IDENTIFIER in result.stderr
+
+
+def test_rejects_unexpected_certificate_root():
+    """A regenerated certificate is a different TCC subject; the grant will not match."""
+    result = check_dr(
+        f'designated => identifier "{IDENTIFIER}" '
+        'and certificate root = H"0000000000000000000000000000000000000000"'
+    )
+    assert result.returncode != 0
+    assert CERT_ROOT in result.stderr
+
+
+def test_rejects_empty_requirement():
+    result = check_dr("   \n")
+    assert result.returncode != 0
+    assert "empty" in result.stderr

--- a/tests/test_build_server_signing.py
+++ b/tests/test_build_server_signing.py
@@ -8,6 +8,7 @@ testable on any machine.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -18,6 +19,17 @@ CERT_ROOT = "36fc54a873d584a34fcfeea7d1f519b19a39de72"
 
 STABLE_DR = f'designated => identifier "{IDENTIFIER}" and certificate root = H"{CERT_ROOT}"'
 
+# These fixtures assume the script's hard-coded defaults for identifier and
+# cert root. A host with its own real certificate configured via
+# OFFICE_AUTOMATE_SIGNING_IDENTIFIER/OFFICE_AUTOMATE_SIGNING_CERT_ROOT would
+# leak those into the subprocess and mismatch the fixtures below, failing the
+# guard tests for a reason that has nothing to do with the guard itself.
+_TEST_ENV = {
+    k: v
+    for k, v in os.environ.items()
+    if k not in ("OFFICE_AUTOMATE_SIGNING_IDENTIFIER", "OFFICE_AUTOMATE_SIGNING_CERT_ROOT")
+}
+
 
 def check_dr(requirement: str) -> subprocess.CompletedProcess:
     return subprocess.run(
@@ -25,6 +37,7 @@ def check_dr(requirement: str) -> subprocess.CompletedProcess:
         input=requirement,
         capture_output=True,
         text=True,
+        env=_TEST_ENV,
     )
 
 


### PR DESCRIPTION
## Summary

`cargo build --release` produces an ad-hoc, linker-signed binary with no Team ID. macOS keys the Local Network (TCC) grant for such a binary on its **cdhash**, so every rebuild is a new subject with no grant — and the denial surfaces as an instant `EHOSTUNREACH` rather than anything that looks like a permissions problem. That is why ERV local readback broke on 11 of 11 boot reads.

Signing with a stable self-signed certificate replaces the content-derived requirement with one anchored on identifier plus certificate root, which does not change when the code does:

```
designated => identifier "com.office-automate.server" and certificate root = H"36fc54a8..."
```

Full spike write-up, including the negative controls, is in [the #167 comment](https://github.com/rajeshgoli/office-automation/issues/167#issuecomment-5184054458).

## Evidence

Verified live on this host (macOS 26.5.1) before writing any code:

| Step | Result |
| --- | --- |
| Rebuild changing code **and** Cargo's metadata hash | Designated requirement **byte-identical** |
| Control: unsigned rebuild, same path | `20:02:25Z WARN ERV boot read failed: ... os error 65` |
| Signed + one-time grant, cdhash `131b9157…` | `20:07:24Z INFO ERV boot read: running=false speed=off` |
| **Rebuilt + re-signed, cdhash `4032bf3d…`, no re-grant** | `20:07:54Z INFO ERV boot read: running=false speed=off` |

The control matters: without it, a signed success is equally consistent with "macOS started keying on path" and proves nothing about identity. Device health was independently confirmed during the failing window (`ping` 10 ms avg, `nc -z 192.168.4.59 6668` open), so the control failure was TCC and not the ERV.

## The detail that would have silently reproduced the bug

Cargo's default signing identifier embeds a metadata hash — `office_automate_server-652815103961bb17` — and it **changed on a version bump**. Signing without pinning would have passed a naive two-rebuild test today and broken readback again on the next `cargo update`. `scripts/build-server.sh` pins it with `codesign -i` and refuses any requirement that does not.

## What changed

- **`scripts/build-server.sh`** — builds, signs, and verifies. Fails closed if the identity is missing; `OFFICE_AUTOMATE_ALLOW_UNSIGNED=1` overrides with a loud warning. Skips signing on non-Darwin. Passes extra args through to `cargo build --release`. No restart logic — that stays in the runbook.
- **`--verify-only`** — the check to run after any build. A bare `cargo build --release` still overwrites the signed binary in place, so the fix needs a standing verification, not just a build wrapper.
- **`docs/deployment/code-signing.md`** — the one-time certificate setup (create → trust for Code Signing → private-key ACL), the mandatory one-off Local Network re-grant at adoption, troubleshooting, and certificate rotation.
- **Four deployment runbooks** that invoked `cargo build --release` directly now invoke the script. Leaving them was knowingly shipping the regression path four more times.

## Notes for the reviewer

- **A Developer ID is not required.** A self-signed, non-Apple-anchored identity is honoured on macOS 26.5.1. This was the ticket's main open question.
- **Adopting this changes the binary's identity, so it requires one Local Network re-grant.** Documented; it is not a regression.
- The pinned certificate root is a machine-specific default, overridable via `OFFICE_AUTOMATE_SIGNING_CERT_ROOT`. A different certificate fails verification with an actionable message rather than silently losing the grant.
- Certificate setup needs three GUI steps and cannot be fully automated. A pure-CLI path via `openssl` + `security import` was attempted and abandoned — the trust decision and key ACL both require GUI authorisation.

## Test Plan

- [x] `python -m pytest tests/ -v` — 19 passed. Five new cases cover the requirement guard via a `--check-dr` stdin seam that needs no keychain, certificate, or built binary, so it runs anywhere.
- [x] Rejects a cdhash requirement, a Cargo-default identifier, an unexpected certificate root, and an empty string.
- [x] Regression case for `codesign` emitting an ad-hoc requirement as a `# designated => ...` comment. This was a real bug found during validation — the original `^designated` match missed it, so the cdhash check would never have fired on the exact case it exists to catch.
- [x] End-to-end build + sign + verify against a real certificate.
- [x] Fail-closed path exits 1; escape-hatch path warns and exits 0.
- [x] Live service left signed, verified, and reading the ERV successfully.

Fixes #167